### PR TITLE
API gains delegated auth

### DIFF
--- a/scripts/create_root.sql
+++ b/scripts/create_root.sql
@@ -1,0 +1,4 @@
+INSERT INTO public.collections 
+    (id, slug, use_path, label, created, modified, created_by, modified_by, is_storage_collection, is_public, customer_id) 
+VALUES
+    ('root', '', false, '{"en": ["(repository root)"]}', now(), now(), 'Admin', 'Admin', true, true, 1);

--- a/scripts/readme.md
+++ b/scripts/readme.md
@@ -1,0 +1,5 @@
+# Scripts
+
+Various scripts for setup/debugging etc.
+
+* `create_root.sql` - create Root collection - update customerId as required

--- a/src/IIIFPresentation/API.Tests/API.Tests.csproj
+++ b/src/IIIFPresentation/API.Tests/API.Tests.csproj
@@ -15,6 +15,7 @@
         <PackageReference Include="FluentAssertions" Version="6.12.0" />
         <PackageReference Include="FluentValidation" Version="11.9.2" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+        <PackageReference Include="Stubbery" Version="2.8.3" />
         <PackageReference Include="xunit" Version="2.9.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
           <PrivateAssets>all</PrivateAssets>

--- a/src/IIIFPresentation/API.Tests/Auth/DelegatedAuthenticatorTests.cs
+++ b/src/IIIFPresentation/API.Tests/Auth/DelegatedAuthenticatorTests.cs
@@ -1,0 +1,91 @@
+﻿using System.Net;
+using API.Auth;
+using API.Settings;
+using LazyCache.Mocks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Stubbery;
+using Test.Helpers.Settings;
+
+namespace API.Tests.Auth;
+
+public class DelegatedAuthenticatorTests : IClassFixture<ApiStub>
+{
+    private readonly DelegatedAuthenticator sut;
+
+    public DelegatedAuthenticatorTests(ApiStub apiStub)
+    {
+        apiStub.EnsureStarted();
+
+        var httpClient = new HttpClient
+        {
+            BaseAddress = new Uri(apiStub.Address)
+        };
+        apiStub
+            .Get("/customers/10", (_, _) => new HttpResponseMessage(HttpStatusCode.OK))
+            .IfHeader("Authorization", "Bearer 12345");
+        
+        apiStub
+            .Get("/customers/10", (_, _) => new HttpResponseMessage(HttpStatusCode.OK))
+            .IfHeader("Authorization", "Basic 12345");
+
+        sut = new DelegatedAuthenticator(httpClient, OptionsHelpers.GetOptionsMonitor(new CacheSettings()),
+            new MockCachingService(), new NullLogger<DelegatedAuthenticator>());
+    }
+    
+    [Fact]
+    public async Task ValidateRequest_NoCredentials_IfNoAuthHeader()
+    {
+        var request = new DefaultHttpContext().Request;
+        
+        var result = await sut.ValidateRequest(request);
+        result.Should().Be(AuthResult.NoCredentials);
+    }
+    
+    [Fact]
+    public async Task ValidateRequest_NoCredentials_IfAuthHeaderEmpty()
+    {
+        var request = new DefaultHttpContext().Request;
+        request.Headers.Authorization = "";
+        
+        var result = await sut.ValidateRequest(request);
+        result.Should().Be(AuthResult.NoCredentials);
+    }
+    
+    [Fact]
+    public async Task ValidateRequest_NoCredentials_IfNoCustomerIdInRoute()
+    {
+        var request = new DefaultHttpContext().Request;
+        request.Headers.Authorization = "Basic 12345";
+        request.RouteValues.Add("NotCustomerId", "123");
+        
+        var result = await sut.ValidateRequest(request);
+        result.Should().Be(AuthResult.NoCredentials);
+    }
+    
+    [Theory]
+    [InlineData("Basic 9999")]
+    [InlineData("Bearer 9999")]
+    public async Task ValidateRequest_Fail_IfDownstreamNon200(string authHeader)
+    {
+        var request = new DefaultHttpContext().Request;
+        request.Headers.Authorization = authHeader;
+        request.RouteValues.Add("customerId", "10");
+        
+        var result = await sut.ValidateRequest(request);
+        result.Should().Be(AuthResult.Failed);
+    }
+    
+    [Theory]
+    [InlineData("Basic 12345")]
+    [InlineData("Bearer 12345")]
+    public async Task ValidateRequest_Pass_IfDownstream200(string authHeader)
+    {
+        var request = new DefaultHttpContext().Request;
+        request.Headers.Authorization = authHeader;
+        request.RouteValues.Add("customerId", "10");
+        
+        var result = await sut.ValidateRequest(request);
+        result.Should().Be(AuthResult.Success);
+    }
+}

--- a/src/IIIFPresentation/API.Tests/Converters/CollectionConverterTests.cs
+++ b/src/IIIFPresentation/API.Tests/Converters/CollectionConverterTests.cs
@@ -1,5 +1,4 @@
 ﻿using API.Converters;
-using FluentAssertions;
 using IIIF.Presentation.V3.Strings;
 using Models.Database.Collections;
 

--- a/src/IIIFPresentation/API.Tests/Helpers/CollectionHelperXTests.cs
+++ b/src/IIIFPresentation/API.Tests/Helpers/CollectionHelperXTests.cs
@@ -1,6 +1,5 @@
 ﻿using API.Converters;
 using API.Helpers;
-using FluentAssertions;
 using Models.Database.Collections;
 
 namespace API.Tests.Helpers;

--- a/src/IIIFPresentation/API.Tests/Helpers/ThumbnailXTests.cs
+++ b/src/IIIFPresentation/API.Tests/Helpers/ThumbnailXTests.cs
@@ -1,5 +1,4 @@
 ﻿using API.Features.Storage.Helpers;
-using FluentAssertions;
 using IIIF.Presentation.V3;
 using IIIF.Presentation.V3.Content;
 

--- a/src/IIIFPresentation/API.Tests/Infrastructure/Helpers/HttpRequestXTests.cs
+++ b/src/IIIFPresentation/API.Tests/Infrastructure/Helpers/HttpRequestXTests.cs
@@ -1,0 +1,44 @@
+﻿using API.Infrastructure.Helpers;
+using Microsoft.AspNetCore.Http;
+
+namespace API.Tests.Infrastructure.Helpers;
+
+public class HttpRequestXTests
+{
+    [Fact]
+    public void HttpRequestX_False_IfNotFound()
+    {
+        var httpRequest = new DefaultHttpContext().Request;
+
+        httpRequest.HasShowExtraHeader().Should().BeFalse();
+    }
+    
+    [Fact]
+    public void HttpRequestX_False_IfHeaderPresent_ButUnknownValue()
+    {
+        var httpRequest = new DefaultHttpContext().Request;
+        httpRequest.Headers.Append("X-IIIF-CS-Show-Extras", "Foo");
+
+        httpRequest.HasShowExtraHeader().Should().BeFalse();
+    }
+    
+    [Theory]
+    [InlineData("X-IIIF-CS-Show-Extras")]
+    [InlineData("x-iiif-cs-show-extras")]
+    public void HttpRequestX_False_IfHeaderPresent_AndAllValue(string header)
+    {
+        var httpRequest = new DefaultHttpContext().Request;
+        httpRequest.Headers.Append(header, "All");
+
+        httpRequest.HasShowExtraHeader().Should().BeTrue();
+    }
+    
+    [Fact]
+    public void HttpRequestX_False_IfHeaderPresent_AndAllValue_Case()
+    {
+        var httpRequest = new DefaultHttpContext().Request;
+        httpRequest.Headers.Append("X-IIIF-CS-Show-Extras", "All");
+
+        httpRequest.HasShowExtraHeader().Should().BeTrue();
+    }
+}

--- a/src/IIIFPresentation/API.Tests/Infrastructure/Helpers/HttpRequestXTests.cs
+++ b/src/IIIFPresentation/API.Tests/Infrastructure/Helpers/HttpRequestXTests.cs
@@ -25,19 +25,10 @@ public class HttpRequestXTests
     [Theory]
     [InlineData("X-IIIF-CS-Show-Extras")]
     [InlineData("x-iiif-cs-show-extras")]
-    public void HttpRequestX_False_IfHeaderPresent_AndAllValue(string header)
+    public void HttpRequestX_True_IfHeaderPresent_AndAllValue(string header)
     {
         var httpRequest = new DefaultHttpContext().Request;
         httpRequest.Headers.Append(header, "All");
-
-        httpRequest.HasShowExtraHeader().Should().BeTrue();
-    }
-    
-    [Fact]
-    public void HttpRequestX_False_IfHeaderPresent_AndAllValue_Case()
-    {
-        var httpRequest = new DefaultHttpContext().Request;
-        httpRequest.Headers.Append("X-IIIF-CS-Show-Extras", "All");
 
         httpRequest.HasShowExtraHeader().Should().BeTrue();
     }

--- a/src/IIIFPresentation/API.Tests/Infrastructure/SqidsGeneratorTests.cs
+++ b/src/IIIFPresentation/API.Tests/Infrastructure/SqidsGeneratorTests.cs
@@ -1,5 +1,4 @@
 ﻿using API.Infrastructure.IdGenerator;
-using FluentAssertions;
 using Sqids;
 
 namespace API.Tests.Infrastructure;

--- a/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
@@ -4,7 +4,6 @@ using System.Net;
 using API.Tests.Integration.Infrastructure;
 using Core.Response;
 using IIIF.Presentation.V3;
-using Microsoft.AspNetCore.Mvc.Testing;
 using Models.API.Collection;
 using Test.Helpers.Helpers;
 using Test.Helpers.Integration;
@@ -20,9 +19,8 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
 
     public GetCollectionTests(StorageFixture storageFixture, PresentationAppFactory<Program> factory)
     {
-        httpClient = factory.WithConnectionString(storageFixture.DbFixture.ConnectionString) 
-            .WithLocalStack(storageFixture.LocalStackFixture)
-            .CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false }); ;
+        httpClient = factory.ConfigureBasicIntegrationTestHttpClient(storageFixture.DbFixture,
+            appFactory => appFactory.WithLocalStack(storageFixture.LocalStackFixture));
         
         storageFixture.DbFixture.CleanUp();
     }
@@ -75,7 +73,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
     }
     
     [Fact]
-    public async Task Get_Hierarchical_Redirects_WhenAuthAndShowExtrasHeaders()
+    public async Task Get_Hierarchical_ReturnsSeeOther_WhenAuthAndShowExtrasHeaders()
     {
         // Arrange
         var requestMessage = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get, "1");
@@ -89,7 +87,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
     }
     
     [Fact]
-    public async Task Get_RootFlat_Redirects_WhenNoAuthAndCsHeader()
+    public async Task Get_RootFlat_ReturnsSeeOther_WhenNoAuthOrCsHeader()
     {
         // Act
         var response = await httpClient.GetAsync($"1/collections/{RootCollection.Id}");
@@ -100,7 +98,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
     }
     
     [Fact]
-    public async Task Get_RootFlat_Redirects_WhenNoCsHeader()
+    public async Task Get_RootFlat_ReturnsSeeOther_WhenNoCsHeader()
     {
         // Arrange
         var requestMessage = new HttpRequestMessage(HttpMethod.Get, $"1/collections/{RootCollection.Id}");
@@ -114,7 +112,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
     }
     
     [Fact]
-    public async Task Get_RootFlat_Redirects_WhenShowExtraHeaderNotAll()
+    public async Task Get_RootFlat_ReturnsSeeOther_WhenShowExtraHeaderNotAll()
     {
         // Arrange
         var requestMessage = new HttpRequestMessage(HttpMethod.Get, $"1/collections/{RootCollection.Id}");
@@ -129,7 +127,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
     }
     
     [Fact]
-    public async Task Get_RootFlat_Redirects_WhenNoAuth()
+    public async Task Get_RootFlat_ReturnsSeeOther_WhenNoAuth()
     {
         // Arrange
         var requestMessage = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get, $"1/collections/{RootCollection.Id}");

--- a/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
@@ -3,7 +3,6 @@
 using System.Net;
 using API.Tests.Integration.Infrastructure;
 using Core.Response;
-using FluentAssertions;
 using IIIF.Presentation.V3;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Models.API.Collection;

--- a/src/IIIFPresentation/API.Tests/Integration/Infrastructure/PresentationAppFactoryX.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/Infrastructure/PresentationAppFactoryX.cs
@@ -1,13 +1,14 @@
-﻿using Microsoft.AspNetCore.Authentication;
+﻿using API.Auth;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
+using Test.Helpers.Integration;
 
-namespace Test.Helpers.Integration;
+namespace API.Tests.Integration.Infrastructure;
 
 public static class PresentationAppFactoryX
 {
     /// <summary>
-    /// Configure app factory to use connection string from DBFixture.
+    /// Configure app factory to use connection string from DBFixture and configure test authenticator logic.
     /// Takes an additional delegate to do additional setup
     /// </summary>
     public static HttpClient ConfigureBasicIntegrationTestHttpClient<T>(
@@ -21,10 +22,7 @@ public static class PresentationAppFactoryX
             .WithConnectionString(dbFixture.ConnectionString)
             .WithTestServices(services =>
             {
-                string authenticationScheme = "Api-Test";
-                services.AddAuthentication(authenticationScheme)
-                    .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
-                        authenticationScheme, _ => { });
+                services.AddSingleton<IAuthenticator, TestAuthenticator>();
             });
 
         var httpClient = additionalSetup(configuredFactory)

--- a/src/IIIFPresentation/API.Tests/Integration/Infrastructure/TestAuthenticator.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/Infrastructure/TestAuthenticator.cs
@@ -1,0 +1,30 @@
+﻿using System.Net.Http.Headers;
+using API.Auth;
+using Microsoft.AspNetCore.Http;
+
+namespace API.Tests.Integration.Infrastructure;
+
+/// <summary>
+/// Test-only <see cref="IAuthenticator"/> which will pass auth as long as Auth header present
+/// </summary>
+public class TestAuthenticator : IAuthenticator
+{
+    private const string AuthHeader = "Authorization";
+    
+    public async Task<AuthResult> ValidateRequest(HttpRequest request)
+    {
+        if (!request.Headers.TryGetValue(AuthHeader, out var value))
+        {
+            // Authorization header not in request
+            return AuthResult.NoCredentials;
+        }
+        
+        if (!AuthenticationHeaderValue.TryParse(value, out _))
+        {
+            // Invalid Authorization header
+            return AuthResult.NoCredentials;
+        }
+        
+        return AuthResult.Success;
+    }
+}

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyCollectionTests.cs
@@ -40,10 +40,9 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
     {
         dbContext = storageFixture.DbFixture.DbContext;
         amazonS3 = storageFixture.LocalStackFixture.AWSS3ClientFactory();
-        
-        httpClient = factory.WithConnectionString(storageFixture.DbFixture.ConnectionString)
-            .WithLocalStack(storageFixture.LocalStackFixture)
-            .CreateClient(new WebApplicationFactoryClientOptions());
+
+        httpClient = factory.ConfigureBasicIntegrationTestHttpClient(storageFixture.DbFixture,
+            appFactory => appFactory.WithLocalStack(storageFixture.LocalStackFixture));
 
         parent = dbContext.Collections.First(x => x.CustomerId == Customer && x.Slug == string.Empty).Id;
         
@@ -807,7 +806,6 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
         
         await dbContext.Collections.AddAsync(initialCollection);
         await dbContext.SaveChangesAsync();
-        
 
         var deleteRequestMessage = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Delete,
             $"{Customer}/collections/{initialCollection.Id}");

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyCollectionTests.cs
@@ -8,7 +8,6 @@ using Amazon.S3;
 using API.Tests.Integration.Infrastructure;
 using Core.Response;
 using FakeItEasy;
-using FluentAssertions;
 using IIIF.Presentation.V3.Strings;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Models.API.Collection;

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyCollectionTests.cs
@@ -201,7 +201,7 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
     }
     
     [Fact]
-    public async Task CreateCollection_FailsToCreateCollection_WhenCalledWithoutAuth()
+    public async Task CreateCollection_ReturnsUnauthorized_WhenCalledWithoutAuth()
     {
         // Arrange
         var collection = new UpsertFlatCollection()
@@ -222,11 +222,11 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
         var response = await httpClient.SendAsync(requestMessage);
 
         // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
     
     [Fact]
-    public async Task CreateCollection_FailsToCreateCollection_WhenCalledWithIncorrectShowExtraHeader()
+    public async Task CreateCollection_ReturnsForbidden_WhenCalledWithIncorrectShowExtraHeader()
     {
         // Arrange
         var collection = new UpsertFlatCollection()
@@ -247,7 +247,7 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
             new MediaTypeHeaderValue("application/json"));
         
         // Act
-        var response = await httpClient.SendAsync(requestMessage);
+        var response = await httpClient.AsCustomer(1).SendAsync(requestMessage);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
@@ -307,6 +307,64 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
 
         // Assert
         await action.Should().ThrowAsync<ConstraintException>();
+    }
+    
+    [Fact]
+    public async Task UpdateCollection_ReturnsUnauthorized_WhenCalledWithoutAuth()
+    {
+        // Arrange
+        var collection = new UpsertFlatCollection()
+        {
+            Behavior = new List<string>()
+            {
+                Behavior.IsPublic,
+                Behavior.IsStorageCollection
+            },
+            Label = new LanguageMap("en", ["test collection"]),
+            Slug = "first-child",
+            Parent = parent
+        };
+        
+        var collectionName = nameof(UpdateCollection_ReturnsUnauthorized_WhenCalledWithoutAuth);
+
+        var requestMessage = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Put,
+            $"{Customer}/collections/{collectionName}", JsonSerializer.Serialize(collection));
+        
+        // Act
+        var response = await httpClient.SendAsync(requestMessage);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+    
+    [Fact]
+    public async Task UpdateCollection_ReturnsForbidden_WhenCalledWithIncorrectShowExtraHeader()
+    {
+        // Arrange
+        var collection = new UpsertFlatCollection()
+        {
+            Behavior = new List<string>()
+            {
+                Behavior.IsPublic,
+                Behavior.IsStorageCollection
+            },
+            Label = new LanguageMap("en", ["test collection"]),
+            Slug = "first-child",
+            Parent = parent
+        };
+
+        var collectionName = nameof(UpdateCollection_ReturnsForbidden_WhenCalledWithIncorrectShowExtraHeader);
+        
+        var requestMessage = new HttpRequestMessage(HttpMethod.Put, $"{Customer}/collections/{collectionName}");
+        requestMessage.Headers.Add("X-IIIF-CS-Show-Extras", "Incorrect");
+        requestMessage.Content = new StringContent(JsonSerializer.Serialize(collection), Encoding.UTF8,
+            new MediaTypeHeaderValue("application/json"));
+        
+        // Act
+        var response = await httpClient.AsCustomer(1).SendAsync(requestMessage);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
     }
     
     [Fact]
@@ -776,6 +834,38 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
         // Act
         var response = await httpClient.SendAsync(updateRequestMessage);
         
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+    
+    [Fact]
+    public async Task DeleteCollection_ReturnsUnauthorized_WhenCalledWithoutAuth()
+    {
+        // Arrange
+        var collectionName = nameof(DeleteCollection_ReturnsUnauthorized_WhenCalledWithoutAuth);
+
+        var requestMessage =
+            HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Delete, $"{Customer}/collections/{collectionName}");
+        
+        // Act
+        var response = await httpClient.SendAsync(requestMessage);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+    
+    [Fact]
+    public async Task DeleteCollection_ReturnsForbidden_WhenCalledWithIncorrectShowExtraHeader()
+    {
+        // Arrange
+        var collectionName = nameof(DeleteCollection_ReturnsForbidden_WhenCalledWithIncorrectShowExtraHeader);
+        
+        var requestMessage = new HttpRequestMessage(HttpMethod.Delete, $"{Customer}/collections/{collectionName}");
+        requestMessage.Headers.Add("X-IIIF-CS-Show-Extras", "Incorrect");
+
+        // Act
+        var response = await httpClient.AsCustomer(1).SendAsync(requestMessage);
+
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
     }

--- a/src/IIIFPresentation/API.Tests/Usings.cs
+++ b/src/IIIFPresentation/API.Tests/Usings.cs
@@ -1,0 +1,3 @@
+﻿// Global using directives
+
+global using FluentAssertions;

--- a/src/IIIFPresentation/API.Tests/appsettings.Testing.json
+++ b/src/IIIFPresentation/API.Tests/appsettings.Testing.json
@@ -1,21 +1,4 @@
 {
-  "Serilog": {
-    "Using": [
-      "Serilog.Sinks.Console"
-    ],
-    "MinimumLevel": {
-      "Default": "Debug",
-      "Override": {
-        "Microsoft": "Warning",
-        "System": "Warning"
-      }
-    },
-    "WriteTo": [
-      {
-        "Name": "Console"
-      }
-    ]
-  },
   "RunMigrations": true,
   "ResourceRoot": "https://localhost:7230",
   "PageSize": 20,
@@ -24,5 +7,8 @@
     "S3": {
       "StorageBucket": "presentation-storage"
     }
+  },
+  "DLCS": {
+    "ApiUri": "https://localhost:7230"
   }
 }

--- a/src/IIIFPresentation/API/Auth/Authorizer.cs
+++ b/src/IIIFPresentation/API/Auth/Authorizer.cs
@@ -2,11 +2,6 @@
 
 public static class Authorizer
 {
-    public static bool CheckAuthorized(HttpRequest request)
-    {
-        return request.Headers.Authorization.Count > 0;
-    }
-    
     public static string GetUser()
     {
         return "Admin";

--- a/src/IIIFPresentation/API/Auth/DelegatedAuthHandler.cs
+++ b/src/IIIFPresentation/API/Auth/DelegatedAuthHandler.cs
@@ -6,10 +6,8 @@ using Microsoft.Extensions.Options;
 namespace API.Auth;
 
 /// <summary>
-/// AuthenticationHandler that hands off calls to DLCS for carrying out authentication. Any auth header provided
-/// here will be proxied to DLCS API - a 200 response = auth successful.
+/// AuthenticationHandler that hands off calls to implementation of <see cref="IAuthenticator"/> for auth logic
 /// </summary>
-/// <remarks>This is temporary and will be replaced in the future by an implementation that has auth logic</remarks>
 public class DelegatedAuthHandler(
     IAuthenticator delegatedAuthenticator,
     IOptionsMonitor<DelegatedAuthenticationOptions> options,

--- a/src/IIIFPresentation/API/Auth/DelegatedAuthHandler.cs
+++ b/src/IIIFPresentation/API/Auth/DelegatedAuthHandler.cs
@@ -1,0 +1,64 @@
+﻿using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+
+namespace API.Auth;
+
+/// <summary>
+/// AuthenticationHandler that hands off calls to DLCS for carrying out authentication. Any auth header provided
+/// here will be proxied to DLCS API - a 200 response = auth successful.
+/// </summary>
+/// <remarks>This is temporary and will be replaced in the future by an implementation that has auth logic</remarks>
+public class DelegatedAuthHandler(
+    DelegatedAuthenticator delegatedAuthenticator,
+    IOptionsMonitor<DelegatedAuthenticationOptions> options,
+    ILoggerFactory logger,
+    UrlEncoder encoder)
+    : AuthenticationHandler<DelegatedAuthenticationOptions>(options, logger, encoder)
+{
+    protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        var result = await delegatedAuthenticator.ValidateRequest(Request);
+        return result switch
+        {
+            AuthResult.NoCredentials => AuthenticateResult.NoResult(),
+            AuthResult.Failed => AuthenticateResult.Fail("Invalid credentials"),
+            AuthResult.Success => AuthenticateResult.Success(GetAuthenticatedTicket()),
+            _ => AuthenticateResult.Fail("Unknown auth result")
+        };
+    }
+
+    protected override Task HandleChallengeAsync(AuthenticationProperties properties)
+    {
+        Response.Headers.WWWAuthenticate = $"Basic realm=\"{Options.Realm}\"";
+        return base.HandleChallengeAsync(properties);
+    }
+    
+    private AuthenticationTicket GetAuthenticatedTicket()
+    {
+        var identity = new ClaimsIdentity(Scheme.Name);
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, Scheme.Name);
+        return ticket;
+    }
+}
+
+/// <summary>
+/// Options for use with <see cref="DelegatedAuthHandler"/>
+/// </summary>
+public class DelegatedAuthenticationOptions : AuthenticationSchemeOptions
+{
+    /// <summary>
+    /// Get or set the Realm for use in auth challenges.
+    /// </summary>
+    public string Realm { get; set; }
+}
+
+/// <summary>
+/// Contains constants for use with basic auth.
+/// </summary>
+public static class BasicAuthenticationDefaults
+{
+    public const string AuthenticationScheme = "Basic";
+}

--- a/src/IIIFPresentation/API/Auth/DelegatedAuthHandler.cs
+++ b/src/IIIFPresentation/API/Auth/DelegatedAuthHandler.cs
@@ -11,7 +11,7 @@ namespace API.Auth;
 /// </summary>
 /// <remarks>This is temporary and will be replaced in the future by an implementation that has auth logic</remarks>
 public class DelegatedAuthHandler(
-    DelegatedAuthenticator delegatedAuthenticator,
+    IAuthenticator delegatedAuthenticator,
     IOptionsMonitor<DelegatedAuthenticationOptions> options,
     ILoggerFactory logger,
     UrlEncoder encoder)

--- a/src/IIIFPresentation/API/Auth/DelegatedAuthHandler.cs
+++ b/src/IIIFPresentation/API/Auth/DelegatedAuthHandler.cs
@@ -50,7 +50,7 @@ public class DelegatedAuthenticationOptions : AuthenticationSchemeOptions
     /// <summary>
     /// Get or set the Realm for use in auth challenges.
     /// </summary>
-    public string Realm { get; set; }
+    public string Realm { get; set; } = null!;
 }
 
 /// <summary>

--- a/src/IIIFPresentation/API/Auth/DelegatedAuthenticator.cs
+++ b/src/IIIFPresentation/API/Auth/DelegatedAuthenticator.cs
@@ -8,13 +8,13 @@ using Microsoft.Extensions.Options;
 namespace API.Auth;
 
 /// <summary>
-/// Validate that provided request contains valid auth credentials
+/// Validate that provided request contains valid auth credentials by proxying to downstream DLCS instance
 /// </summary>
 public class DelegatedAuthenticator(
     HttpClient httpClient,
     IOptionsMonitor<CacheSettings> cacheSettings,
     IAppCache appCache,
-    ILogger<DelegatedAuthenticator> logger)
+    ILogger<DelegatedAuthenticator> logger) : IAuthenticator
 {
     private const string AuthHeader = "Authorization";
     private const string CustomerIdRouteValue = "customerId";

--- a/src/IIIFPresentation/API/Auth/DelegatedAuthenticator.cs
+++ b/src/IIIFPresentation/API/Auth/DelegatedAuthenticator.cs
@@ -71,7 +71,7 @@ public class DelegatedAuthenticator(
         // Parse the CustomerId out of this.
         var delegatePath = $"/customers/{customerId}";
 
-        // make a request to DLCS and verify the result received - if it's 200 we're good
+        // Make a request to DLCS and verify the result received - if it's 200 we're good
         var request = new HttpRequestMessage(HttpMethod.Get, delegatePath);
         request.Headers.Authorization = authenticationHeaderValue;
         var response = await httpClient.SendAsync(request);

--- a/src/IIIFPresentation/API/Auth/DelegatedAuthenticator.cs
+++ b/src/IIIFPresentation/API/Auth/DelegatedAuthenticator.cs
@@ -1,0 +1,87 @@
+﻿using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Http.Headers;
+using API.Settings;
+using LazyCache;
+using Microsoft.Extensions.Options;
+
+namespace API.Auth;
+
+/// <summary>
+/// Validate that provided request contains valid auth credentials
+/// </summary>
+public class DelegatedAuthenticator(
+    HttpClient httpClient,
+    IOptionsMonitor<CacheSettings> cacheSettings,
+    IAppCache appCache,
+    ILogger<DelegatedAuthenticator> logger)
+{
+    private const string AuthHeader = "Authorization";
+    private const string CustomerIdRouteValue = "customerId";
+
+    public async Task<AuthResult> ValidateRequest(HttpRequest request)
+    {
+        if (!request.Headers.TryGetValue(AuthHeader, out var value))
+        {
+            // Authorization header not in request
+            return AuthResult.NoCredentials;
+        }
+
+        if (!AuthenticationHeaderValue.TryParse(value, out AuthenticationHeaderValue? headerValue)
+            || string.IsNullOrEmpty(headerValue.Parameter))
+        {
+            // Invalid Authorization header
+            return AuthResult.NoCredentials;
+        }
+
+        if (!request.RouteValues.TryGetValue(CustomerIdRouteValue, out var customerIdRouteVal)
+            || customerIdRouteVal is null)
+        {
+            logger.LogDebug("Unable to identify customerId in auth request to {request}", request.Path);
+            return AuthResult.NoCredentials;
+        }
+
+        var customerId = customerIdRouteVal.ToString()!;
+        return await IsValidUser(headerValue, customerId)
+            ? AuthResult.Success
+            : AuthResult.Failed;
+    }
+
+    private async Task<bool> IsValidUser(AuthenticationHeaderValue authenticationHeaderValue, string customerId)
+    {
+        var cacheKey = $"{customerId}:{authenticationHeaderValue.Scheme}";
+        var authParameter = authenticationHeaderValue.Parameter!;
+        
+        // TODO - do I need any locking here?
+        var list = await appCache.GetAsync<ConcurrentBag<string>>(cacheKey);
+        if (list != null && list.Contains(authParameter)) return true;
+
+        var isValid = await IsValidUserDlcs(authenticationHeaderValue, customerId);
+        if (!isValid) return false;
+        
+        list ??= [];
+        list.Add(authParameter);
+        appCache.Add(cacheKey, list, cacheSettings.CurrentValue.GetMemoryCacheOptions());
+        return true;
+    }
+
+    private async Task<bool> IsValidUserDlcs(AuthenticationHeaderValue authenticationHeaderValue, string customerId)
+    {
+        // Parse the CustomerId out of this.
+        var delegatePath = $"/customers/{customerId}";
+
+        // make a request to DLCS and verify the result received - if it's 200 we're good
+        var request = new HttpRequestMessage(HttpMethod.Get, delegatePath);
+        request.Headers.Authorization = authenticationHeaderValue;
+        var response = await httpClient.SendAsync(request);
+
+        return response.StatusCode == HttpStatusCode.OK;
+    }
+}
+
+public enum AuthResult
+{
+    Success,
+    Failed,
+    NoCredentials,
+}

--- a/src/IIIFPresentation/API/Auth/DelegatedAuthenticator.cs
+++ b/src/IIIFPresentation/API/Auth/DelegatedAuthenticator.cs
@@ -8,8 +8,10 @@ using Microsoft.Extensions.Options;
 namespace API.Auth;
 
 /// <summary>
-/// Validate that provided request contains valid auth credentials by proxying to downstream DLCS instance
+/// Validate that provided request contains valid auth credentials by proxying to downstream DLCS instance.
+/// Any auth header provided here will be proxied to DLCS API - a 200 response = auth successful.
 /// </summary>
+/// <remarks>This is temporary and will be replaced in the future by an implementation that has auth logic</remarks>
 public class DelegatedAuthenticator(
     HttpClient httpClient,
     IOptionsMonitor<CacheSettings> cacheSettings,
@@ -52,7 +54,6 @@ public class DelegatedAuthenticator(
         var cacheKey = $"{customerId}:{authenticationHeaderValue.Scheme}";
         var authParameter = authenticationHeaderValue.Parameter!;
         
-        // TODO - do I need any locking here?
         var list = await appCache.GetAsync<ConcurrentBag<string>>(cacheKey);
         if (list != null && list.Contains(authParameter)) return true;
 

--- a/src/IIIFPresentation/API/Auth/IAuthenticator.cs
+++ b/src/IIIFPresentation/API/Auth/IAuthenticator.cs
@@ -1,0 +1,9 @@
+namespace API.Auth;
+
+/// <summary>
+/// Validate that provided request contains valid auth credentials
+/// </summary>
+public interface IAuthenticator
+{
+    Task<AuthResult> ValidateRequest(HttpRequest request);
+}

--- a/src/IIIFPresentation/API/Auth/ServiceCollectionX.cs
+++ b/src/IIIFPresentation/API/Auth/ServiceCollectionX.cs
@@ -1,0 +1,24 @@
+using API.Settings;
+using Microsoft.AspNetCore.Authentication;
+
+namespace API.Auth;
+
+internal static class ServiceCollectionX
+{
+    /// <summary>
+    /// Add <see cref="DelegatedAuthHandler"/> to services collection.
+    /// </summary>
+    public static AuthenticationBuilder AddDelegatedAuthHandler(this IServiceCollection services,
+        DlcsSettings dlcsSettings, Action<DelegatedAuthenticationOptions> configureOptions)
+    {
+        services.AddHttpClient<DelegatedAuthenticator>(client =>
+        {
+            client.BaseAddress = dlcsSettings.ApiUri;
+        });
+        
+        return services
+            .AddAuthentication(BasicAuthenticationDefaults.AuthenticationScheme)
+            .AddScheme<DelegatedAuthenticationOptions, DelegatedAuthHandler>(
+                BasicAuthenticationDefaults.AuthenticationScheme, configureOptions);
+    }
+}

--- a/src/IIIFPresentation/API/Auth/ServiceCollectionX.cs
+++ b/src/IIIFPresentation/API/Auth/ServiceCollectionX.cs
@@ -11,7 +11,7 @@ internal static class ServiceCollectionX
     public static AuthenticationBuilder AddDelegatedAuthHandler(this IServiceCollection services,
         DlcsSettings dlcsSettings, Action<DelegatedAuthenticationOptions> configureOptions)
     {
-        services.AddHttpClient<DelegatedAuthenticator>(client =>
+        services.AddHttpClient<IAuthenticator, DelegatedAuthenticator>(client =>
         {
             client.BaseAddress = dlcsSettings.ApiUri;
         });

--- a/src/IIIFPresentation/API/Converters/UrlRoots.cs
+++ b/src/IIIFPresentation/API/Converters/UrlRoots.cs
@@ -1,18 +1,12 @@
 ﻿namespace API.Converters;
 
 /// <summary>
-///     To construct a response object, you need the protocol and domain of the API itself,
-///     and the protocol and domain of the public facing resources (e.g., Image Services).
+/// To construct a response object, you need the protocol and domain of the API itself
 /// </summary>
 public class UrlRoots
 {
     /// <summary>
-    ///     The base URI for current request - this is the full URI excluding path and query string
+    /// The base URI for current request - this is the full URI excluding path and query string
     /// </summary>
     public string? BaseUrl { get; set; }
-
-    /// <summary>
-    ///     The base URI for image services and other public-facing resources
-    /// </summary>
-    public string? ResourceRoot { get; set; }
 }

--- a/src/IIIFPresentation/API/Features/Storage/Requests/GetHierarchicalCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/GetHierarchicalCollection.cs
@@ -3,6 +3,7 @@ using API.Helpers;
 using AWS.S3;
 using AWS.S3.Models;
 using AWS.Settings;
+using Core.Streams;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
@@ -41,10 +42,10 @@ public class GetHierarchicalCollectionHandler(PresentationContext dbContext, IBu
                 var objectFromS3 = await bucketReader.GetObjectFromBucket(new ObjectInBucket(settings.S3.StorageBucket,
                     $"{request.CustomerId}/collections/{collection.Id}"), cancellationToken);
 
-                if (objectFromS3.Stream != null)
+                if (!objectFromS3.Stream.IsNull())
                 {
-                    StreamReader reader = new StreamReader(objectFromS3.Stream);
-                    collectionFromS3 = reader.ReadToEnd();
+                    using var reader = new StreamReader(objectFromS3.Stream);
+                    collectionFromS3 = await reader.ReadToEndAsync(cancellationToken);
                 }
             }
             else

--- a/src/IIIFPresentation/API/Features/Storage/StorageController.cs
+++ b/src/IIIFPresentation/API/Features/Storage/StorageController.cs
@@ -11,6 +11,7 @@ using API.Settings;
 using IIIF.Presentation;
 using IIIF.Serialisation;
 using MediatR;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Models.API.Collection.Upsert;
@@ -43,15 +44,12 @@ public class StorageController(IOptions<ApiSettings> options, IMediator mediator
             : Content(storageRoot.StoredCollection, ContentTypes.V3);
     }
     
+    [Authorize]
     [HttpPost("{*slug}")]
     [ETagCaching]
     public async Task<IActionResult> PostHierarchicalCollection(int customerId, string slug)
     {
-        if (!Request.ShowExtraProperties())
-        {
-            return this.PresentationProblem(statusCode: (int)HttpStatusCode.Forbidden);
-        }
-
+        // X-IIIF-CS-Show-Extras is not required here, the body should be vanilla json
         using var streamReader = new StreamReader(Request.Body);
         
         var rawRequestBody = await streamReader.ReadToEndAsync();

--- a/src/IIIFPresentation/API/Features/Storage/StorageController.cs
+++ b/src/IIIFPresentation/API/Features/Storage/StorageController.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using API.Attributes;
+using API.Auth;
 using API.Converters;
 using API.Features.Storage.Requests;
 using API.Features.Storage.Validators;
@@ -21,7 +22,7 @@ namespace API.Features.Storage;
 
 [Route("/{customerId}")]
 [ApiController]
-public class StorageController(IOptions<ApiSettings> options, IMediator mediator)
+public class StorageController(IAuthenticator authenticator, IOptions<ApiSettings> options, IMediator mediator)
     : PresentationController(options.Value, mediator)
 {
     [HttpGet("{*slug}")]
@@ -33,7 +34,7 @@ public class StorageController(IOptions<ApiSettings> options, IMediator mediator
 
         if (storageRoot.Collection is not { IsPublic: true }) return this.PresentationNotFound();
 
-        if (Request.ShowExtraProperties())
+        if (Request.HasShowExtraHeader() && await authenticator.ValidateRequest(Request) == AuthResult.Success)
         {
             return SeeOther(storageRoot.Collection.GenerateFlatCollectionId(GetUrlRoots()));
         }
@@ -56,7 +57,7 @@ public class StorageController(IOptions<ApiSettings> options, IMediator mediator
         
         return await HandleUpsert(new PostHierarchicalCollection(customerId, slug, GetUrlRoots(), rawRequestBody));
     }
-
+    
     [HttpGet("collections/{id}")]
     [ETagCaching]
     [VaryHeader]
@@ -73,7 +74,7 @@ public class StorageController(IOptions<ApiSettings> options, IMediator mediator
 
         if (storageRoot.Collection == null) return this.PresentationNotFound();
 
-        if (Request.ShowExtraProperties())
+        if (Request.HasShowExtraHeader() && await authenticator.ValidateRequest(Request) == AuthResult.Success)
         {
             var orderByParameter = orderByField != null
                 ? $"{(descending ? nameof(orderByDescending) : nameof(orderBy))}={orderByField}" 
@@ -86,12 +87,12 @@ public class StorageController(IOptions<ApiSettings> options, IMediator mediator
         return SeeOther(storageRoot.Collection.GenerateHierarchicalCollectionId(GetUrlRoots()));
     }
 
+    [Authorize]
     [HttpPost("collections")]
     [ETagCaching]
-    public async Task<IActionResult> Post(int customerId, 
-        [FromServices] UpsertFlatCollectionValidator validator)
+    public async Task<IActionResult> Post(int customerId, [FromServices] UpsertFlatCollectionValidator validator)
     {
-        if (!Request.ShowExtraProperties())
+        if (!Request.HasShowExtraHeader())
         {
             return this.PresentationProblem(statusCode: (int)HttpStatusCode.Forbidden);
         }
@@ -112,12 +113,13 @@ public class StorageController(IOptions<ApiSettings> options, IMediator mediator
         return await HandleUpsert(new CreateCollection(customerId, collection!, rawRequestBody, GetUrlRoots()));
     }
     
+    [Authorize]
     [HttpPut("collections/{id}")]
     [ETagCaching]
     public async Task<IActionResult> Put(int customerId, string id, [FromBody] UpsertFlatCollection collection, 
         [FromServices] UpsertFlatCollectionValidator validator)
     {
-        if (!Request.ShowExtraProperties())
+        if (!Request.HasShowExtraHeader())
         {
             return this.PresentationProblem(statusCode: (int)HttpStatusCode.Forbidden);
         }
@@ -133,10 +135,11 @@ public class StorageController(IOptions<ApiSettings> options, IMediator mediator
             Request.Headers.IfMatch));
     }
     
+    [Authorize]
     [HttpDelete("collections/{id}")]
     public async Task<IActionResult> Delete(int customerId, string id)
     {
-        if (!Request.ShowExtraProperties())
+        if (!Request.HasShowExtraHeader())
         {
             return this.PresentationProblem(statusCode: (int)HttpStatusCode.Forbidden);
         }

--- a/src/IIIFPresentation/API/Infrastructure/Filters/VaryHeaderAttribute.cs
+++ b/src/IIIFPresentation/API/Infrastructure/Filters/VaryHeaderAttribute.cs
@@ -1,11 +1,12 @@
-﻿using Microsoft.AspNetCore.Mvc.Filters;
+﻿using API.Infrastructure.Http;
+using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Net.Http.Headers;
 
 namespace API.Infrastructure.Filters;
 
 public class VaryHeaderAttribute : ActionFilterAttribute
 {
-    private static readonly string[] VaryHeaders = ["X-IIIF-CS-Show-Extras", "Authorization"];
+    private static readonly string[] VaryHeaders = [CustomHttpHeaders.ShowExtras, "Authorization"];
 
     public override void OnActionExecuted(ActionExecutedContext context)
     {

--- a/src/IIIFPresentation/API/Infrastructure/Helpers/HttpRequestX.cs
+++ b/src/IIIFPresentation/API/Infrastructure/Helpers/HttpRequestX.cs
@@ -8,8 +8,7 @@ public static class HttpRequestX
 
     public static bool ShowExtraProperties(this HttpRequest request)
     {
-        return request.Headers.FirstOrDefault(x => x.Key == AdditionalPropertiesHeader.Key).Value == AdditionalPropertiesHeader.Value &&
-               Authorizer.CheckAuthorized(request);
+        return request.HasShowExtraHeader() && Authorizer.CheckAuthorized(request);
     }
     
     public static bool HasShowExtraHeader(this HttpRequest request)

--- a/src/IIIFPresentation/API/Infrastructure/Helpers/HttpRequestX.cs
+++ b/src/IIIFPresentation/API/Infrastructure/Helpers/HttpRequestX.cs
@@ -1,11 +1,13 @@
 ﻿using API.Auth;
+using API.Infrastructure.Http;
 
 namespace API.Infrastructure.Helpers;
 
 public static class HttpRequestX
 {
-    private static readonly KeyValuePair<string, string> AdditionalPropertiesHeader = new ("X-IIIF-CS-Show-Extras", "All");
+    private static readonly KeyValuePair<string, string> AdditionalPropertiesHeader = new (CustomHttpHeaders.ShowExtras, "All");
 
+    [Obsolete("Use HasShowExtraHeader or DelegatedAuthenticator")]
     public static bool ShowExtraProperties(this HttpRequest request)
     {
         return request.HasShowExtraHeader() && Authorizer.CheckAuthorized(request);

--- a/src/IIIFPresentation/API/Infrastructure/Helpers/HttpRequestX.cs
+++ b/src/IIIFPresentation/API/Infrastructure/Helpers/HttpRequestX.cs
@@ -15,7 +15,7 @@ public static class HttpRequestX
     
     public static bool HasShowExtraHeader(this HttpRequest request)
     {
-        return request.Headers.FirstOrDefault(x => x.Key == AdditionalPropertiesHeader.Key).Value ==
+        return request.Headers.FirstOrDefault(h => string.Equals(h.Key, AdditionalPropertiesHeader.Key, StringComparison.OrdinalIgnoreCase)).Value ==
                AdditionalPropertiesHeader.Value;
     }
 }

--- a/src/IIIFPresentation/API/Infrastructure/Helpers/HttpRequestX.cs
+++ b/src/IIIFPresentation/API/Infrastructure/Helpers/HttpRequestX.cs
@@ -1,5 +1,4 @@
-﻿using API.Auth;
-using API.Infrastructure.Http;
+﻿using API.Infrastructure.Http;
 
 namespace API.Infrastructure.Helpers;
 
@@ -7,12 +6,6 @@ public static class HttpRequestX
 {
     private static readonly KeyValuePair<string, string> AdditionalPropertiesHeader = new (CustomHttpHeaders.ShowExtras, "All");
 
-    [Obsolete("Use HasShowExtraHeader or DelegatedAuthenticator")]
-    public static bool ShowExtraProperties(this HttpRequest request)
-    {
-        return request.HasShowExtraHeader() && Authorizer.CheckAuthorized(request);
-    }
-    
     public static bool HasShowExtraHeader(this HttpRequest request)
     {
         return request.Headers.FirstOrDefault(h => string.Equals(h.Key, AdditionalPropertiesHeader.Key, StringComparison.OrdinalIgnoreCase)).Value ==

--- a/src/IIIFPresentation/API/Infrastructure/Http/CustomHttpHeaders.cs
+++ b/src/IIIFPresentation/API/Infrastructure/Http/CustomHttpHeaders.cs
@@ -1,0 +1,9 @@
+﻿namespace API.Infrastructure.Http;
+
+internal static class CustomHttpHeaders
+{
+    /// <summary>
+    /// HTTP header supplied to view extra values, in addition to basic IIIF Presentation payload 
+    /// </summary>
+    public const string ShowExtras = "X-IIIF-CS-Show-Extras";
+}

--- a/src/IIIFPresentation/API/Infrastructure/PresentationController.cs
+++ b/src/IIIFPresentation/API/Infrastructure/PresentationController.cs
@@ -15,7 +15,7 @@ public abstract class PresentationController : Controller
     protected readonly IMediator Mediator;
 
     /// <summary>
-    ///     API Settings available to derived controller classes
+    /// API Settings available to derived controller classes
     /// </summary>
     protected readonly ApiSettings Settings;
 
@@ -27,17 +27,9 @@ public abstract class PresentationController : Controller
     }
 
     /// <summary>
-    ///  Used by derived controllers to construct correct fully qualified URLs in returned objects.
+    /// Used by derived controllers to construct correct fully qualified URLs in returned objects.
     /// </summary>
-    /// <returns></returns>
-    protected UrlRoots GetUrlRoots()
-    {
-        return new UrlRoots
-        {
-            BaseUrl = Request.GetBaseUrl(),
-            ResourceRoot = Settings.ResourceRoot.ToString()
-        };
-    }
+    protected UrlRoots GetUrlRoots() => new() { BaseUrl = Request.GetBaseUrl(), };
 
     /// <summary>
     /// Handle an upsert request - this takes a IRequest which returns a ModifyEntityResult{T}.
@@ -73,15 +65,15 @@ public abstract class PresentationController : Controller
     }
 
     /// <summary>
-    ///     Handles a deletion
+    /// Handles a deletion
     /// </summary>
     /// <param name="request">The request/response to be sent through Mediatr</param>
     /// <param name="errorTitle">The title of the error</param>
     /// <param name="cancellationToken">Current cancellation token</param>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when the <see cref="DeleteResult" /> is not understood</exception>
     /// <returns>
-    ///     ActionResult generated from DeleteResult. This will be 204 on success. Or an
-    ///     error and appropriate status code if failed.
+    /// ActionResult generated from DeleteResult. This will be 204 on success. Or an
+    /// error and appropriate status code if failed.
     /// </returns>
     /// <remarks>This will be replaced with overload that takes DeleteEntityResult in future</remarks>
     protected async Task<IActionResult> HandleDelete(
@@ -99,15 +91,15 @@ public abstract class PresentationController : Controller
     }
 
     /// <summary>
-    ///     Handles a deletion, turning DeleteResult to a http response
+    /// Handles a deletion, turning DeleteResult to a http response
     /// </summary>
     /// <param name="request">The request/response to be sent through Mediatr</param>
     /// <param name="errorTitle">The title of the error</param>
     /// <param name="cancellationToken">Current cancellation token</param>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when the <see cref="DeleteResult" /> is not understood</exception>
     /// <returns>
-    ///     ActionResult generated from DeleteResult. This will be 204 on success. Or an
-    ///     error and appropriate status code if failed.
+    /// ActionResult generated from DeleteResult. This will be 204 on success. Or an
+    /// error and appropriate status code if failed.
     /// </returns>
     protected async Task<IActionResult> HandleDelete(
         IRequest<DeleteEntityResult> request,
@@ -138,20 +130,20 @@ public abstract class PresentationController : Controller
     private string GetErrorType<TType>(TType type) => $"{GetUrlRoots().BaseUrl}/errors/{type?.GetType().Name}/{type}";
 
     /// <summary>
-    ///     Handle a GET request - this takes a IRequest which returns a FetchEntityResult{T}.
-    ///     The request is sent and result is transformed to an http result.
+    /// Handle a GET request - this takes a IRequest which returns a FetchEntityResult{T}.
+    /// The request is sent and result is transformed to an http result.
     /// </summary>
     /// <param name="request">IRequest to fetch data</param>
     /// <param name="instance">The value for <see cref="JSType.Error.Instance" />.</param>
     /// <param name="errorTitle">
-    ///     The value for <see cref="JSType.Error.Title" />. In some instances this will be prepended to the actual error name.
-    ///     e.g. errorTitle + ": Conflict"
+    /// The value for <see cref="JSType.Error.Title" />. In some instances this will be prepended to the actual error name.
+    /// e.g. errorTitle + ": Conflict"
     /// </param>
     /// <param name="cancellationToken">Current cancellation token</param>
     /// <typeparam name="T">Type of entity being fetched</typeparam>
     /// <returns>
-    ///     ActionResult generated from FetchEntityResult. This will be the model + 200 on success. Or an
-    ///     error and appropriate status code if failed.
+    /// ActionResult generated from FetchEntityResult. This will be the model + 200 on success. Or an
+    /// error and appropriate status code if failed.
     /// </returns>
     protected async Task<IActionResult> HandleFetch<T>(
         IRequest<FetchEntityResult<T>> request,
@@ -169,7 +161,7 @@ public abstract class PresentationController : Controller
     }
 
     /// <summary>
-    ///     Make a request and handle exceptions
+    /// Make a request and handle exceptions
     /// </summary>
     protected async Task<IActionResult> HandleRequest(Func<Task<IActionResult>> handler,
         string? errorTitle = "Request failed")

--- a/src/IIIFPresentation/API/Program.cs
+++ b/src/IIIFPresentation/API/Program.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using API.Auth;
 using API.Features.Storage.Validators;
 using API.Infrastructure;
 using API.Infrastructure.Helpers;
@@ -32,9 +33,16 @@ builder.Services.AddOptions<ApiSettings>()
     .BindConfiguration(string.Empty);
 builder.Services.AddOptions<CacheSettings>()
     .BindConfiguration(nameof(CacheSettings));
+var dlcsSettings = builder.Configuration.GetSection(DlcsSettings.SettingsName);
+builder.Services.Configure<DlcsSettings>(dlcsSettings);
 
-var cacheSettings = builder.Configuration.Get<CacheSettings>() ?? new CacheSettings();
+var cacheSettings = builder.Configuration.GetSection(nameof(CacheSettings)).Get<CacheSettings>();
+var dlcs = dlcsSettings.Get<DlcsSettings>()!;
 
+builder.Services.AddDelegatedAuthHandler(dlcs, opts =>
+{
+    opts.Realm = "DLCS-API";
+});
 builder.Services.AddDataAccess(builder.Configuration);
 builder.Services.AddCaching(cacheSettings);
 builder.Services.AddSingleton<IETagManager, ETagManager>();
@@ -67,9 +75,11 @@ if (app.Environment.IsDevelopment())
     IIIFPresentationContextConfiguration.TryRunMigrations(builder.Configuration, app.Logger);
 }
 
-app.UseHttpsRedirection();
-
-app.UseSerilogRequestLogging();
+app
+    .UseHttpsRedirection()
+    .UseAuthentication()
+    .UseAuthorization()
+    .UseSerilogRequestLogging();
 
 app.MapControllers();
 

--- a/src/IIIFPresentation/API/Program.cs
+++ b/src/IIIFPresentation/API/Program.cs
@@ -36,7 +36,7 @@ builder.Services.AddOptions<CacheSettings>()
 var dlcsSettings = builder.Configuration.GetSection(DlcsSettings.SettingsName);
 builder.Services.Configure<DlcsSettings>(dlcsSettings);
 
-var cacheSettings = builder.Configuration.GetSection(nameof(CacheSettings)).Get<CacheSettings>();
+var cacheSettings = builder.Configuration.GetSection(nameof(CacheSettings)).Get<CacheSettings>() ?? new CacheSettings();
 var dlcs = dlcsSettings.Get<DlcsSettings>()!;
 
 builder.Services.AddDelegatedAuthHandler(dlcs, opts =>

--- a/src/IIIFPresentation/API/Settings/ApiSettings.cs
+++ b/src/IIIFPresentation/API/Settings/ApiSettings.cs
@@ -5,7 +5,7 @@ namespace API.Settings;
 public class ApiSettings
 {
     /// <summary>
-    ///     The base URI for image services and other public-facing resources
+    /// The base URI for image services and other public-facing resources
     /// </summary>
     public required Uri ResourceRoot { get; set; }
 
@@ -22,4 +22,6 @@ public class ApiSettings
     public string? PathBase { get; set; }
     
     public AWSSettings AWS { get; set; }
+
+    public DlcsSettings Dlcs { get; set; } = new();
 }

--- a/src/IIIFPresentation/API/Settings/ApiSettings.cs
+++ b/src/IIIFPresentation/API/Settings/ApiSettings.cs
@@ -16,7 +16,7 @@ public class ApiSettings
     
     public string? PathBase { get; set; }
     
-    public AWSSettings AWS { get; set; }
+    public required AWSSettings AWS { get; set; }
 
-    public DlcsSettings Dlcs { get; set; } = new();
+    public required DlcsSettings DLCS { get; set; }
 }

--- a/src/IIIFPresentation/API/Settings/ApiSettings.cs
+++ b/src/IIIFPresentation/API/Settings/ApiSettings.cs
@@ -5,11 +5,6 @@ namespace API.Settings;
 public class ApiSettings
 {
     /// <summary>
-    /// The base URI for image services and other public-facing resources
-    /// </summary>
-    public required Uri ResourceRoot { get; set; }
-
-    /// <summary>
     /// Page size for paged collections
     /// </summary>
     public int PageSize { get; set; } = 100;

--- a/src/IIIFPresentation/API/Settings/CacheSettings.cs
+++ b/src/IIIFPresentation/API/Settings/CacheSettings.cs
@@ -1,4 +1,6 @@
-﻿namespace API.Settings;
+﻿using Microsoft.Extensions.Caching.Memory;
+
+namespace API.Settings;
 
 /// <summary>
 /// Settings related to caching
@@ -51,6 +53,20 @@ public class CacheSettings
         TimeToLive.TryGetValue(CacheSource.Memory, out var settings)
             ? settings.GetTtl(duration)
             : fallback.GetTtl(duration);
+    
+    /// <summary>
+    /// Get <see cref="MemoryCacheEntryOptions"/> object with specified values.
+    /// </summary>
+    public MemoryCacheEntryOptions GetMemoryCacheOptions(
+        CacheDuration duration = CacheDuration.Default, long size = 1,
+        CacheItemPriority priority = CacheItemPriority.Normal)
+        => new()
+        {
+            Priority = priority,
+            Size = size,
+            AbsoluteExpirationRelativeToNow =
+                TimeSpan.FromSeconds(GetTtl(duration, CacheSource.Memory)),
+        };
 }
 
 public class CacheGroupSettings

--- a/src/IIIFPresentation/API/Settings/DlcsSettings.cs
+++ b/src/IIIFPresentation/API/Settings/DlcsSettings.cs
@@ -7,5 +7,5 @@ public class DlcsSettings
     /// <summary>
     /// URL root of DLCS API 
     /// </summary>
-    public Uri ApiUri { get; set; }
+    public required Uri ApiUri { get; set; }
 }

--- a/src/IIIFPresentation/API/Settings/DlcsSettings.cs
+++ b/src/IIIFPresentation/API/Settings/DlcsSettings.cs
@@ -2,7 +2,7 @@
 
 public class DlcsSettings
 {
-    public const string SettingsName = "Dlcs";
+    public const string SettingsName = "DLCS";
     
     /// <summary>
     /// URL root of DLCS API 

--- a/src/IIIFPresentation/API/Settings/DlcsSettings.cs
+++ b/src/IIIFPresentation/API/Settings/DlcsSettings.cs
@@ -1,0 +1,11 @@
+﻿namespace API.Settings;
+
+public class DlcsSettings
+{
+    public const string SettingsName = "Dlcs";
+    
+    /// <summary>
+    /// URL root of DLCS API 
+    /// </summary>
+    public Uri ApiUri { get; set; }
+}

--- a/src/IIIFPresentation/API/appsettings.Example.json
+++ b/src/IIIFPresentation/API/appsettings.Example.json
@@ -24,5 +24,8 @@
         "LongTtlSecs": 60
       }
     }
+  },
+  "Dlcs": {
+    "ApiUri": "https://api.dlcs.digirati.io"
   }
 }

--- a/src/IIIFPresentation/API/appsettings.Example.json
+++ b/src/IIIFPresentation/API/appsettings.Example.json
@@ -25,7 +25,7 @@
       }
     }
   },
-  "Dlcs": {
+  "DLCS": {
     "ApiUri": "https://api.dlcs.digirati.io"
   }
 }

--- a/src/IIIFPresentation/API/appsettings.Example.json
+++ b/src/IIIFPresentation/API/appsettings.Example.json
@@ -1,6 +1,5 @@
 {
   "RunMigrations": true,
-  "ResourceRoot": "https://localhost:7230",
   "AWS": {
     "Profile": "dlcs",
     "Region": "eu-west-1",

--- a/src/IIIFPresentation/IIIFPresentation.sln.DotSettings
+++ b/src/IIIFPresentation/IIIFPresentation.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=dlcs/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/IIIFPresentation/IIIFPresentation.sln.DotSettings
+++ b/src/IIIFPresentation/IIIFPresentation.sln.DotSettings
@@ -1,2 +1,3 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=dlcs/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=dlcs/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=iiif/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/IIIFPresentation/Test.Helpers/Integration/TestAuthHandlerX.cs
+++ b/src/IIIFPresentation/Test.Helpers/Integration/TestAuthHandlerX.cs
@@ -16,36 +16,3 @@ public static class TestAuthHandlerX
         return client;
     }
 }
-
-/// <summary>
-/// Authentication Handler to make testing easier.
-/// </summary>
-public class TestAuthHandler(
-    IOptionsMonitor<AuthenticationSchemeOptions> options,
-    ILoggerFactory logger,
-    UrlEncoder encoder)
-    : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
-{
-    private const string AuthHeader = "Authorization";
-
-    protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
-    {
-        if (!Request.Headers.TryGetValue(AuthHeader, out var value))
-        {
-            // Authorization header not in request
-            return AuthenticateResult.NoResult();
-        }
-        
-        if (!AuthenticationHeaderValue.TryParse(value, out _))
-        {
-            // Invalid Authorization header
-            return AuthenticateResult.NoResult();
-        }
-
-        var identity = new ClaimsIdentity(Scheme.Name);
-        var principal = new ClaimsPrincipal(identity);
-        var ticket = new AuthenticationTicket(principal, ClaimsIssuer);
-        var result = AuthenticateResult.Success(ticket);
-        return result;
-    }
-}

--- a/src/IIIFPresentation/Test.Helpers/Integration/TestAuthHandlerX.cs
+++ b/src/IIIFPresentation/Test.Helpers/Integration/TestAuthHandlerX.cs
@@ -1,4 +1,9 @@
 ﻿using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Test.Helpers.Integration;
 
@@ -9,5 +14,38 @@ public static class TestAuthHandlerX
         client.DefaultRequestHeaders.Authorization = 
             new AuthenticationHeaderValue($"user|{customer}");
         return client;
+    }
+}
+
+/// <summary>
+/// Authentication Handler to make testing easier.
+/// </summary>
+public class TestAuthHandler(
+    IOptionsMonitor<AuthenticationSchemeOptions> options,
+    ILoggerFactory logger,
+    UrlEncoder encoder)
+    : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+{
+    private const string AuthHeader = "Authorization";
+
+    protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        if (!Request.Headers.TryGetValue(AuthHeader, out var value))
+        {
+            // Authorization header not in request
+            return AuthenticateResult.NoResult();
+        }
+        
+        if (!AuthenticationHeaderValue.TryParse(value, out _))
+        {
+            // Invalid Authorization header
+            return AuthenticateResult.NoResult();
+        }
+
+        var identity = new ClaimsIdentity(Scheme.Name);
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, ClaimsIssuer);
+        var result = AuthenticateResult.Success(ticket);
+        return result;
     }
 }

--- a/src/IIIFPresentation/Test.Helpers/Settings/OptionsHelper.cs
+++ b/src/IIIFPresentation/Test.Helpers/Settings/OptionsHelper.cs
@@ -1,0 +1,20 @@
+﻿using FakeItEasy;
+using Microsoft.Extensions.Options;
+
+namespace Test.Helpers.Settings;
+
+public static class OptionsHelpers
+{
+    /// <summary>
+    /// Creates an <see cref="IOptionsMonitor{TOptions}"/> that returns provided object for CurrentValue
+    /// </summary>
+    /// <param name="expectedResult">The CurrentValue of OptionsMonitor</param>
+    /// <typeparam name="T">Type of object</typeparam>
+    /// <returns>Fake <see cref="IOptionsMonitor{TOptions}"/> with CurrentValue setup.</returns>
+    public static IOptionsMonitor<T> GetOptionsMonitor<T>(T expectedResult)
+    {
+        var optionsMonitor = A.Fake<IOptionsMonitor<T>>();
+        A.CallTo(() => optionsMonitor.CurrentValue).Returns(expectedResult);
+        return optionsMonitor;
+    }
+}

--- a/src/IIIFPresentation/Test.Helpers/Test.Helpers.csproj
+++ b/src/IIIFPresentation/Test.Helpers/Test.Helpers.csproj
@@ -12,6 +12,7 @@
     <ItemGroup>
         <PackageReference Include="AWSSDK.S3" Version="3.7.403.3" />
         <PackageReference Include="coverlet.collector" Version="6.0.0" />
+        <PackageReference Include="FakeItEasy" Version="8.3.0" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.7" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
         <PackageReference Include="Testcontainers" Version="3.10.0" />

--- a/src/IIIFPresentation/Test.Helpers/Test.Helpers.csproj
+++ b/src/IIIFPresentation/Test.Helpers/Test.Helpers.csproj
@@ -28,8 +28,4 @@
       <ProjectReference Include="..\Repository\Repository.csproj" />
     </ItemGroup>
 
-    <ItemGroup>
-      <Folder Include="Integration\Deserialization\" />
-    </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Resolves #89. Adds auth to API. This currently takes any `Authorization` header passed and proxies it to a downstream DLCS instance, it will attempt to `GET /customer/{customerId}` and if we receive a 200 request is allowed. Result of call is cached in-memory for a short period.

Implementation notes:
* Add `DelegatedAuthHandler` to API, this allows for use of standard `[Authorize]` attributes. Note that this checks authorization only, checks for `x-iiif-cs-show-extras` header is handles elsewhere. Logic for actual auth logic is is delegated to `IAuthorizer` impl.
* `IAuthorizer` has a single implementation, `DelegatedAuthenticator`, which makes request to DLCS and caches results.
  * _Note that there's no locking around this as we don't expect high call volumes_

Other changes:
* Make `x-iiif-cs-show-extras` header case insensitive 
* Refactored `PostHierarchicalCollection` to make quick/cheap serialiser check first before doing any DB work.
* Slight refactoring of `PresentationAppFactory` - change in dotnet 8 meant values in `appsettings.testing.json` weren't available until the host had been built.
* Sample SQL script for creating root collection