### PR TITLE
Ensure matching 'modified' and 'creation' collection values on create

### DIFF
--- a/src/IIIFPresentation/API.Tests/Integration/ModifyCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyCollectionTests.cs
@@ -80,6 +80,7 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
         fromDatabase.Tags.Should().Be("some, tags");
         fromDatabase.IsPublic.Should().BeTrue();
         fromDatabase.IsStorageCollection.Should().BeTrue();
+        fromDatabase.Modified.Should().Be(fromDatabase.Created);
         responseCollection!.View!.PageSize.Should().Be(20);
         responseCollection.View.Page.Should().Be(1);
         responseCollection.View.Id.Should().Contain("?page=1&pageSize=20");

--- a/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
@@ -47,12 +47,13 @@ public class CreateCollectionHandler(
             return ModifyEntityResult<FlatCollection>.Failure(
                 $"The parent collection could not be found", WriteResult.Conflict);
         }
-        
+
+        var dateCreated = DateTime.UtcNow;
         var collection = new Collection()
         {
             Id = Guid.NewGuid().ToString(),
-            Created = DateTime.UtcNow,
-            Modified = DateTime.UtcNow,
+            Created = dateCreated,
+            Modified = dateCreated,
             CreatedBy = Authorizer.GetUser(),
             CustomerId = request.CustomerId,
             IsPublic = request.Collection.Behavior.IsPublic(),


### PR DESCRIPTION
Resolves https://github.com/dlcs/iiif-presentation/issues/39

This PR fixes a minor bug that caused a slight difference between the `created` and `modified` timestamps on a newly created collection, caused by calling `DateTime.UtcNow` twice.