### PR TITLE
Hierarchical collection to return with AsJson

### DIFF
--- a/src/IIIFPresentation/API/Features/Storage/StorageController.cs
+++ b/src/IIIFPresentation/API/Features/Storage/StorageController.cs
@@ -54,7 +54,7 @@ public class StorageController(IOptions<ApiSettings> options, IMediator mediator
 
         if (Request.ShowExtraProperties())
         {
-            return Ok(storageRoot.Collection.ToHierarchicalCollection(GetUrlRoots(), storageRoot.Items));
+            return Ok(storageRoot.Collection.ToFlatCollection(GetUrlRoots(), Settings.PageSize, storageRoot.Items));
         }
 
         return Content(storageRoot.Collection.ToHierarchicalCollection(GetUrlRoots(), storageRoot.Items).AsJson(),

--- a/src/IIIFPresentation/API/Features/Storage/StorageController.cs
+++ b/src/IIIFPresentation/API/Features/Storage/StorageController.cs
@@ -9,8 +9,8 @@ using API.Settings;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
-using FluentValidation;
-using Models.API.Collection;
+using IIIF.Presentation;
+using IIIF.Serialisation;
 using Models.API.Collection.Upsert;
 
 namespace API.Features.Storage;
@@ -28,7 +28,8 @@ public class StorageController(IOptions<ApiSettings> options, IMediator mediator
 
         if (storageRoot.Collection == null) return NotFound();
 
-        return Ok(storageRoot.Collection.ToHierarchicalCollection(GetUrlRoots(), storageRoot.Items));
+        return Content(storageRoot.Collection.ToHierarchicalCollection(GetUrlRoots(), storageRoot.Items).AsJson(),
+            ContentTypes.V3);
     }
     
     [HttpGet("{*slug}")]
@@ -39,7 +40,8 @@ public class StorageController(IOptions<ApiSettings> options, IMediator mediator
 
         if (storageRoot.Collection is not { IsPublic: true }) return NotFound();
 
-        return Ok(storageRoot.Collection.ToHierarchicalCollection(GetUrlRoots(), storageRoot.Items));
+        return Content(storageRoot.Collection.ToHierarchicalCollection(GetUrlRoots(), storageRoot.Items).AsJson(),
+            ContentTypes.V3);
     }
     
     [HttpGet("collections/{id}")]
@@ -50,9 +52,13 @@ public class StorageController(IOptions<ApiSettings> options, IMediator mediator
 
         if (storageRoot.Collection == null) return NotFound();
 
-        return Ok(Request.ShowExtraProperties()
-            ? storageRoot.Collection.ToFlatCollection(GetUrlRoots(), Settings.PageSize, storageRoot.Items)
-            : storageRoot.Collection.ToHierarchicalCollection(GetUrlRoots(), storageRoot.Items));
+        if (Request.ShowExtraProperties())
+        {
+            return Ok(storageRoot.Collection.ToHierarchicalCollection(GetUrlRoots(), storageRoot.Items));
+        }
+
+        return Content(storageRoot.Collection.ToHierarchicalCollection(GetUrlRoots(), storageRoot.Items).AsJson(),
+            ContentTypes.V3);
     }
     
     [HttpPost("collections")]


### PR DESCRIPTION
Partly resolves #17 

This PR moves hierarchical collects to use `.AsJson` found with iiif-net library over relying on internal serialization.

The reason for this change is that `.AsJson` contains a number of converters designed for the iiif spec which are not available through standard serialization.  Additionally, the `Content-Type` header is now correctly set to that required by the iiif spec

This Pr does not change `FlatCollection` as it's currently being modified to work with the iiif-net library in #7