### PR TITLE
Modify collection table to expose root collection as root

### DIFF
--- a/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
@@ -5,6 +5,7 @@ using FluentAssertions;
 using IIIF.Presentation.V3;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Models.API.Collection;
+using Test.Helpers.Helpers;
 using Test.Helpers.Integration;
 
 #nullable disable
@@ -70,14 +71,14 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.SeeOther);
-        response.Headers.Location!.Should().Be("http://localhost/1/collections/root");
+        response.Headers.Location!.Should().Be($"http://localhost/1/collections/{RootCollection.Id}");
     }
     
     [Fact]
     public async Task Get_RootFlat_Redirects_WhenNoAuthAndCsHeader()
     {
         // Act
-        var response = await httpClient.GetAsync("1/collections/root");
+        var response = await httpClient.GetAsync($"1/collections/{RootCollection.Id}");
         
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.SeeOther);
@@ -88,7 +89,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
     public async Task Get_RootFlat_Redirects_WhenNoCsHeader()
     {
         // Arrange
-        var requestMessage = new HttpRequestMessage(HttpMethod.Get, "1/collections/root");
+        var requestMessage = new HttpRequestMessage(HttpMethod.Get, $"1/collections/{RootCollection.Id}");
 
         // Act
         var response = await httpClient.AsCustomer(1).SendAsync(requestMessage);
@@ -102,7 +103,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
     public async Task Get_RootFlat_Redirects_WhenShowExtraHeaderNotAll()
     {
         // Arrange
-        var requestMessage = new HttpRequestMessage(HttpMethod.Get, "1/collections/root");
+        var requestMessage = new HttpRequestMessage(HttpMethod.Get, $"1/collections/{RootCollection.Id}");
         requestMessage.Headers.Add("IIIF-CS-Show-Extra", "Incorrect");
 
         // Act
@@ -117,7 +118,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
     public async Task Get_RootFlat_Redirects_WhenNoAuth()
     {
         // Arrange
-        var requestMessage = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get, "1/collections/root");
+        var requestMessage = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get, $"1/collections/{RootCollection.Id}");
     
         // Act
         var response = await httpClient.SendAsync(requestMessage);
@@ -131,7 +132,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
     public async Task Get_RootFlat_ReturnsEntryPointFlat_WhenAuthAndHeader()
     {
         // Arrange
-        var requestMessage = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get, "1/collections/root");
+        var requestMessage = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get, $"1/collections/{RootCollection.Id}");
 
         // Act
         var response = await httpClient.AsCustomer(1).SendAsync(requestMessage);
@@ -140,7 +141,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        collection!.Id.Should().Be("http://localhost/1/collections/root");
+        collection!.Id.Should().Be($"http://localhost/1/collections/{RootCollection.Id}");
         collection.PublicId.Should().Be("http://localhost/1");
         collection.Items!.Count.Should().Be(2);
         collection.Items[0].Id.Should().Be("http://localhost/1/collections/FirstChildCollection");
@@ -170,7 +171,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         collection.TotalItems.Should().Be(1);
         collection.CreatedBy.Should().Be("admin");
         collection.Behavior.Should().Contain("public-iiif");
-        collection.Parent.Should().Be("http://localhost/1/collections/root");
+        collection.Parent.Should().Be($"http://localhost/1/collections/{RootCollection.Id}");
     }
     
     [Fact]
@@ -193,7 +194,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         flatCollection.CreatedBy.Should().Be("admin");
         flatCollection.Behavior.Should().Contain("storage-collection");
         flatCollection.Behavior.Should().NotContain("public-iiif");
-        flatCollection.Parent.Should().Be("http://localhost/1/collections/root");
+        flatCollection.Parent.Should().Be($"http://localhost/1/collections/{RootCollection.Id}");
         hierarchicalResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
@@ -202,7 +203,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
     {
         // Arrange
         var requestMessage =
-            HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get, "1/collections/root?page=1&pageSize=100");
+            HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get, $"1/collections/{RootCollection.Id}?page=1&pageSize=100");
 
         // Act
         var response = await httpClient.AsCustomer(1).SendAsync(requestMessage);
@@ -222,7 +223,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
     {
         // Arrange
         var requestMessage =
-            HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get, "1/collections/root?page=1&pageSize=1");
+            HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get, $"1/collections/{RootCollection.Id}?page=1&pageSize=1");
 
         // Act
         var response = await httpClient.AsCustomer(1).SendAsync(requestMessage);
@@ -243,7 +244,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
     {
         // Arrange
         var requestMessage =
-            HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get, "1/collections/root?page=2&pageSize=1");
+            HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get, $"1/collections/{RootCollection.Id}?page=2&pageSize=1");
 
         // Act
         var response = await httpClient.AsCustomer(1).SendAsync(requestMessage);
@@ -264,7 +265,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
     {
         // Arrange
         var requestMessage =
-            HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get, "1/collections/root?page=0&pageSize=0");
+            HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get, $"1/collections/{RootCollection.Id}?page=0&pageSize=0");
 
         // Act
         var response = await httpClient.AsCustomer(1).SendAsync(requestMessage);
@@ -284,7 +285,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
     {
         // Arrange
         var requestMessage =
-            HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get, "1/collections/root?page=1&pageSize=1000");
+            HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get, $"1/collections/{RootCollection.Id}?page=1&pageSize=1000");
 
         // Act
         var response = await httpClient.AsCustomer(1).SendAsync(requestMessage);
@@ -308,7 +309,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         // Arrange
         var requestMessage =
             HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get,
-                $"1/collections/root?page=1&pageSize=1&orderBy={field}");
+                $"1/collections/{RootCollection.Id}?page=1&pageSize=1&orderBy={field}");
 
         // Act
         var response = await httpClient.AsCustomer(1).SendAsync(requestMessage);
@@ -333,7 +334,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         // Arrange
         var requestMessage =
             HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get,
-                $"1/collections/root?page=1&pageSize=1&orderByDescending={field}");
+                $"1/collections/{RootCollection.Id}?page=1&pageSize=1&orderByDescending={field}");
 
         // Act
         var response = await httpClient.AsCustomer(1).SendAsync(requestMessage);
@@ -343,7 +344,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         // Assert
         collection.TotalItems.Should().Be(2);
         collection.View!.PageSize.Should().Be(1);
-        collection.View.Id.Should().Be($"http://localhost/1/collections/root?page=1&pageSize=1&orderByDescending={field}");
+        collection.View.Id.Should().Be($"http://localhost/1/collections/{RootCollection.Id}?page=1&pageSize=1&orderByDescending={field}");
         collection.View.Page.Should().Be(1);
         collection.View.TotalPages.Should().Be(2);
         collection.Items!.Count.Should().Be(1);
@@ -356,7 +357,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         // Arrange
         var requestMessage =
             HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get,
-                $"1/collections/root?page=1&pageSize=1&orderByDescending=notValid");
+                $"1/collections/{RootCollection.Id}?page=1&pageSize=1&orderByDescending=notValid");
 
         // Act
         var response = await httpClient.AsCustomer(1).SendAsync(requestMessage);
@@ -366,7 +367,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         // Assert
         collection.TotalItems.Should().Be(2);
         collection.View!.PageSize.Should().Be(1);
-        collection.View.Id.Should().Be($"http://localhost/1/collections/root?page=1&pageSize=1");
+        collection.View.Id.Should().Be($"http://localhost/1/collections/{RootCollection.Id}?page=1&pageSize=1");
         collection.View.Page.Should().Be(1);
         collection.View.TotalPages.Should().Be(2);
         collection.Items!.Count.Should().Be(1);

--- a/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
@@ -140,7 +140,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        collection!.Id.Should().Be("http://localhost/1/collections/RootStorage");
+        collection!.Id.Should().Be("http://localhost/1/collections/root");
         collection.PublicId.Should().Be("http://localhost/1");
         collection.Items!.Count.Should().Be(2);
         collection.Items[0].Id.Should().Be("http://localhost/1/collections/FirstChildCollection");
@@ -162,13 +162,14 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        collection!.Id.Should().Be("http://localhost/1/collections/RootStorage");
+        collection!.Id.Should().Be("http://localhost/1/collections/root");
         collection.PublicId.Should().Be("http://localhost/1");
         collection.Items!.Count.Should().Be(2);
         collection.Items[0].Id.Should().Be("http://localhost/1/collections/FirstChildCollection");
         collection.TotalItems.Should().Be(2);
         collection.CreatedBy.Should().Be("admin");
         collection.Behavior.Should().Contain("public-iiif");
+        collection.Parent.Should().BeNull();
     }
     
     [Fact]
@@ -192,6 +193,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         collection.TotalItems.Should().Be(1);
         collection.CreatedBy.Should().Be("admin");
         collection.Behavior.Should().Contain("public-iiif");
+        collection.Parent.Should().Be("http://localhost/1/collections/root");
     }
     
     [Fact]
@@ -214,6 +216,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         flatCollection.CreatedBy.Should().Be("admin");
         flatCollection.Behavior.Should().Contain("storage-collection");
         flatCollection.Behavior.Should().NotContain("public-iiif");
+        flatCollection.Parent.Should().Be("http://localhost/1/collections/root");
         hierarchicalResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
@@ -238,7 +241,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
     }
     
     [Fact]
-    public async Task Get_RootFlat_ReturnsReducedItems_WhenCalledWithSmallPageSize()
+    public async Task Get_ChildFlat_ReturnsReducedItems_WhenCalledWithSmallPageSize()
     {
         // Arrange
         var requestMessage =
@@ -323,7 +326,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
     [InlineData("id")]
     [InlineData("slug")]
     [InlineData("created")]
-    public async Task Get_RootFlat_ReturnsCorrectItem_WhenCalledWithSmallPageSizeAndOrderBy(string field)
+    public async Task Get_ChildFlat_ReturnsCorrectItem_WhenCalledWithSmallPageSizeAndOrderBy(string field)
     {
         // Arrange
         var requestMessage =
@@ -363,7 +366,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         // Assert
         collection.TotalItems.Should().Be(2);
         collection.View!.PageSize.Should().Be(1);
-        collection.View.Id.Should().Be($"http://localhost/1/collections/RootStorage?page=1&pageSize=1&orderByDescending={field}");
+        collection.View.Id.Should().Be($"http://localhost/1/collections/root?page=1&pageSize=1&orderByDescending={field}");
         collection.View.Page.Should().Be(1);
         collection.View.TotalPages.Should().Be(2);
         collection.Items!.Count.Should().Be(1);
@@ -371,7 +374,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
     }
     
     [Fact]
-    public async Task Get_RootFlat_IgnoresOrderBy_WhenCalledWithInvalidOrderBy()
+    public async Task Get_ChildFlat_IgnoresOrderBy_WhenCalledWithInvalidOrderBy()
     {
         // Arrange
         var requestMessage =
@@ -386,7 +389,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         // Assert
         collection.TotalItems.Should().Be(2);
         collection.View!.PageSize.Should().Be(1);
-        collection.View.Id.Should().Be($"http://localhost/1/collections/RootStorage?page=1&pageSize=1");
+        collection.View.Id.Should().Be($"http://localhost/1/collections/root?page=1&pageSize=1");
         collection.View.Page.Should().Be(1);
         collection.View.TotalPages.Should().Be(2);
         collection.Items!.Count.Should().Be(1);

--- a/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
@@ -70,7 +70,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.SeeOther);
-        response.Headers.Location!.Should().Be("http://localhost/1/collections/RootStorage");
+        response.Headers.Location!.Should().Be("http://localhost/1/collections/root");
     }
     
     [Fact]
@@ -147,29 +147,6 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         collection.TotalItems.Should().Be(2);
         collection.CreatedBy.Should().Be("admin");
         collection.Behavior.Should().Contain("public-iiif");
-    }
-    
-    [Fact]
-    public async Task Get_RootFlat_ReturnsEntryPointFlat_WhenCalledById()
-    {
-        // Arrange
-        var requestMessage = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get, "1/collections/RootStorage");
-
-        // Act
-        var response = await httpClient.AsCustomer(1).SendAsync(requestMessage);
-
-        var collection = await response.ReadAsPresentationJsonAsync<FlatCollection>();
-
-        // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
-        collection!.Id.Should().Be("http://localhost/1/collections/root");
-        collection.PublicId.Should().Be("http://localhost/1");
-        collection.Items!.Count.Should().Be(2);
-        collection.Items[0].Id.Should().Be("http://localhost/1/collections/FirstChildCollection");
-        collection.TotalItems.Should().Be(2);
-        collection.CreatedBy.Should().Be("admin");
-        collection.Behavior.Should().Contain("public-iiif");
-        collection.Parent.Should().BeNull();
     }
     
     [Fact]

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyCollectionTests.cs
@@ -12,6 +12,7 @@ using Models.API.General;
 using Models.Database.Collections;
 using Models.Infrastucture;
 using Repository;
+using Test.Helpers.Helpers;
 using Test.Helpers.Integration;
 using JsonSerializer = System.Text.Json.JsonSerializer;
 
@@ -412,7 +413,7 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
     
-        [Fact]
+    [Fact]
     public async Task UpdateCollection_FailsToUpdateCollection_WhenParentDoesNotExist()
     {
         // Arrange
@@ -590,7 +591,7 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
     {
         // Arrange
         var deleteRequestMessage = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Delete,
-            $"{Customer}/collections/root");
+            $"{Customer}/collections/{RootCollection.Id}");
         
         // Act
         var response = await httpClient.AsCustomer(1).SendAsync(deleteRequestMessage);
@@ -609,7 +610,7 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
     {
         // Arrange
         var deleteRequestMessage = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Delete,
-            $"{Customer}/collections/root");
+            $"{Customer}/collections/{RootCollection.Id}");
         
         // Act
         var response = await httpClient.AsCustomer(1).SendAsync(deleteRequestMessage);

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyCollectionTests.cs
@@ -79,6 +79,9 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
         fromDatabase.Tags.Should().Be("some, tags");
         fromDatabase.IsPublic.Should().BeTrue();
         fromDatabase.IsStorageCollection.Should().BeTrue();
+        responseCollection!.View!.PageSize.Should().Be(20);
+        responseCollection.View.Page.Should().Be(1);
+        responseCollection.View.Id.Should().Contain("?page=1&pageSize=20");
     }
     
     [Fact]
@@ -283,6 +286,9 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
         fromDatabase.Tags.Should().Be("some, tags, 2");
         fromDatabase.IsPublic.Should().BeTrue();
         fromDatabase.IsStorageCollection.Should().BeTrue();
+        responseCollection!.View!.PageSize.Should().Be(20);
+        responseCollection.View.Page.Should().Be(1);
+        responseCollection.View.Id.Should().Contain("?page=1&pageSize=20");
     }
     
     [Fact]

--- a/src/IIIFPresentation/API/Converters/CollectionConverter.cs
+++ b/src/IIIFPresentation/API/Converters/CollectionConverter.cs
@@ -120,7 +120,7 @@ public static class CollectionConverter
             TotalPages = totalPages,
         };
 
-        if (totalPages > 1)
+        if (currentPage > 1)
         {
             view.First = dbAsset.GenerateFlatCollectionViewFirst(urlRoots, pageSize, orderQueryParam);
             view.Previous = dbAsset.GenerateFlatCollectionViewPrevious(urlRoots, currentPage, pageSize, orderQueryParam);

--- a/src/IIIFPresentation/API/Features/Storage/Helpers/PresentationContextX.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Helpers/PresentationContextX.cs
@@ -37,22 +37,12 @@ public static class PresentationContextX
         return null;
     }
     
-    public static async Task<Collection?> RetrieveCollection(this PresentationContext dbContext,  int customerId, string collectionId,
-        string rootCollectionId, CancellationToken cancellationToken)
+    public static async Task<Collection?> RetrieveCollection(this PresentationContext dbContext,  int customerId, 
+        string collectionId, CancellationToken cancellationToken)
     {
-        Collection? collection;
-        if (collectionId.Equals(rootCollectionId, StringComparison.OrdinalIgnoreCase))
-        {
-            collection = await dbContext.Collections.AsNoTracking().FirstOrDefaultAsync(
-                s => s.CustomerId == customerId && s.Parent == null,
-                cancellationToken);
-        }
-        else
-        {
-            collection = await dbContext.Collections.AsNoTracking().FirstOrDefaultAsync(
-                s => s.CustomerId == customerId && s.Id == collectionId,
-                cancellationToken);
-        }
+        var collection = await dbContext.Collections.AsNoTracking().FirstOrDefaultAsync(
+            s => s.CustomerId == customerId && s.Id == collectionId,
+            cancellationToken);
         
         return collection;
     }

--- a/src/IIIFPresentation/API/Features/Storage/Helpers/PresentationContextX.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Helpers/PresentationContextX.cs
@@ -2,6 +2,7 @@
 using Core;
 using Microsoft.EntityFrameworkCore;
 using Models.API.Collection;
+using Models.Database.Collections;
 using Repository;
 using Repository.Helpers;
 
@@ -34,5 +35,25 @@ public static class PresentationContextX
         }
 
         return null;
+    }
+    
+    public static async Task<Collection?> RetrieveCollection(this PresentationContext dbContext,  int customerId, string collectionId,
+        string rootCollectionId, CancellationToken cancellationToken)
+    {
+        Collection? collection;
+        if (collectionId.Equals(rootCollectionId, StringComparison.OrdinalIgnoreCase))
+        {
+            collection = await dbContext.Collections.AsNoTracking().FirstOrDefaultAsync(
+                s => s.CustomerId == customerId && s.Parent == null,
+                cancellationToken);
+        }
+        else
+        {
+            collection = await dbContext.Collections.AsNoTracking().FirstOrDefaultAsync(
+                s => s.CustomerId == customerId && s.Id == collectionId,
+                cancellationToken);
+        }
+        
+        return collection;
     }
 }

--- a/src/IIIFPresentation/API/Features/Storage/Helpers/RootCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Helpers/RootCollection.cs
@@ -1,0 +1,6 @@
+﻿namespace API.Features.Storage.Helpers;
+
+public static class RootCollection
+{
+    public const string Id = "root";
+}

--- a/src/IIIFPresentation/API/Features/Storage/Helpers/RootCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Helpers/RootCollection.cs
@@ -1,6 +1,0 @@
-﻿namespace API.Features.Storage.Helpers;
-
-public static class RootCollection
-{
-    public const string Id = "root";
-}

--- a/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
@@ -1,6 +1,7 @@
 ﻿using API.Auth;
 using API.Converters;
 using API.Features.Storage.Helpers;
+using API.Helpers;
 using API.Infrastructure.Requests;
 using API.Settings;
 using Core;
@@ -32,9 +33,19 @@ public class CreateCollectionHandler(
     : IRequestHandler<CreateCollection, ModifyEntityResult<FlatCollection>>
 {
     private readonly ApiSettings settings = options.Value;
-
+    
     public async Task<ModifyEntityResult<FlatCollection>> Handle(CreateCollection request, CancellationToken cancellationToken)
     {
+        // check parent exists
+        var parentCollection = await dbContext.RetrieveCollection(request.CustomerId,
+            request.Collection.Parent.GetLastPathElement(), RootCollection.Id, cancellationToken);
+
+        if (parentCollection == null)
+        {
+            return ModifyEntityResult<FlatCollection>.Failure(
+                $"The parent collection could not be found", WriteResult.Conflict);
+        }
+        
         var collection = new Collection()
         {
             Id = Guid.NewGuid().ToString(),
@@ -45,7 +56,7 @@ public class CreateCollectionHandler(
             IsPublic = request.Collection.Behavior.IsPublic(),
             IsStorageCollection = request.Collection.Behavior.IsStorageCollection(),
             Label = request.Collection.Label,
-            Parent = request.Collection.Parent!.GetLastPathElement(),
+            Parent = parentCollection.Id,
             Slug = request.Collection.Slug,
             Thumbnail = request.Collection.Thumbnail,
             Tags = request.Collection.Tags,
@@ -65,6 +76,8 @@ public class CreateCollectionHandler(
         {
             collection.FullPath = CollectionRetrieval.RetrieveFullPathForCollection(collection, dbContext);
         }
+
+        collection.UpdateParentForRootIfRequired(request.Collection.Parent);
 
         return ModifyEntityResult<FlatCollection>.Success(
             collection.ToFlatCollection(request.UrlRoots, 1, settings.PageSize, 0, []), // there can be no items attached to this, as it's just been created

--- a/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
@@ -40,7 +40,7 @@ public class CreateCollectionHandler(
     {
         // check parent exists
         var parentCollection = await dbContext.RetrieveCollection(request.CustomerId,
-            request.Collection.Parent.GetLastPathElement(), RootCollection.Id, cancellationToken);
+            request.Collection.Parent.GetLastPathElement(), cancellationToken);
 
         if (parentCollection == null)
         {
@@ -78,9 +78,7 @@ public class CreateCollectionHandler(
         {
             collection.FullPath = CollectionRetrieval.RetrieveFullPathForCollection(collection, dbContext);
         }
-
-        collection.UpdateParentForRootIfRequired(request.Collection.Parent);
-
+        
         return ModifyEntityResult<FlatCollection>.Success(
             collection.ToFlatCollection(request.UrlRoots, settings.PageSize, CurrentPage, 0, []), // there can be no items attached to this, as it's just been created
             WriteResult.Created);

--- a/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
@@ -33,6 +33,8 @@ public class CreateCollectionHandler(
     : IRequestHandler<CreateCollection, ModifyEntityResult<FlatCollection>>
 {
     private readonly ApiSettings settings = options.Value;
+
+    private const int CurrentPage = 1;
     
     public async Task<ModifyEntityResult<FlatCollection>> Handle(CreateCollection request, CancellationToken cancellationToken)
     {
@@ -80,7 +82,7 @@ public class CreateCollectionHandler(
         collection.UpdateParentForRootIfRequired(request.Collection.Parent);
 
         return ModifyEntityResult<FlatCollection>.Success(
-            collection.ToFlatCollection(request.UrlRoots, 1, settings.PageSize, 0, []), // there can be no items attached to this, as it's just been created
+            collection.ToFlatCollection(request.UrlRoots, settings.PageSize, CurrentPage, 0, []), // there can be no items attached to this, as it's just been created
             WriteResult.Created);
     }
 }

--- a/src/IIIFPresentation/API/Features/Storage/Requests/GetCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/GetCollection.cs
@@ -32,8 +32,7 @@ public class GetCollectionHandler(PresentationContext dbContext) : IRequestHandl
     public async Task<CollectionWithItems> Handle(GetCollection request,
         CancellationToken cancellationToken)
     {
-        Collection? collection = await dbContext.RetrieveCollection(request.CustomerId, request.Id, RootCollection.Id, 
-            cancellationToken);
+        Collection? collection = await dbContext.RetrieveCollection(request.CustomerId, request.Id, cancellationToken);
         
         List<Collection>? items = null;
         int total = 0;
@@ -58,17 +57,6 @@ public class GetCollectionHandler(PresentationContext dbContext) : IRequestHandl
             if (collection.Parent != null)
             {
                 collection.FullPath = CollectionRetrieval.RetrieveFullPathForCollection(collection, dbContext);
-                
-                var parentCollection = await dbContext.RetrieveCollection(request.CustomerId, collection.Parent, RootCollection.Id, 
-                    cancellationToken);
-                if (parentCollection!.Parent == null)
-                {
-                    collection.Parent = RootCollection.Id;
-                }
-            }
-            else
-            {
-                collection.Id = RootCollection.Id;
             }
         }
 

--- a/src/IIIFPresentation/API/Helpers/CollectionHelperX.cs
+++ b/src/IIIFPresentation/API/Helpers/CollectionHelperX.cs
@@ -1,4 +1,6 @@
 ﻿using API.Converters;
+using API.Features.Storage.Helpers;
+using Core.Helpers;
 using Models.Database.Collections;
 
 namespace API.Helpers;
@@ -43,4 +45,15 @@ public static class CollectionHelperX
     
     public static string GenerateFullPath(this Collection collection, string itemSlug) => 
         $"{(collection.Parent != null ? $"{collection.Slug}/" : string.Empty)}{itemSlug}";
+    
+    public static Collection UpdateParentForRootIfRequired(this Collection collection, string parentToChangeTo)
+    {
+        // everything saved so set the response value to be the root collection if required
+        if (parentToChangeTo.GetLastPathElement() == RootCollection.Id)
+        {
+            collection.Parent = RootCollection.Id;
+        }
+
+        return collection;
+    }
 }

--- a/src/IIIFPresentation/API/Helpers/CollectionHelperX.cs
+++ b/src/IIIFPresentation/API/Helpers/CollectionHelperX.cs
@@ -45,15 +45,4 @@ public static class CollectionHelperX
     
     public static string GenerateFullPath(this Collection collection, string itemSlug) => 
         $"{(collection.Parent != null ? $"{collection.Slug}/" : string.Empty)}{itemSlug}";
-    
-    public static Collection UpdateParentForRootIfRequired(this Collection collection, string parentToChangeTo)
-    {
-        // everything saved so set the response value to be the root collection if required
-        if (parentToChangeTo.GetLastPathElement() == RootCollection.Id)
-        {
-            collection.Parent = RootCollection.Id;
-        }
-
-        return collection;
-    }
 }

--- a/src/IIIFPresentation/Repository/Migrations/20240920085119_addingNewPk.Designer.cs
+++ b/src/IIIFPresentation/Repository/Migrations/20240920085119_addingNewPk.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Repository;
@@ -11,9 +12,11 @@ using Repository;
 namespace Repository.Migrations
 {
     [DbContext(typeof(PresentationContext))]
-    partial class PresentationContextModelSnapshot : ModelSnapshot
+    [Migration("20240920085119_addingNewPk")]
+    partial class addingNewPk
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/IIIFPresentation/Repository/Migrations/20240920085119_addingNewPk.cs
+++ b/src/IIIFPresentation/Repository/Migrations/20240920085119_addingNewPk.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Repository.Migrations
+{
+    /// <inheritdoc />
+    public partial class addingNewPk : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropPrimaryKey(
+                name: "pk_collections",
+                table: "collections");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "pk_collections",
+                table: "collections",
+                columns: new[] { "id", "customer_id" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropPrimaryKey(
+                name: "pk_collections",
+                table: "collections");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "pk_collections",
+                table: "collections",
+                column: "id");
+        }
+    }
+}

--- a/src/IIIFPresentation/Repository/PresentationContext.cs
+++ b/src/IIIFPresentation/Repository/PresentationContext.cs
@@ -29,6 +29,7 @@ public class PresentationContext : DbContext
     {
         modelBuilder.Entity<Collection>(entity =>
         {
+            entity.HasKey(e => new {e.Id, e.CustomerId});
             entity.HasIndex(e => new { e.CustomerId, e.Slug, e.Parent }).IsUnique();
             
             entity.Property(e => e.Label).HasColumnType("jsonb");

--- a/src/IIIFPresentation/Test.Helpers/Helpers/RootCollection.cs
+++ b/src/IIIFPresentation/Test.Helpers/Helpers/RootCollection.cs
@@ -1,0 +1,6 @@
+﻿namespace Test.Helpers.Helpers;
+
+public static class RootCollection
+{
+    public static string Id => "root";
+}

--- a/src/IIIFPresentation/Test.Helpers/Integration/PresentationContextFixture.cs
+++ b/src/IIIFPresentation/Test.Helpers/Integration/PresentationContextFixture.cs
@@ -32,7 +32,7 @@ public class PresentationContextFixture : IAsyncLifetime
     {
         await DbContext.Collections.AddAsync(new Collection()
         {
-            Id = "RootStorage",
+            Id = "root",
             Slug = "",
             UsePath = true,
             Label = new LanguageMap
@@ -66,7 +66,7 @@ public class PresentationContextFixture : IAsyncLifetime
             IsStorageCollection = true,
             IsPublic = true,
             CustomerId = 1,
-            Parent = "RootStorage"
+            Parent = "root"
         });
         
         await DbContext.Collections.AddAsync(new Collection()
@@ -106,7 +106,7 @@ public class PresentationContextFixture : IAsyncLifetime
             IsStorageCollection = true,
             IsPublic = false,
             CustomerId = 1,
-            Parent = "RootStorage"
+            Parent = "root"
         });
 
         await DbContext.SaveChangesAsync();
@@ -148,6 +148,6 @@ public class PresentationContextFixture : IAsyncLifetime
     public void CleanUp()
     {
         DbContext.Database.ExecuteSqlRawAsync(
-            "DELETE FROM collections WHERE id NOT IN ('RootStorage','FirstChildCollection','SecondChildCollection', 'NonPublic')");
+            "DELETE FROM collections WHERE id NOT IN ('root','FirstChildCollection','SecondChildCollection', 'NonPublic')");
     }
 }

--- a/src/IIIFPresentation/Test.Helpers/Integration/PresentationContextFixture.cs
+++ b/src/IIIFPresentation/Test.Helpers/Integration/PresentationContextFixture.cs
@@ -2,6 +2,7 @@
 using Microsoft.EntityFrameworkCore;
 using Models.Database.Collections;
 using Repository;
+using Test.Helpers.Helpers;
 using Testcontainers.PostgreSql;
 
 #nullable disable
@@ -32,7 +33,7 @@ public class PresentationContextFixture : IAsyncLifetime
     {
         await DbContext.Collections.AddAsync(new Collection()
         {
-            Id = "root",
+            Id = RootCollection.Id,
             Slug = "",
             UsePath = true,
             Label = new LanguageMap
@@ -66,7 +67,7 @@ public class PresentationContextFixture : IAsyncLifetime
             IsStorageCollection = true,
             IsPublic = true,
             CustomerId = 1,
-            Parent = "root"
+            Parent = RootCollection.Id
         });
         
         await DbContext.Collections.AddAsync(new Collection()
@@ -106,7 +107,7 @@ public class PresentationContextFixture : IAsyncLifetime
             IsStorageCollection = true,
             IsPublic = false,
             CustomerId = 1,
-            Parent = "root"
+            Parent = RootCollection.Id
         });
 
         await DbContext.SaveChangesAsync();


### PR DESCRIPTION
Resolves #23

This PR updates flat collections to refer to the root collection as root everywhere. This includes when gathering parent collections.

How this works is that the primary key of the `collections` table has changed to a composite key of `customer id` and `id`, meaning that the root record of the customer will always have an id of `root`.  The knock-on effect of this is a simplification in how we work out the root collection, as there is now not a separate internal id that is referred to as `root` by customers