### PR TITLE
Thumbnail can't handle IIIF style thumbnail on POST

### DIFF
--- a/src/IIIFPresentation/API.Tests/Integration/ModifyCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyCollectionTests.cs
@@ -181,7 +181,7 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
         
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-        error!.Detail.Should().Be("Error attempting to validate collection is IIIF");
+        error!.Detail.Should().Be("An error occurred while attempting to validate the collection as IIIF");
     }
     
     [Fact]

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyCollectionTests.cs
@@ -63,7 +63,7 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
             Label = new LanguageMap("en", ["test collection"]),
             Slug = "programmatic-child",
             Parent = parent,
-            Thumbnail = "some/thumbnail",
+            PresentationThumbnail = "some/thumbnail",
             Tags = "some, tags",
             ItemsOrder = 1,
         };
@@ -98,20 +98,32 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
     public async Task CreateCollection_CreatesCollection_WhenIsStorageCollectionFalse()
     {
         // Arrange
-        var collection = new UpsertFlatCollection()
-        {
-            Behavior = new List<string>()
-            {
-                Behavior.IsPublic
-            },
-            Label = new LanguageMap("en", ["test collection"]),
-            Slug = "iiif-child",
-            Parent = parent,
-            Tags = "some, tags",
-            ItemsOrder = 1,
-        };
+        var collection = $@"{{
+   ""type"": ""Collection"",
+   ""behavior"": [
+       ""public-iiif""
+   ],
+   ""label"": {{
+       ""en"": [
+           ""iiif post""
+       ]
+   }},
+    ""slug"": ""iiif-child"",
+    ""parent"": ""{parent}"",
+    ""tags"": ""some, tags"",
+    ""itemsOrder"": 1,
+    ""thumbnail"": [
+        {{
+          ""id"": ""https://example.org/img/thumb.jpg"",
+          ""type"": ""Image"",
+          ""format"": ""image/jpeg"",
+          ""width"": 300,
+          ""height"": 200
+        }}
+    ]
+}}";
 
-        var requestMessage = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Post, $"{Customer}/collections", JsonSerializer.Serialize(collection));
+        var requestMessage = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Post, $"{Customer}/collections", collection);
         
         // Act
         var response = await httpClient.AsCustomer(1).SendAsync(requestMessage);
@@ -128,13 +140,14 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
         fromDatabase.Parent.Should().Be(parent);
-        fromDatabase.Label!.Values.First()[0].Should().Be("test collection");
+        fromDatabase.Label!.Values.First()[0].Should().Be("iiif post");
         fromDatabase.Slug.Should().Be("iiif-child");
         fromDatabase.ItemsOrder.Should().Be(1);
         fromDatabase.Tags.Should().Be("some, tags");
         fromDatabase.IsPublic.Should().BeTrue();
         fromDatabase.IsStorageCollection.Should().BeFalse();
         fromDatabase.Modified.Should().Be(fromDatabase.Created);
+        fromDatabase.Thumbnail.Should().Be("https://example.org/img/thumb.jpg");
         responseCollection!.View!.PageSize.Should().Be(20);
         responseCollection.View.Page.Should().Be(1);
         responseCollection.View.Id.Should().Contain("?page=1&pageSize=20");
@@ -155,7 +168,7 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
             Slug = "iiif-child",
             Parent = parent,
             Tags = "some, tags",
-            Thumbnail = "some/thumbnail",
+            PresentationThumbnail = "some/thumbnail",
             ItemsOrder = 1,
         };
 
@@ -412,7 +425,7 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
             Slug = "programmatic-child",
             Parent = parent,
             ItemsOrder = 1,
-            Thumbnail = "some/location/2",
+            PresentationThumbnail = "some/location/2",
             Tags = "some, tags, 2",
         };
 
@@ -457,7 +470,7 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
             Slug = "create-from-update",
             Parent = parent,
             ItemsOrder = 1,
-            Thumbnail = "some/location/2",
+            PresentationThumbnail = "some/location/2",
             Tags = "some, tags, 2",
         };
 
@@ -502,7 +515,7 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
             Slug = "create-from-update-2",
             Parent = parent,
             ItemsOrder = 1,
-            Thumbnail = "some/location/2",
+            PresentationThumbnail = "some/location/2",
             Tags = "some, tags, 2",
         };
 

--- a/src/IIIFPresentation/API/Features/Storage/Helpers/ErrorHelper.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Helpers/ErrorHelper.cs
@@ -25,7 +25,7 @@ public static class ErrorHelper
         where TCollection : class
     {
         return ModifyEntityResult<TCollection, ModifyCollectionType>.Failure(
-            "Error attempting to validate collection is IIIF", ModifyCollectionType.CannotValidateIIIF,
-            WriteResult.BadRequest);
+            "An error occurred while attempting to validate the collection as IIIF",
+            ModifyCollectionType.CannotValidateIIIF, WriteResult.BadRequest);
     }
 }

--- a/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
@@ -103,9 +103,6 @@ public class CreateCollectionHandler(
             collection.Thumbnail = request.Collection.PresentationThumbnail;
         }
         
-        await using var transaction = 
-            await dbContext.Database.BeginTransactionAsync(cancellationToken);
-        
         dbContext.Collections.Add(collection);
 
         var saveErrors =
@@ -118,8 +115,6 @@ public class CreateCollectionHandler(
         }
         
         await UploadToS3IfRequiredAsync(request, collection.Id, convertedIIIFCollection!, cancellationToken);
-        
-        await transaction.CommitAsync(cancellationToken);
 
         if (collection.Parent != null)
         {

--- a/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
@@ -135,22 +135,12 @@ public class CreateCollectionHandler(
     {
         var collectionAsIIIF = request.RawRequestBody.FromJson<IIIF.Presentation.V3.Collection>();
         var convertedIIIFCollection = collectionAsIIIF.AsJson();
-        var thumbnails = collectionAsIIIF.Thumbnail?.Where(CheckThumbnailIsImage).Select(c => (Image)c).ToList();
+        var thumbnails = collectionAsIIIF.Thumbnail?.Where(c => c is Image).Select(c => (Image)c).ToList();
         if (thumbnails != null)
         {
             collection.Thumbnail = thumbnails.GetThumbnailPath();
         }
         return convertedIIIFCollection;
-    }
-
-    private static bool CheckThumbnailIsImage(ExternalResource externalResource)
-    {
-        if (externalResource is Image)
-        {
-            return true;
-        }
-        
-        return false;
     }
 
     private async Task UploadToS3IfRequiredAsync(CreateCollection request,

--- a/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
@@ -28,7 +28,7 @@ public class CreateCollection(int customerId, UpsertFlatCollection collection, s
 {
     public int CustomerId { get; } = customerId;
 
-    public UpsertFlatCollection? Collection { get; } = collection;
+    public UpsertFlatCollection Collection { get; } = collection;
     
     public string RawRequestBody { get; } = rawRequestBody;
 

--- a/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
@@ -135,9 +135,22 @@ public class CreateCollectionHandler(
     {
         var collectionAsIIIF = request.RawRequestBody.FromJson<IIIF.Presentation.V3.Collection>();
         var convertedIIIFCollection = collectionAsIIIF.AsJson();
-        var thumbnails = collectionAsIIIF.Thumbnail?.Select(c => c as Image).ToList(); 
-        collection.Thumbnail = thumbnails!?.GetThumbnailPath();
+        var thumbnails = collectionAsIIIF.Thumbnail?.Where(CheckThumbnailIsImage).Select(c => (Image)c).ToList();
+        if (thumbnails != null)
+        {
+            collection.Thumbnail = thumbnails.GetThumbnailPath();
+        }
         return convertedIIIFCollection;
+    }
+
+    private static bool CheckThumbnailIsImage(ExternalResource externalResource)
+    {
+        if (externalResource is Image)
+        {
+            return true;
+        }
+        
+        return false;
     }
 
     private async Task UploadToS3IfRequiredAsync(CreateCollection request,

--- a/src/IIIFPresentation/API/Features/Storage/Requests/GetHierarchicalCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/GetHierarchicalCollection.cs
@@ -40,7 +40,7 @@ public class GetHierarchicalCollectionHandler(PresentationContext dbContext, IBu
             if (!collection.IsStorageCollection)
             {
                 var objectFromS3 = await bucketReader.GetObjectFromBucket(new ObjectInBucket(settings.S3.StorageBucket,
-                    $"{request.CustomerId}/collections/{collection.Id}"), cancellationToken);
+                    collection.GetCollectionBucketKey()), cancellationToken);
 
                 if (!objectFromS3.Stream.IsNull())
                 {

--- a/src/IIIFPresentation/API/Features/Storage/Requests/PostHierarchicalCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/PostHierarchicalCollection.cs
@@ -76,7 +76,7 @@ public class PostHierarchicalCollectionHandler(
         
         await bucketWriter.WriteToBucket(
             new ObjectInBucket(settings.AWS.S3.StorageBucket,
-                $"{request.CustomerId}/collections/{collection.Id}"),
+                collection.GetCollectionBucketKey()),
             collectionFromBody.AsJson(), "application/json", cancellationToken);
         
         if (collection.Parent != null)
@@ -120,7 +120,7 @@ public class PostHierarchicalCollectionHandler(
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Error attempting to validate collection is IIIF");
+            logger.LogError(ex, "An error occurred while attempting to validate the collection as IIIF");
         }
 
         return collection;

--- a/src/IIIFPresentation/API/Features/Storage/Requests/UpsertCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/UpsertCollection.cs
@@ -79,7 +79,7 @@ public class UpsertCollectionHandler(
                 Label = request.Collection.Label,
                 Parent = parentCollection.Id,
                 Slug = request.Collection.Slug,
-                Thumbnail = request.Collection.Thumbnail,
+                Thumbnail = request.Collection.PresentationThumbnail,
                 Tags = request.Collection.Tags,
                 ItemsOrder = request.Collection.ItemsOrder
             };
@@ -116,7 +116,7 @@ public class UpsertCollectionHandler(
             databaseCollection.Label = request.Collection.Label;
             databaseCollection.Parent = request.Collection.Parent;
             databaseCollection.Slug = request.Collection.Slug;
-            databaseCollection.Thumbnail = request.Collection.Thumbnail;
+            databaseCollection.Thumbnail = request.Collection.PresentationThumbnail;
             databaseCollection.Tags = request.Collection.Tags;
             databaseCollection.ItemsOrder = request.Collection.ItemsOrder;
         }

--- a/src/IIIFPresentation/API/Features/Storage/StorageController.cs
+++ b/src/IIIFPresentation/API/Features/Storage/StorageController.cs
@@ -105,7 +105,7 @@ public class StorageController(IAuthenticator authenticator, IOptions<ApiSetting
 
         if (collection == null)
         {
-            return this.PresentationProblem("could not deserialize collection", null, (int)HttpStatusCode.BadRequest,
+            return this.PresentationProblem("Could not deserialize collection", null, (int)HttpStatusCode.BadRequest,
                 "Deserialization Error");
         }
 

--- a/src/IIIFPresentation/API/Features/Storage/StorageController.cs
+++ b/src/IIIFPresentation/API/Features/Storage/StorageController.cs
@@ -102,8 +102,14 @@ public class StorageController(IAuthenticator authenticator, IOptions<ApiSetting
         var rawRequestBody = await streamReader.ReadToEndAsync();
         
         var collection = JsonConvert.DeserializeObject<UpsertFlatCollection>(rawRequestBody);
-        
-        var validation = await validator.ValidateAsync(collection!);
+
+        if (collection == null)
+        {
+            return this.PresentationProblem("could not deserialize collection", null, (int)HttpStatusCode.BadRequest,
+                "Deserialization Error");
+        }
+
+        var validation = await validator.ValidateAsync(collection);
         
         if (!validation.IsValid)
         {

--- a/src/IIIFPresentation/API/Features/Storage/StorageController.cs
+++ b/src/IIIFPresentation/API/Features/Storage/StorageController.cs
@@ -20,7 +20,7 @@ using Newtonsoft.Json;
 
 namespace API.Features.Storage;
 
-[Route("/{customerId}")]
+[Route("/{customerId:int}")]
 [ApiController]
 public class StorageController(IAuthenticator authenticator, IOptions<ApiSettings> options, IMediator mediator)
     : PresentationController(options.Value, mediator)

--- a/src/IIIFPresentation/API/Features/Storage/StorageController.cs
+++ b/src/IIIFPresentation/API/Features/Storage/StorageController.cs
@@ -110,7 +110,7 @@ public class StorageController(IAuthenticator authenticator, IOptions<ApiSetting
             return this.ValidationFailed(validation);
         }
         
-        return await HandleUpsert(new CreateCollection(customerId, collection!, rawRequestBody, GetUrlRoots()));
+        return await HandleUpsert(new CreateCollection(customerId, collection, rawRequestBody, GetUrlRoots()));
     }
     
     [Authorize]

--- a/src/IIIFPresentation/API/Helpers/CollectionHelperX.cs
+++ b/src/IIIFPresentation/API/Helpers/CollectionHelperX.cs
@@ -46,6 +46,9 @@ public static class CollectionHelperX
         new(
             $"{collection.GenerateFlatCollectionId(urlRoots)}?page={lastPage}&pageSize={pageSize}{orderQueryParam}");
     
+    public static string GetCollectionBucketKey(this Collection collection) =>
+            $"{collection.CustomerId}/collections/{collection.Id}";
+    
     public static string GenerateFullPath(this Collection collection, string itemSlug) => 
         $"{(collection.Parent != null ? $"{collection.Slug}/" : string.Empty)}{itemSlug}";
     

--- a/src/IIIFPresentation/Models/API/Collection/Upsert/UpsertFlatCollection.cs
+++ b/src/IIIFPresentation/Models/API/Collection/Upsert/UpsertFlatCollection.cs
@@ -1,4 +1,8 @@
-﻿using IIIF.Presentation.V3.Strings;
+﻿using System.Diagnostics;
+using IIIF.Presentation.V3.Content;
+using IIIF.Presentation.V3.Strings;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Models.API.Collection.Upsert;
 
@@ -14,7 +18,19 @@ public class UpsertFlatCollection
     
     public string? Tags { get; set; }
     
-    public string? Thumbnail { get; set; }
+    public string? PresentationThumbnail { get; set; }
+    
+    [JsonProperty("thumbnail")]
+    public object? ThumbnailFromRequest
+    {
+        set
+        {
+            if (value is not JArray)
+            {
+                PresentationThumbnail = value?.ToString();
+            }
+        }
+    }
     
     public int? ItemsOrder { get; set; }
 }


### PR DESCRIPTION
Resolves #57

This PR allows thumbnails to be correctly converted between `ExternalResource` and `string` when using POST on a IIIF collection, via a `collections`