### PR TITLE
Fix `orderByDescending` behaviour

### DIFF
--- a/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
@@ -337,14 +337,15 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         collection.View.Page.Should().Be(1);
         collection.View.TotalPages.Should().Be(3);
         collection.Items!.Count.Should().Be(1);
+        
         collection.Items.OfType<Collection>().First().Id.Should().Be("http://localhost/1/collections/FirstChildCollection");
     }
     
     [Theory]
-    [InlineData("id")]
-    [InlineData("slug")]
-    [InlineData("created")]
-    public async Task Get_RootFlat_ReturnsFirstPageWithSecondItem_WhenCalledWithSmallPageSizeAndOrderByDescending(string field)
+    [InlineData("id", "NonPublic")]
+    [InlineData("slug", "NonPublic")]
+    [InlineData("created", "IiifCollection")]
+    public async Task Get_RootFlat_ReturnsFirstPageWithSecondItem_WhenCalledWithSmallPageSizeAndOrderByDescending(string field, string expectedItemId)
     {
         // Arrange
         var requestMessage =
@@ -363,7 +364,8 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         collection.View.Page.Should().Be(1);
         collection.View.TotalPages.Should().Be(3);
         collection.Items!.Count.Should().Be(1);
-        collection.Items.OfType<Collection>().First().Id.Should().Be("http://localhost/1/collections/IiifCollection");
+        
+        collection.Items.OfType<Collection>().First().Id.Should().Be($"http://localhost/1/collections/{expectedItemId}");
     }
     
     [Fact]

--- a/src/IIIFPresentation/API/Features/Storage/StorageController.cs
+++ b/src/IIIFPresentation/API/Features/Storage/StorageController.cs
@@ -71,14 +71,18 @@ public class StorageController(IOptions<ApiSettings> options, IMediator mediator
         
         var orderByField = this.GetOrderBy(orderBy, orderByDescending, out var descending);
         var storageRoot =
-            await Mediator.Send(new GetCollection(customerId, id, page.Value, pageSize.Value, orderBy, descending));
+            await Mediator.Send(new GetCollection(customerId, id, page.Value, pageSize.Value, orderByField, descending));
 
         if (storageRoot.Collection == null) return this.PresentationNotFound();
 
         if (Request.ShowExtraProperties())
         {
+            var orderByParameter = orderByField != null
+                ? $"{(descending ? nameof(orderByDescending) : nameof(orderBy))}={orderByField}" 
+                : null;
+   
             return Ok(storageRoot.Collection.ToFlatCollection(GetUrlRoots(), pageSize.Value, page.Value,
-                storageRoot.TotalItems, storageRoot.Items, orderByField));
+                storageRoot.TotalItems, storageRoot.Items, orderByParameter));
         }
 
         return SeeOther(storageRoot.Collection.GenerateHierarchicalCollectionId(GetUrlRoots()));

--- a/src/IIIFPresentation/API/Infrastructure/ControllerBaseX.cs
+++ b/src/IIIFPresentation/API/Infrastructure/ControllerBaseX.cs
@@ -102,11 +102,11 @@ public static class ControllerBaseX
         descending = false;
         if (orderBy.HasText() && OrderByHelper.AllowedOrderByFields.Contains(orderBy.ToLower()))
         {
-            orderByField = $"orderBy={orderBy}";
+            orderByField = orderBy;
         }
         else if (orderByDescending.HasText() && OrderByHelper.AllowedOrderByFields.Contains(orderByDescending.ToLower()))
         {
-            orderByField = $"orderByDescending={orderByDescending}";
+            orderByField = orderByDescending;
             descending = true;
         }
 


### PR DESCRIPTION
This PR fixes a bug where storage collection queries specifying `orderByDescending={field_name}` would only order items by the creation date, regardless of which field was specified.

It also updates the valid 'orderByDescending' test in `GetCollectionTests` to expect a different item when dealing with the `slug` and `id` fields, as they are now sorted alphabetically.