### PR TITLE
Update collections to only refer to the root collection as /root

### DIFF
--- a/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
@@ -140,7 +140,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        collection!.Id.Should().Be("http://localhost/1/collections/RootStorage");
+        collection!.Id.Should().Be("http://localhost/1/collections/root");
         collection.PublicId.Should().Be("http://localhost/1");
         collection.Items!.Count.Should().Be(2);
         collection.Items[0].Id.Should().Be("http://localhost/1/collections/FirstChildCollection");
@@ -162,13 +162,14 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        collection!.Id.Should().Be("http://localhost/1/collections/RootStorage");
+        collection!.Id.Should().Be("http://localhost/1/collections/root");
         collection.PublicId.Should().Be("http://localhost/1");
         collection.Items!.Count.Should().Be(2);
         collection.Items[0].Id.Should().Be("http://localhost/1/collections/FirstChildCollection");
         collection.TotalItems.Should().Be(2);
         collection.CreatedBy.Should().Be("admin");
         collection.Behavior.Should().Contain("public-iiif");
+        collection.Parent.Should().BeNull();
     }
     
     [Fact]
@@ -192,6 +193,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         collection.TotalItems.Should().Be(1);
         collection.CreatedBy.Should().Be("admin");
         collection.Behavior.Should().Contain("public-iiif");
+        collection.Parent.Should().Be("http://localhost/1/collections/root");
     }
     
     [Fact]
@@ -214,6 +216,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         flatCollection.CreatedBy.Should().Be("admin");
         flatCollection.Behavior.Should().Contain("storage-collection");
         flatCollection.Behavior.Should().NotContain("public-iiif");
+        flatCollection.Parent.Should().Be("http://localhost/1/collections/root");
         hierarchicalResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
@@ -238,7 +241,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
     }
     
     [Fact]
-    public async Task Get_RootFlat_ReturnsReducedItems_WhenCalledWithSmallPageSize()
+    public async Task Get_ChildFlat_ReturnsReducedItems_WhenCalledWithSmallPageSize()
     {
         // Arrange
         var requestMessage =
@@ -323,7 +326,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
     [InlineData("id")]
     [InlineData("slug")]
     [InlineData("created")]
-    public async Task Get_RootFlat_ReturnsCorrectItem_WhenCalledWithSmallPageSizeAndOrderBy(string field)
+    public async Task Get_ChildFlat_ReturnsCorrectItem_WhenCalledWithSmallPageSizeAndOrderBy(string field)
     {
         // Arrange
         var requestMessage =
@@ -363,7 +366,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         // Assert
         collection.TotalItems.Should().Be(2);
         collection.View!.PageSize.Should().Be(1);
-        collection.View.Id.Should().Be($"http://localhost/1/collections/RootStorage?page=1&pageSize=1&orderByDescending={field}");
+        collection.View.Id.Should().Be($"http://localhost/1/collections/root?page=1&pageSize=1&orderByDescending={field}");
         collection.View.Page.Should().Be(1);
         collection.View.TotalPages.Should().Be(2);
         collection.Items!.Count.Should().Be(1);
@@ -371,7 +374,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
     }
     
     [Fact]
-    public async Task Get_RootFlat_IgnoresOrderBy_WhenCalledWithInvalidOrderBy()
+    public async Task Get_ChildFlat_IgnoresOrderBy_WhenCalledWithInvalidOrderBy()
     {
         // Arrange
         var requestMessage =
@@ -386,7 +389,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         // Assert
         collection.TotalItems.Should().Be(2);
         collection.View!.PageSize.Should().Be(1);
-        collection.View.Id.Should().Be($"http://localhost/1/collections/RootStorage?page=1&pageSize=1");
+        collection.View.Id.Should().Be($"http://localhost/1/collections/root?page=1&pageSize=1");
         collection.View.Page.Should().Be(1);
         collection.View.TotalPages.Should().Be(2);
         collection.Items!.Count.Should().Be(1);

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyCollectionTests.cs
@@ -79,6 +79,9 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
         fromDatabase.Tags.Should().Be("some, tags");
         fromDatabase.IsPublic.Should().BeTrue();
         fromDatabase.IsStorageCollection.Should().BeTrue();
+        responseCollection!.View!.PageSize.Should().Be(20);
+        responseCollection.View.Page.Should().Be(1);
+        responseCollection.View.Id.Should().Contain("?page=1&pageSize=20");
     }
     
     [Fact]
@@ -283,6 +286,9 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
         fromDatabase.Tags.Should().Be("some, tags, 2");
         fromDatabase.IsPublic.Should().BeTrue();
         fromDatabase.IsStorageCollection.Should().BeTrue();
+        responseCollection!.View!.PageSize.Should().Be(20);
+        responseCollection.View.Page.Should().Be(1);
+        responseCollection.View.Id.Should().Contain("?page=1&pageSize=20");
     }
     
     [Fact]

--- a/src/IIIFPresentation/API/Converters/CollectionConverter.cs
+++ b/src/IIIFPresentation/API/Converters/CollectionConverter.cs
@@ -120,7 +120,7 @@ public static class CollectionConverter
             TotalPages = totalPages,
         };
 
-        if (totalPages > 1)
+        if (currentPage > 1)
         {
             view.First = dbAsset.GenerateFlatCollectionViewFirst(urlRoots, pageSize, orderQueryParam);
             view.Previous = dbAsset.GenerateFlatCollectionViewPrevious(urlRoots, currentPage, pageSize, orderQueryParam);

--- a/src/IIIFPresentation/API/Features/Storage/Helpers/PresentationContextX.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Helpers/PresentationContextX.cs
@@ -2,6 +2,7 @@
 using Core;
 using Microsoft.EntityFrameworkCore;
 using Models.API.Collection;
+using Models.Database.Collections;
 using Repository;
 using Repository.Helpers;
 
@@ -34,5 +35,25 @@ public static class PresentationContextX
         }
 
         return null;
+    }
+    
+    public static async Task<Collection?> RetrieveCollection(this PresentationContext dbContext,  int customerId, string collectionId,
+        string rootCollectionId, CancellationToken cancellationToken)
+    {
+        Collection? collection;
+        if (collectionId.Equals(rootCollectionId, StringComparison.OrdinalIgnoreCase))
+        {
+            collection = await dbContext.Collections.AsNoTracking().FirstOrDefaultAsync(
+                s => s.CustomerId == customerId && s.Parent == null,
+                cancellationToken);
+        }
+        else
+        {
+            collection = await dbContext.Collections.AsNoTracking().FirstOrDefaultAsync(
+                s => s.CustomerId == customerId && s.Id == collectionId,
+                cancellationToken);
+        }
+        
+        return collection;
     }
 }

--- a/src/IIIFPresentation/API/Features/Storage/Helpers/RootCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Helpers/RootCollection.cs
@@ -1,0 +1,6 @@
+﻿namespace API.Features.Storage.Helpers;
+
+public static class RootCollection
+{
+    public const string Id = "root";
+}

--- a/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
@@ -1,6 +1,7 @@
 ﻿using API.Auth;
 using API.Converters;
 using API.Features.Storage.Helpers;
+using API.Helpers;
 using API.Infrastructure.Requests;
 using API.Settings;
 using Core;
@@ -32,9 +33,19 @@ public class CreateCollectionHandler(
     : IRequestHandler<CreateCollection, ModifyEntityResult<FlatCollection>>
 {
     private readonly ApiSettings settings = options.Value;
-
+    
     public async Task<ModifyEntityResult<FlatCollection>> Handle(CreateCollection request, CancellationToken cancellationToken)
     {
+        // check parent exists
+        var parentCollection = await dbContext.RetrieveCollection(request.CustomerId,
+            request.Collection.Parent.GetLastPathElement(), RootCollection.Id, cancellationToken);
+
+        if (parentCollection == null)
+        {
+            return ModifyEntityResult<FlatCollection>.Failure(
+                $"The parent collection could not be found", WriteResult.Conflict);
+        }
+        
         var collection = new Collection()
         {
             Id = Guid.NewGuid().ToString(),
@@ -45,7 +56,7 @@ public class CreateCollectionHandler(
             IsPublic = request.Collection.Behavior.IsPublic(),
             IsStorageCollection = request.Collection.Behavior.IsStorageCollection(),
             Label = request.Collection.Label,
-            Parent = request.Collection.Parent!.GetLastPathElement(),
+            Parent = parentCollection.Id,
             Slug = request.Collection.Slug,
             Thumbnail = request.Collection.Thumbnail,
             Tags = request.Collection.Tags,
@@ -65,6 +76,8 @@ public class CreateCollectionHandler(
         {
             collection.FullPath = CollectionRetrieval.RetrieveFullPathForCollection(collection, dbContext);
         }
+
+        collection.UpdateParentForRootIfRequired(request.Collection.Parent);
 
         return ModifyEntityResult<FlatCollection>.Success(
             collection.ToFlatCollection(request.UrlRoots, 1, settings.PageSize, 0, []), // there can be no items attached to this, as it's just been created

--- a/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
@@ -33,6 +33,8 @@ public class CreateCollectionHandler(
     : IRequestHandler<CreateCollection, ModifyEntityResult<FlatCollection>>
 {
     private readonly ApiSettings settings = options.Value;
+
+    private const int CurrentPage = 1;
     
     public async Task<ModifyEntityResult<FlatCollection>> Handle(CreateCollection request, CancellationToken cancellationToken)
     {
@@ -80,7 +82,7 @@ public class CreateCollectionHandler(
         collection.UpdateParentForRootIfRequired(request.Collection.Parent);
 
         return ModifyEntityResult<FlatCollection>.Success(
-            collection.ToFlatCollection(request.UrlRoots, 1, settings.PageSize, 0, []), // there can be no items attached to this, as it's just been created
+            collection.ToFlatCollection(request.UrlRoots, settings.PageSize, CurrentPage, 0, []), // there can be no items attached to this, as it's just been created
             WriteResult.Created);
     }
 }

--- a/src/IIIFPresentation/API/Helpers/CollectionHelperX.cs
+++ b/src/IIIFPresentation/API/Helpers/CollectionHelperX.cs
@@ -1,4 +1,6 @@
 ﻿using API.Converters;
+using API.Features.Storage.Helpers;
+using Core.Helpers;
 using Models.Database.Collections;
 
 namespace API.Helpers;
@@ -43,4 +45,15 @@ public static class CollectionHelperX
     
     public static string GenerateFullPath(this Collection collection, string itemSlug) => 
         $"{(collection.Parent != null ? $"{collection.Slug}/" : string.Empty)}{itemSlug}";
+    
+    public static Collection UpdateParentForRootIfRequired(this Collection collection, string parentToChangeTo)
+    {
+        // everything saved so set the response value to be the root collection if required
+        if (parentToChangeTo.GetLastPathElement() == RootCollection.Id)
+        {
+            collection.Parent = RootCollection.Id;
+        }
+
+        return collection;
+    }
 }


### PR DESCRIPTION
Resolves #23

this PR updates flat collections to refer to the root collection as `root` everywhere.  This includes when gathering parent collections.