### PR TITLE
Adding headers to allow https in response

### DIFF
--- a/src/IIIFPresentation/API/Program.cs
+++ b/src/IIIFPresentation/API/Program.cs
@@ -2,6 +2,7 @@ using System.Text.Json.Serialization;
 using API.Features.Storage.Validators;
 using API.Infrastructure;
 using API.Settings;
+using Microsoft.AspNetCore.HttpOverrides;
 using Newtonsoft.Json;
 using Repository;
 using Serilog;
@@ -32,6 +33,10 @@ builder.Services.AddOptions<ApiSettings>()
 builder.Services.AddDataAccess(builder.Configuration);
 builder.Services.ConfigureMediatR();
 builder.Services.AddHealthChecks();
+builder.Services.Configure<ForwardedHeadersOptions>(opts =>
+{
+    opts.ForwardedHeaders = ForwardedHeaders.XForwardedHost | ForwardedHeaders.XForwardedProto;
+});
 
 builder.Services.ConfigureHttpJsonOptions( options =>
 {
@@ -42,6 +47,8 @@ builder.Services.ConfigureHttpJsonOptions( options =>
 builder.Services.AddOptionsWithValidateOnStart<Program>();
 
 var app = builder.Build();
+
+app.UseForwardedHeaders();
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())


### PR DESCRIPTION
Resolves #21

This PR adds in some additional configuration to enable URL's in response bodies to use the `https` schema when accessed via AWS, as opposed to `http`