### PR TITLE
Update SQL script to use the new hierarchy table

### DIFF
--- a/scripts/create_root.sql
+++ b/scripts/create_root.sql
@@ -1,4 +1,9 @@
 INSERT INTO public.collections 
-    (id, slug, use_path, label, created, modified, created_by, modified_by, is_storage_collection, is_public, customer_id) 
-VALUES
-    ('root', '', false, '{"en": ["(repository root)"]}', now(), now(), 'Admin', 'Admin', true, true, 1);
+	(id, use_path, label, thumbnail, locked_by, created, modified, created_by, modified_by, tags, is_storage_collection, is_public, customer_id) 
+VALUES 
+	('root', true, '{"en": ["(repository root)"]}', 'some/thumb', null, now(),  now(), 'Admin', 'Admin', null, true, true, 1);
+
+INSERT INTO public.hierarchy 
+	(id, collection_id, manifest_id, type, slug, parent, items_order, canonical, customer_id) 
+VALUES 
+	(1, 'root', null, 0, '', null, null, true, 1);


### PR DESCRIPTION
This PR is a simple fix to update the `create_root` SQL script to use the new hierarchy table