### PR TITLE
Add ability to retrieve a IIIF collection from S3

### DIFF
--- a/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
@@ -17,6 +17,7 @@ namespace API.Tests.Integration;
 public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
 {
     private readonly HttpClient httpClient;
+    private const int TotalDatabaseChildItems = 3;
 
     public GetCollectionTests(StorageFixture storageFixture, PresentationAppFactory<Program> factory)
     {
@@ -39,7 +40,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         collection!.Id.Should().Be("http://localhost/1");
-        collection.Items.Count.Should().Be(3);
+        collection.Items.Count.Should().Be(TotalDatabaseChildItems);
         var firstItem = (Collection)collection.Items[0];
         firstItem.Id.Should().Be("http://localhost/1/first-child");
     }
@@ -157,9 +158,9 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         collection!.Id.Should().Be($"http://localhost/1/collections/{RootCollection.Id}");
         collection.PublicId.Should().Be("http://localhost/1");
-        collection.Items!.Count.Should().Be(3);
+        collection.Items!.Count.Should().Be(TotalDatabaseChildItems);
         collection.Items.OfType<Collection>().First().Id.Should().Be("http://localhost/1/collections/FirstChildCollection");
-        collection.TotalItems.Should().Be(3);
+        collection.TotalItems.Should().Be(TotalDatabaseChildItems);
         collection.CreatedBy.Should().Be("admin");
         collection.Behavior.Should().Contain("public-iiif");
     }
@@ -225,11 +226,11 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         var collection = await response.ReadAsPresentationJsonAsync<PresentationCollection>();
         
         // Assert
-        collection.TotalItems.Should().Be(3);
+        collection.TotalItems.Should().Be(TotalDatabaseChildItems);
         collection.View!.PageSize.Should().Be(100);
         collection.View.Page.Should().Be(1);
         collection.View.TotalPages.Should().Be(1);
-        collection.Items!.Count.Should().Be(3);
+        collection.Items!.Count.Should().Be(TotalDatabaseChildItems);
     }
     
     [Fact]
@@ -245,7 +246,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         var collection = await response.ReadAsPresentationJsonAsync<PresentationCollection>();
         
         // Assert
-        collection.TotalItems.Should().Be(3);
+        collection.TotalItems.Should().Be(TotalDatabaseChildItems);
         collection.View!.PageSize.Should().Be(1);
         collection.View.Page.Should().Be(1);
         collection.View.TotalPages.Should().Be(3);
@@ -266,7 +267,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         var collection = await response.ReadAsPresentationJsonAsync<PresentationCollection>();
         
         // Assert
-        collection.TotalItems.Should().Be(3);
+        collection.TotalItems.Should().Be(TotalDatabaseChildItems);
         collection.View!.PageSize.Should().Be(1);
         collection.View.Page.Should().Be(2);
         collection.View.TotalPages.Should().Be(3);
@@ -287,11 +288,11 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         var collection = await response.ReadAsPresentationJsonAsync<PresentationCollection>();
         
         // Assert
-        collection.TotalItems.Should().Be(3);
+        collection.TotalItems.Should().Be(TotalDatabaseChildItems);
         collection.View!.PageSize.Should().Be(20);
         collection.View.Page.Should().Be(1);
         collection.View.TotalPages.Should().Be(1);
-        collection.Items!.Count.Should().Be(3);
+        collection.Items!.Count.Should().Be(TotalDatabaseChildItems);
     }
     
     [Fact]
@@ -307,11 +308,11 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         var collection = await response.ReadAsPresentationJsonAsync<PresentationCollection>();
         
         // Assert
-        collection.TotalItems.Should().Be(3);
+        collection.TotalItems.Should().Be(TotalDatabaseChildItems);
         collection.View!.PageSize.Should().Be(100);
         collection.View.Page.Should().Be(1);
         collection.View.TotalPages.Should().Be(1);
-        collection.Items!.Count.Should().Be(3);
+        collection.Items!.Count.Should().Be(TotalDatabaseChildItems);
     }
     
     [Theory]
@@ -331,7 +332,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         var collection = await response.ReadAsPresentationJsonAsync<PresentationCollection>();
         
         // Assert
-        collection.TotalItems.Should().Be(3);
+        collection.TotalItems.Should().Be(TotalDatabaseChildItems);
         collection.View!.PageSize.Should().Be(1);
         collection.View.Page.Should().Be(1);
         collection.View.TotalPages.Should().Be(3);
@@ -356,7 +357,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         var collection = await response.ReadAsPresentationJsonAsync<PresentationCollection>();
         
         // Assert
-        collection.TotalItems.Should().Be(3);
+        collection.TotalItems.Should().Be(TotalDatabaseChildItems);
         collection.View!.PageSize.Should().Be(1);
         collection.View.Id.Should().Be($"http://localhost/1/collections/{RootCollection.Id}?page=1&pageSize=1&orderByDescending={field}");
         collection.View.Page.Should().Be(1);
@@ -379,7 +380,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         var collection = await response.ReadAsPresentationJsonAsync<PresentationCollection>();
         
         // Assert
-        collection.TotalItems.Should().Be(3);
+        collection.TotalItems.Should().Be(TotalDatabaseChildItems);
         collection.View!.PageSize.Should().Be(1);
         collection.View.Id.Should().Be($"http://localhost/1/collections/{RootCollection.Id}?page=1&pageSize=1");
         collection.View.Page.Should().Be(1);

--- a/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
@@ -13,17 +13,18 @@ using Test.Helpers.Integration;
 namespace API.Tests.Integration;
 
 [Trait("Category", "Integration")]
-[Collection(CollectionDefinitions.DatabaseCollection.CollectionName)]
+[Collection(CollectionDefinitions.StorageCollection.CollectionName)]
 public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
 {
     private readonly HttpClient httpClient;
 
-    public GetCollectionTests(PresentationContextFixture dbFixture, PresentationAppFactory<Program> factory)
+    public GetCollectionTests(StorageFixture storageFixture, PresentationAppFactory<Program> factory)
     {
-        httpClient = factory.WithConnectionString(dbFixture.ConnectionString)
+        httpClient = factory.WithConnectionString(storageFixture.DbFixture.ConnectionString) 
+            .WithLocalStack(storageFixture.LocalStackFixture)
             .CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false }); ;
         
-        dbFixture.CleanUp();
+        storageFixture.DbFixture.CleanUp();
     }
     
     [Fact]
@@ -38,7 +39,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         collection!.Id.Should().Be("http://localhost/1");
-        collection.Items.Count.Should().Be(2);
+        collection.Items.Count.Should().Be(3);
         var firstItem = (Collection)collection.Items[0];
         firstItem.Id.Should().Be("http://localhost/1/first-child");
     }
@@ -156,9 +157,9 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         collection!.Id.Should().Be($"http://localhost/1/collections/{RootCollection.Id}");
         collection.PublicId.Should().Be("http://localhost/1");
-        collection.Items!.Count.Should().Be(2);
+        collection.Items!.Count.Should().Be(3);
         collection.Items.OfType<Collection>().First().Id.Should().Be("http://localhost/1/collections/FirstChildCollection");
-        collection.TotalItems.Should().Be(2);
+        collection.TotalItems.Should().Be(3);
         collection.CreatedBy.Should().Be("admin");
         collection.Behavior.Should().Contain("public-iiif");
     }
@@ -224,11 +225,11 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         var collection = await response.ReadAsPresentationJsonAsync<PresentationCollection>();
         
         // Assert
-        collection.TotalItems.Should().Be(2);
+        collection.TotalItems.Should().Be(3);
         collection.View!.PageSize.Should().Be(100);
         collection.View.Page.Should().Be(1);
         collection.View.TotalPages.Should().Be(1);
-        collection.Items!.Count.Should().Be(2);
+        collection.Items!.Count.Should().Be(3);
     }
     
     [Fact]
@@ -244,10 +245,10 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         var collection = await response.ReadAsPresentationJsonAsync<PresentationCollection>();
         
         // Assert
-        collection.TotalItems.Should().Be(2);
+        collection.TotalItems.Should().Be(3);
         collection.View!.PageSize.Should().Be(1);
         collection.View.Page.Should().Be(1);
-        collection.View.TotalPages.Should().Be(2);
+        collection.View.TotalPages.Should().Be(3);
         collection.Items!.Count.Should().Be(1);
         collection.Items.OfType<Collection>().First().Id.Should().Be("http://localhost/1/collections/FirstChildCollection");
     }
@@ -265,10 +266,10 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         var collection = await response.ReadAsPresentationJsonAsync<PresentationCollection>();
         
         // Assert
-        collection.TotalItems.Should().Be(2);
+        collection.TotalItems.Should().Be(3);
         collection.View!.PageSize.Should().Be(1);
         collection.View.Page.Should().Be(2);
-        collection.View.TotalPages.Should().Be(2);
+        collection.View.TotalPages.Should().Be(3);
         collection.Items!.Count.Should().Be(1);
         collection.Items.OfType<Collection>().First().Id.Should().Be("http://localhost/1/collections/NonPublic");
     }
@@ -286,11 +287,11 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         var collection = await response.ReadAsPresentationJsonAsync<PresentationCollection>();
         
         // Assert
-        collection.TotalItems.Should().Be(2);
+        collection.TotalItems.Should().Be(3);
         collection.View!.PageSize.Should().Be(20);
         collection.View.Page.Should().Be(1);
         collection.View.TotalPages.Should().Be(1);
-        collection.Items!.Count.Should().Be(2);
+        collection.Items!.Count.Should().Be(3);
     }
     
     [Fact]
@@ -306,11 +307,11 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         var collection = await response.ReadAsPresentationJsonAsync<PresentationCollection>();
         
         // Assert
-        collection.TotalItems.Should().Be(2);
+        collection.TotalItems.Should().Be(3);
         collection.View!.PageSize.Should().Be(100);
         collection.View.Page.Should().Be(1);
         collection.View.TotalPages.Should().Be(1);
-        collection.Items!.Count.Should().Be(2);
+        collection.Items!.Count.Should().Be(3);
     }
     
     [Theory]
@@ -330,10 +331,10 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         var collection = await response.ReadAsPresentationJsonAsync<PresentationCollection>();
         
         // Assert
-        collection.TotalItems.Should().Be(2);
+        collection.TotalItems.Should().Be(3);
         collection.View!.PageSize.Should().Be(1);
         collection.View.Page.Should().Be(1);
-        collection.View.TotalPages.Should().Be(2);
+        collection.View.TotalPages.Should().Be(3);
         collection.Items!.Count.Should().Be(1);
         collection.Items.OfType<Collection>().First().Id.Should().Be("http://localhost/1/collections/FirstChildCollection");
     }
@@ -355,13 +356,13 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         var collection = await response.ReadAsPresentationJsonAsync<PresentationCollection>();
         
         // Assert
-        collection.TotalItems.Should().Be(2);
+        collection.TotalItems.Should().Be(3);
         collection.View!.PageSize.Should().Be(1);
         collection.View.Id.Should().Be($"http://localhost/1/collections/{RootCollection.Id}?page=1&pageSize=1&orderByDescending={field}");
         collection.View.Page.Should().Be(1);
-        collection.View.TotalPages.Should().Be(2);
+        collection.View.TotalPages.Should().Be(3);
         collection.Items!.Count.Should().Be(1);
-        collection.Items.OfType<Collection>().First().Id.Should().Be("http://localhost/1/collections/NonPublic");
+        collection.Items.OfType<Collection>().First().Id.Should().Be("http://localhost/1/collections/IiifCollection");
     }
     
     [Fact]
@@ -378,11 +379,11 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         var collection = await response.ReadAsPresentationJsonAsync<PresentationCollection>();
         
         // Assert
-        collection.TotalItems.Should().Be(2);
+        collection.TotalItems.Should().Be(3);
         collection.View!.PageSize.Should().Be(1);
         collection.View.Id.Should().Be($"http://localhost/1/collections/{RootCollection.Id}?page=1&pageSize=1");
         collection.View.Page.Should().Be(1);
-        collection.View.TotalPages.Should().Be(2);
+        collection.View.TotalPages.Should().Be(3);
         collection.Items!.Count.Should().Be(1);
         collection.Items.OfType<Collection>().First().Id.Should().Be("http://localhost/1/collections/FirstChildCollection");
     }
@@ -393,7 +394,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         // Arrange
         var requestMessage =
             HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get,
-                $"1/collections/{RootCollection.Id}?page=1&pageSize=1&orderByDescending=notValid");
+                $"1/collections/{RootCollection.Id}");
 
         // Act
         var response = await httpClient.AsCustomer(1).SendAsync(requestMessage);
@@ -401,5 +402,21 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         response.Headers.Vary.Should().HaveCount(2);
+    }
+    
+    [Fact]
+    public async Task Get_IiifCollection_ReturnsCollectionFromS3()
+    {
+        // Arrange and Act
+        var response = await httpClient.GetAsync("1/iiif-collection");
+        
+        var collection = await response.ReadAsIIIFJsonAsync<Collection>();
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.Vary.Should().HaveCount(2);
+        collection!.Items.Should().BeNull();
+        collection.Behavior![0].Should().Be("public-iiif");
+        collection.Type.Should().Be("Collection");
     }
 }

--- a/src/IIIFPresentation/API/Features/Storage/Models/CollectionWithItems.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Models/CollectionWithItems.cs
@@ -2,23 +2,23 @@
 
 namespace API.Features.Storage.Models;
 
-public class CollectionWithItems
+public class CollectionWithItems(
+    Collection? collection,
+    List<Collection>? items,
+    int totalItems,
+    string? storedCollection = null)
 {
-    public CollectionWithItems(Collection? collection, List<Collection>? items, int totalItems)
-    {
-        Collection = collection;
-        Items = items;
-        TotalItems = totalItems;
-    }
+    public Collection? Collection { get; init; } = collection;
+    public List<Collection>? Items { get; init; } = items;
+    public int TotalItems { get; init; } = totalItems;
+    public string? StoredCollection { get; init; } = storedCollection;
 
-    public Collection? Collection { get; init; }
-    public List<Collection>? Items { get; init; }
-    public int TotalItems { get; init; }
-
-    public void Deconstruct(out Collection? collection, out List<Collection>? items, out int totalItems)
+    public void Deconstruct(out Collection? collection, out List<Collection>? items, out int totalItems, 
+        out string? storedCollection)
     {
         collection = Collection;
         items = Items;
         totalItems = TotalItems;
+        storedCollection = StoredCollection;
     }
 }

--- a/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
@@ -119,14 +119,16 @@ public class CreateCollectionHandler(
             catch (JsonSerializationException ex)
             {
                 logger.LogError(ex, "Error attempting to validate collection is IIIF");
-                return ModifyEntityResult<PresentationCollection>.Failure(
-                    "Error attempting to validate collection is IIIF", WriteResult.BadRequest);
+                return ModifyEntityResult<PresentationCollection, ModifyCollectionType>.Failure(
+                    "Error attempting to validate collection is IIIF", ModifyCollectionType.CannotValidateIIIF,
+                    WriteResult.BadRequest);
             }
             catch (Exception ex)
             {
                 logger.LogError(ex, "An unknown exception occured while creating a new collection");
-                return ModifyEntityResult<PresentationCollection>.Failure(
-                    "Unknown error occured while creating a collection", WriteResult.Error);
+                return ModifyEntityResult<PresentationCollection, ModifyCollectionType>.Failure(
+                    "Unknown error occured while creating a collection", ModifyCollectionType.Unknown,
+                    WriteResult.Error);
             }
         }
         

--- a/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
@@ -120,7 +120,7 @@ public class CreateCollectionHandler(
             {
                 logger.LogError(ex, "Error attempting to validate collection is IIIF");
                 return ModifyEntityResult<PresentationCollection>.Failure(
-                    "Error attempting to validate collection is IIIF", WriteResult.Error);
+                    "Error attempting to validate collection is IIIF", WriteResult.BadRequest);
             }
             catch (Exception ex)
             {

--- a/src/IIIFPresentation/API/Features/Storage/Requests/GetHierarchicalCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/GetHierarchicalCollection.cs
@@ -143,13 +143,20 @@ WHERE
         }
 
         List<Collection>? items = null;
+        string? collectionFromS3 = null;
 
         if (collection != null)
         {
             if (!collection.IsStorageCollection)
             {
-                var collectionFromS3 = await bucketReader.GetObjectFromBucket(new ObjectInBucket(settings.S3.StorageBucket,
+                var objectFromS3 = await bucketReader.GetObjectFromBucket(new ObjectInBucket(settings.S3.StorageBucket,
                     $"{request.CustomerId}/collections/{collection.Id}"), cancellationToken);
+
+                if (objectFromS3.Stream != null)
+                {
+                    StreamReader reader = new StreamReader(objectFromS3.Stream);
+                    collectionFromS3 = reader.ReadToEnd();
+                }
             }
             else
             {
@@ -166,6 +173,6 @@ WHERE
             collection.FullPath = request.Slug;
         }
 
-        return new CollectionWithItems(collection, items, items?.Count ?? 0);
+        return new CollectionWithItems(collection, items, items?.Count ?? 0, collectionFromS3);
     }
 }

--- a/src/IIIFPresentation/API/Features/Storage/Requests/GetHierarchicalCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/GetHierarchicalCollection.cs
@@ -164,10 +164,7 @@ WHERE
                     .Where(s => s.CustomerId == request.CustomerId && s.Parent == collection.Id)
                     .ToListAsync(cancellationToken: cancellationToken);
 
-                foreach (var item in items)
-                {
-                    item.FullPath = collection.GenerateFullPath(item.Slug);
-                }
+                items.ForEach(item => item.FullPath = collection.GenerateFullPath(item.Slug));
             }
 
             collection.FullPath = request.Slug;

--- a/src/IIIFPresentation/API/Features/Storage/StorageController.cs
+++ b/src/IIIFPresentation/API/Features/Storage/StorageController.cs
@@ -10,12 +10,9 @@ using API.Infrastructure.Helpers;
 using API.Settings;
 using IIIF.Presentation;
 using IIIF.Serialisation;
-using Core.Helpers;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
-using IIIF.Presentation;
-using IIIF.Serialisation;
 using Models.API.Collection.Upsert;
 using Newtonsoft.Json;
 
@@ -27,7 +24,7 @@ public class StorageController(IOptions<ApiSettings> options, IMediator mediator
     : PresentationController(options.Value, mediator)
 {
     [HttpGet("{*slug}")]
-    [ETagCaching()]
+    [ETagCaching]
     [VaryHeader]
     public async Task<IActionResult> GetHierarchicalCollection(int customerId, string slug = "")
     {
@@ -40,8 +37,10 @@ public class StorageController(IOptions<ApiSettings> options, IMediator mediator
             return SeeOther(storageRoot.Collection.GenerateFlatCollectionId(GetUrlRoots()));
         }
 
-        return Content(storageRoot.Collection.ToHierarchicalCollection(GetUrlRoots(), storageRoot.Items).AsJson(),
-            ContentTypes.V3);
+        return storageRoot.StoredCollection == null
+            ? Content(storageRoot.Collection.ToHierarchicalCollection(GetUrlRoots(), storageRoot.Items).AsJson(), 
+                ContentTypes.V3)
+            : Content(storageRoot.StoredCollection, ContentTypes.V3);
     }
 
     [HttpGet("collections/{id}")]

--- a/src/IIIFPresentation/Models/API/General/ModifyCollectionType.cs
+++ b/src/IIIFPresentation/Models/API/General/ModifyCollectionType.cs
@@ -9,4 +9,7 @@ public enum ModifyCollectionType
     ETagNotMatched = 5,
     PossibleCircularReference = 6,
     CannotGenerateUniqueId = 7,
+    CannotValidateIIIF = 8,
+    
+    Unknown = 1000
 }

--- a/src/IIIFPresentation/Test.Helpers/Integration/LocalStackFixture.cs
+++ b/src/IIIFPresentation/Test.Helpers/Integration/LocalStackFixture.cs
@@ -1,6 +1,7 @@
 ﻿using Amazon;
 using Amazon.Runtime;
 using Amazon.S3;
+using Amazon.S3.Model;
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Containers;
 
@@ -70,5 +71,23 @@ public class LocalStackFixture : IAsyncLifetime
         // Create basic buckets used by DLCS
         var amazonS3Client = AWSS3ClientFactory();
         await amazonS3Client.PutBucketAsync(StorageBucketName);
+        await amazonS3Client.PutObjectAsync(new PutObjectRequest()
+        {
+            BucketName = StorageBucketName,
+            Key = "1/collections/IiifCollection", 
+            ContentBody = $$"""
+                            {
+                            "type": "Collection",
+                            "behavior": [
+                                "public-iiif",
+                            ],
+                            "label": {
+                                "en": [
+                                    "first child - iiif"
+                                ]
+                            }
+                            }
+                            """
+        });
     }
 }

--- a/src/IIIFPresentation/Test.Helpers/Integration/PresentationContextFixture.cs
+++ b/src/IIIFPresentation/Test.Helpers/Integration/PresentationContextFixture.cs
@@ -109,6 +109,26 @@ public class PresentationContextFixture : IAsyncLifetime
             CustomerId = 1,
             Parent = RootCollection.Id
         });
+        
+        await DbContext.Collections.AddAsync(new Collection()
+        {
+            Id = "IiifCollection",
+            Slug = "iiif-collection",
+            UsePath = true,
+            Label = new LanguageMap
+            {
+                {"en", new List<string> {"first child - iiif"}}
+            },
+            Thumbnail = "some/location",
+            Created = DateTime.UtcNow,
+            Modified = DateTime.UtcNow,
+            CreatedBy = "admin",
+            Tags = "some, tags",
+            IsStorageCollection = false,
+            IsPublic = true,
+            CustomerId = 1,
+            Parent = RootCollection.Id
+        });
 
         await DbContext.SaveChangesAsync();
     }
@@ -149,6 +169,6 @@ public class PresentationContextFixture : IAsyncLifetime
     public void CleanUp()
     {
         DbContext.Database.ExecuteSqlRawAsync(
-            "DELETE FROM collections WHERE id NOT IN ('root','FirstChildCollection','SecondChildCollection', 'NonPublic')");
+            "DELETE FROM collections WHERE id NOT IN ('root','FirstChildCollection','SecondChildCollection', 'NonPublic', 'IiifCollection')");
     }
 }


### PR DESCRIPTION
Resolves #26 

This PR is the retrieval side of #26, and allows IIIF collections on the GET hierarchical path.

Additionally, this PR modifies `POST` to verify that the collection is a valid IIIF collection and strips out extra properties