### PR TITLE
Add vary heade to flat and hierarchical collection GETs

### DIFF
--- a/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
@@ -59,6 +59,19 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         var firstItem = (Collection)collection.Items[0];
         firstItem.Id.Should().Be("http://localhost/1/first-child/second-child");
     }
+
+    [Fact]
+    public async Task Get_ChildHierarchical_Returns_Vary_Header()
+    {
+        // Act
+        var response = await httpClient.GetAsync("1/first-child");
+
+        var collection = await response.ReadAsIIIFJsonAsync<Collection>();
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.Vary.Should().HaveCount(2);
+    }
     
     [Fact]
     public async Task Get_Hierarchical_Redirects_WhenAuthAndShowExtrasHeaders()
@@ -372,5 +385,21 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         collection.View.TotalPages.Should().Be(2);
         collection.Items!.Count.Should().Be(1);
         collection.Items.OfType<Collection>().First().Id.Should().Be("http://localhost/1/collections/FirstChildCollection");
+    }
+
+    [Fact]
+    public async Task Get_ChildFlat_Returns_Vary_Header()
+    {
+        // Arrange
+        var requestMessage =
+            HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get,
+                $"1/collections/{RootCollection.Id}?page=1&pageSize=1&orderByDescending=notValid");
+
+        // Act
+        var response = await httpClient.AsCustomer(1).SendAsync(requestMessage);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.Vary.Should().HaveCount(2);
     }
 }

--- a/src/IIIFPresentation/API/Features/Storage/StorageController.cs
+++ b/src/IIIFPresentation/API/Features/Storage/StorageController.cs
@@ -5,13 +5,14 @@ using API.Features.Storage.Requests;
 using API.Features.Storage.Validators;
 using API.Helpers;
 using API.Infrastructure;
+using API.Infrastructure.Filters;
 using API.Infrastructure.Helpers;
 using API.Settings;
+using IIIF.Presentation;
+using IIIF.Serialisation;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
-using IIIF.Presentation;
-using IIIF.Serialisation;
 using Models.API.Collection.Upsert;
 
 namespace API.Features.Storage;
@@ -23,6 +24,7 @@ public class StorageController(IOptions<ApiSettings> options, IMediator mediator
 {
     [HttpGet("{*slug}")]
     [ETagCaching()]
+    [VaryHeader]
     public async Task<IActionResult> GetHierarchicalCollection(int customerId, string slug = "")
     {
         var storageRoot = await Mediator.Send(new GetHierarchicalCollection(customerId, slug));
@@ -40,6 +42,7 @@ public class StorageController(IOptions<ApiSettings> options, IMediator mediator
 
     [HttpGet("collections/{id}")]
     [ETagCaching]
+    [VaryHeader]
     public async Task<IActionResult> Get(int customerId, string id, int? page = 1, int? pageSize = -1, 
         string? orderBy = null, string? orderByDescending = null)
     {
@@ -113,8 +116,8 @@ public class StorageController(IOptions<ApiSettings> options, IMediator mediator
 
         return await HandleDelete(new DeleteCollection(customerId, id));
     }
-    
-    private IActionResult SeeOther(string location)
+
+    private StatusCodeResult SeeOther(string location)
     {
         Response.Headers.Location = location;
 

--- a/src/IIIFPresentation/API/Infrastructure/Filters/VaryHeaderAttribute.cs
+++ b/src/IIIFPresentation/API/Infrastructure/Filters/VaryHeaderAttribute.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Net.Http.Headers;
+
+namespace API.Infrastructure.Filters;
+
+public class VaryHeaderAttribute : ActionFilterAttribute
+{
+    private static readonly string[] VaryHeaders = ["X-IIIF-CS-Show-Extras", "Authorization"];
+
+    public override void OnActionExecuted(ActionExecutedContext context)
+    {
+        if (context.Result is not null)
+            context.HttpContext.Response.Headers.Append(HeaderNames.Vary, VaryHeaders);
+    }
+}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/53c5f2d9-9985-46f5-9198-ec32c6d1a6f3)

Array can be expanded or moved to config if anything like that ever becomes necessary.

Attr can be easily modified to take the `string[] headerNames` in ctor, if we ever need to vary the vary header in various actions 😆 

For now took the simple approach. Well, simple would be to add `Response.Headers.Append` in the actions themselves, but you know, that's awful :D 