### PR TITLE
Adding ability to detect when updating a collection might create a circular reference

### DIFF
--- a/src/IIIFPresentation/API/Features/Storage/Helpers/PresentationContextX.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Helpers/PresentationContextX.cs
@@ -2,6 +2,7 @@
 using Core;
 using Microsoft.EntityFrameworkCore;
 using Models.API.Collection;
+using Models.API.General;
 using Models.Database.Collections;
 using Repository;
 using Repository.Helpers;
@@ -10,7 +11,7 @@ namespace API.Features.Storage.Helpers;
 
 public static class PresentationContextX
 {
-    public static async Task<ModifyEntityResult<PresentationCollection>?> TrySaveCollection(
+    public static async Task<ModifyEntityResult<PresentationCollection, ModifyCollectionType>?> TrySaveCollection(
         this PresentationContext dbContext, 
         int customerId, 
         ILogger logger,
@@ -26,12 +27,13 @@ public static class PresentationContextX
 
             if (ex.IsCustomerIdSlugParentViolation())
             {
-                return ModifyEntityResult<PresentationCollection>.Failure(
-                    $"The collection could not be created due to a duplicate slug value", WriteResult.Conflict);
+                return ModifyEntityResult<PresentationCollection, ModifyCollectionType>.Failure(
+                    $"The collection could not be created due to a duplicate slug value",
+                    ModifyCollectionType.DuplicateSlugValue, WriteResult.Conflict);
             }
 
-            return ModifyEntityResult<PresentationCollection>.Failure(
-                $"The collection could not be created");
+            return ModifyEntityResult<PresentationCollection, ModifyCollectionType>.Failure(
+               $"The collection could not be created", ModifyCollectionType.UnknownDatabaseSaveError);
         }
 
         return null;

--- a/src/IIIFPresentation/API/Features/Storage/Requests/UpsertCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/UpsertCollection.cs
@@ -5,12 +5,14 @@ using API.Infrastructure.Helpers;
 using API.Infrastructure.Requests;
 using API.Settings;
 using Core;
+using Core.Exceptions;
 using Core.Helpers;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using Models.API.Collection;
 using Models.API.Collection.Upsert;
+using Models.API.General;
 using Models.Database.Collections;
 using Repository;
 using Repository.Helpers;
@@ -19,7 +21,7 @@ namespace API.Features.Storage.Requests;
 
 public class UpsertCollection(int customerId, string collectionId, UpsertFlatCollection collection, UrlRoots urlRoots, 
     string? eTag)
-    : IRequest<ModifyEntityResult<PresentationCollection>>
+    : IRequest<ModifyEntityResult<PresentationCollection, ModifyCollectionType>>
 {
     public int CustomerId { get; } = customerId;
 
@@ -37,13 +39,13 @@ public class UpsertCollectionHandler(
     IETagManager eTagManager,
     ILogger<CreateCollection> logger,
     IOptions<ApiSettings> options)
-    : IRequestHandler<UpsertCollection, ModifyEntityResult<PresentationCollection>>
+    : IRequestHandler<UpsertCollection, ModifyEntityResult<PresentationCollection, ModifyCollectionType>>
 {
     private readonly ApiSettings settings = options.Value;
 
     private const int DefaultCurrentPage = 1;
 
-    public async Task<ModifyEntityResult<PresentationCollection>> Handle(UpsertCollection request, 
+    public async Task<ModifyEntityResult<PresentationCollection, ModifyCollectionType>> Handle(UpsertCollection request, 
         CancellationToken cancellationToken)
     {
         var databaseCollection =
@@ -53,8 +55,9 @@ public class UpsertCollectionHandler(
         {
             if (request.ETag is not null)
             {
-                return ModifyEntityResult<PresentationCollection>.Failure(
-                    "ETag should not be added when inserting a collection via PUT", WriteResult.PreConditionFailed);
+                return ModifyEntityResult<PresentationCollection, ModifyCollectionType>.Failure(
+                    "ETag should not be added when inserting a collection via PUT", ModifyCollectionType.ETagNotAllowed,
+                    WriteResult.PreConditionFailed);
             }
 
             var createdDate = DateTime.UtcNow;
@@ -63,8 +66,9 @@ public class UpsertCollectionHandler(
                 request.Collection.Parent.GetLastPathElement(), cancellationToken);
             if (parentCollection == null)
             {
-                return ModifyEntityResult<PresentationCollection>.Failure(
-                    "The parent collection could not be found", WriteResult.BadRequest);
+                return ModifyEntityResult<PresentationCollection, ModifyCollectionType>.Failure(
+                    "The parent collection could not be found", ModifyCollectionType.ParentCollectionNotFound,
+                    WriteResult.BadRequest);
             }
 
             databaseCollection = new Collection
@@ -92,8 +96,8 @@ public class UpsertCollectionHandler(
 
             if (request.ETag != eTag)
             {
-                return ModifyEntityResult<PresentationCollection>.Failure(
-                    "ETag does not match", WriteResult.PreConditionFailed);
+                return ModifyEntityResult<PresentationCollection, ModifyCollectionType>.Failure(
+                    "ETag does not match", ModifyCollectionType.ETagNotMatched, WriteResult.PreConditionFailed);
             }
 
             if (databaseCollection.Parent != request.Collection.Parent)
@@ -103,8 +107,9 @@ public class UpsertCollectionHandler(
 
                 if (parentCollection == null)
                 {
-                    return ModifyEntityResult<PresentationCollection>.Failure(
-                        $"The parent collection could not be found", WriteResult.BadRequest);
+                    return ModifyEntityResult<PresentationCollection, ModifyCollectionType>.Failure(
+                        $"The parent collection could not be found", ModifyCollectionType.ParentCollectionNotFound,
+                        WriteResult.BadRequest);
                 }
             }
 
@@ -120,6 +125,8 @@ public class UpsertCollectionHandler(
             databaseCollection.ItemsOrder = request.Collection.ItemsOrder;
         }
 
+        await using var transaction = 
+            await dbContext.Database.BeginTransactionAsync(cancellationToken);
 
         var saveErrors = await dbContext.TrySaveCollection(request.CustomerId, logger, cancellationToken);
 
@@ -143,11 +150,22 @@ public class UpsertCollectionHandler(
 
         if (databaseCollection.Parent != null)
         {
-            databaseCollection.FullPath =
-                CollectionRetrieval.RetrieveFullPathForCollection(databaseCollection, dbContext);
+            try
+            {
+                databaseCollection.FullPath =
+                    CollectionRetrieval.RetrieveFullPathForCollection(databaseCollection, dbContext);
+            }
+            catch (PresentationException)
+            {
+                return ModifyEntityResult<PresentationCollection, ModifyCollectionType>.Failure(
+                    "New slug exceeds 1000 records.  This could mean an item no longer belongs to the root collection.",
+                     ModifyCollectionType.PossibleCircularReference, WriteResult.BadRequest);
+            }
         }
+        
+        await transaction.CommitAsync(cancellationToken);
 
-        return ModifyEntityResult<PresentationCollection>.Success(
+        return ModifyEntityResult<PresentationCollection, ModifyCollectionType>.Success(
             databaseCollection.ToFlatCollection(request.UrlRoots, settings.PageSize, DefaultCurrentPage, total,
                 await items.ToListAsync(cancellationToken: cancellationToken)));
     }

--- a/src/IIIFPresentation/API/Infrastructure/PresentationController.cs
+++ b/src/IIIFPresentation/API/Infrastructure/PresentationController.cs
@@ -135,7 +135,7 @@ public abstract class PresentationController : Controller
         };
     }
 
-    public string GetErrorType<TType>(TType type) => $"{GetUrlRoots().BaseUrl}/errors/{type?.GetType().Name}/{type}";
+    private string GetErrorType<TType>(TType type) => $"{GetUrlRoots().BaseUrl}/errors/{type?.GetType().Name}/{type}";
 
     /// <summary>
     ///     Handle a GET request - this takes a IRequest which returns a FetchEntityResult{T}.

--- a/src/IIIFPresentation/API/Infrastructure/PresentationController.cs
+++ b/src/IIIFPresentation/API/Infrastructure/PresentationController.cs
@@ -40,27 +40,29 @@ public abstract class PresentationController : Controller
     }
 
     /// <summary>
-    ///     Handle an upsert request - this takes a IRequest which returns a ModifyEntityResult{T}.
-    ///     The request is sent and result is transformed to an http result.
+    /// Handle an upsert request - this takes a IRequest which returns a ModifyEntityResult{T}.
+    /// The request is sent and result is transformed to an http result.
     /// </summary>
     /// <param name="request">IRequest to modify data</param>
     /// <param name="instance">The value for <see cref="JSType.Error.Instance" />.</param>
     /// <param name="errorTitle">
-    ///     The value for <see cref="JSType.Error.Title" />. In some instances this will be prepended to the actual error name.
-    ///     e.g. errorTitle + ": Conflict"
+    /// The value for <see cref="JSType.Error.Title" />. In some instances this will be prepended to the actual error name.
+    /// e.g. errorTitle + ": Conflict"
     /// </param>
     /// <param name="cancellationToken">Current cancellation token</param>
     /// <typeparam name="T">Type of entity being upserted</typeparam>
+    /// <typeparam name="TEnum">An enum designating the error type</typeparam>
     /// <returns>
-    ///     ActionResult generated from ModifyEntityResult. This will be the model + 200/201 on success. Or an
-    ///     error and appropriate status code if failed.
+    /// ActionResult generated from ModifyEntityResult. This will be the model + 200/201 on success. Or an
+    /// error and appropriate status code if failed.
     /// </returns>
-    protected async Task<IActionResult> HandleUpsert<T>(
-        IRequest<ModifyEntityResult<T>> request,
-        string? instance = null,
-        string? errorTitle = "Operation failed",
-        CancellationToken cancellationToken = default)
-        where T : class
+    protected async Task<IActionResult> HandleUpsert<T, TEnum>(
+    IRequest<ModifyEntityResult<T, TEnum>> request,
+    string? instance = null,
+    string? errorTitle = "Operation failed",
+    CancellationToken cancellationToken = default)
+    where T : class
+    where TEnum : Enum
     {
         return await HandleRequest(async () =>
         {
@@ -133,8 +135,7 @@ public abstract class PresentationController : Controller
         };
     }
 
-    private string GetErrorType<TType>(TType type) => $"{GetUrlRoots().BaseUrl}/errors/{type?.GetType().Name}/{type}";
-
+    public string GetErrorType<TType>(TType type) => $"{GetUrlRoots().BaseUrl}/errors/{type?.GetType().Name}/{type}";
 
     /// <summary>
     ///     Handle a GET request - this takes a IRequest which returns a FetchEntityResult{T}.

--- a/src/IIIFPresentation/API/Infrastructure/Requests/ModifyEntityResult.cs
+++ b/src/IIIFPresentation/API/Infrastructure/Requests/ModifyEntityResult.cs
@@ -6,36 +6,40 @@ namespace API.Infrastructure.Requests;
 ///     Represents the result of a request to modify an entity
 /// </summary>
 /// <typeparam name="T">Type of entity being modified</typeparam>
-public class ModifyEntityResult<T> : IModifyRequest
+public class ModifyEntityResult<T, TEnum> : IModifyRequest
     where T : class
 {
     /// <summary>
-    ///     Enum representing overall result of operation
+    /// Enum representing overall result of operation
     /// </summary>
     public WriteResult WriteResult { get; private init; }
 
     /// <summary>
-    ///     Optional representation of entity
+    /// Optional representation of entity
     /// </summary>
     public T? Entity { get; private init; }
 
     /// <summary>
-    ///     Optional error message if didn't succeed
+    /// Optional error message if didn't succeed
     /// </summary>
     public string? Error { get; private init; }
 
     /// <summary>
-    ///     Explicit value stating success or failure
+    /// Explicit value stating success or failure
     /// </summary>
     public bool IsSuccess { get; private init; }
+    
+    public TEnum? ErrorType { get; private init; }
 
-    public static ModifyEntityResult<T> Failure(string error, WriteResult result = WriteResult.Unknown)
+    public static ModifyEntityResult<T, TEnum> Failure(string error, TEnum? errorType, WriteResult result = WriteResult.Unknown)
     {
-        return new ModifyEntityResult<T> { Error = error, WriteResult = result, IsSuccess = false };
+        return new ModifyEntityResult<T, TEnum>
+            { Error = error, WriteResult = result, IsSuccess = false, ErrorType = errorType };
     }
 
-    public static ModifyEntityResult<T> Success(T entity, WriteResult result = WriteResult.Updated)
+    public static ModifyEntityResult<T, TEnum> Success(T entity, WriteResult result = WriteResult.Updated)
     {
-        return new ModifyEntityResult<T> { Entity = entity, WriteResult = result, IsSuccess = true };
+        return new ModifyEntityResult<T, TEnum>
+            { Entity = entity, WriteResult = result, IsSuccess = true };
     }
 }

--- a/src/IIIFPresentation/Models/API/General/DeleteCollectionType.cs
+++ b/src/IIIFPresentation/Models/API/General/DeleteCollectionType.cs
@@ -6,3 +6,14 @@ public enum DeleteCollectionType
     CollectionNotEmpty = 2,
     Unknown = 3
 }
+
+public enum ModifyCollectionType
+{
+    DuplicateSlugValue = 1,
+    UnknownDatabaseSaveError = 2,
+    ETagNotAllowed = 3,
+    ParentCollectionNotFound = 4,
+    ETagNotMatched = 5,
+    PossibleCircularReference = 6,
+    CannotGenerateUniqueId = 7,
+}

--- a/src/IIIFPresentation/Models/API/General/DeleteCollectionType.cs
+++ b/src/IIIFPresentation/Models/API/General/DeleteCollectionType.cs
@@ -6,14 +6,3 @@ public enum DeleteCollectionType
     CollectionNotEmpty = 2,
     Unknown = 3
 }
-
-public enum ModifyCollectionType
-{
-    DuplicateSlugValue = 1,
-    UnknownDatabaseSaveError = 2,
-    ETagNotAllowed = 3,
-    ParentCollectionNotFound = 4,
-    ETagNotMatched = 5,
-    PossibleCircularReference = 6,
-    CannotGenerateUniqueId = 7,
-}

--- a/src/IIIFPresentation/Models/API/General/ModifyCollectionType.cs
+++ b/src/IIIFPresentation/Models/API/General/ModifyCollectionType.cs
@@ -1,0 +1,12 @@
+namespace Models.API.General;
+
+public enum ModifyCollectionType
+{
+    DuplicateSlugValue = 1,
+    UnknownDatabaseSaveError = 2,
+    ETagNotAllowed = 3,
+    ParentCollectionNotFound = 4,
+    ETagNotMatched = 5,
+    PossibleCircularReference = 6,
+    CannotGenerateUniqueId = 7,
+}

--- a/src/IIIFPresentation/Repository/Helpers/CollectionRetrieval.cs
+++ b/src/IIIFPresentation/Repository/Helpers/CollectionRetrieval.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using Core.Exceptions;
+using Microsoft.EntityFrameworkCore;
 using Models.Database.Collections;
 
 namespace Repository.Helpers;
@@ -50,6 +51,7 @@ WITH RECURSIVE parentsearch AS (
     generation_number+1 AS generation_number
  FROM collections child
      JOIN parentsearch ps ON child.id=ps.parent
+     WHERE generation_number <= 1000
 )
 SELECT * FROM parentsearch ORDER BY generation_number DESC
 ";
@@ -57,6 +59,11 @@ SELECT * FROM parentsearch ORDER BY generation_number DESC
             .FromSqlRaw(query)
             .OrderBy(i => i.CustomerId)
             .ToList();
+
+        if (parentCollections.Count >= 1000)
+        {
+            throw new PresentationException("Parent to child relationship exceeds 1000 records");
+        }
         
         var fullPath = string.Join('/', parentCollections
             .Where(parent => !string.IsNullOrEmpty(parent.Parent))


### PR DESCRIPTION
Resolves #32 

This PR updates the `PUT` method to be able to detect when a possible circular reference is created between a parent and child record

Additionally, this PR also introduces error codes for modify/create collections in a similar manner to delete
