### PR TITLE
Pass query params when redirecting from hierarchical to flat

### DIFF
--- a/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
@@ -87,6 +87,20 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
     }
     
     [Fact]
+    public async Task Get_Hierarchical_ReturnsSeeOther_WithQueryParameters_WhenAuthAndShowExtrasHeadersAndQuery()
+    {
+        // Arrange
+        var requestMessage = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get, "1?page=2&pageSize=2");
+        
+        // Act
+        var response = await httpClient.AsCustomer(1).SendAsync(requestMessage);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.SeeOther);
+        response.Headers.Location!.Should().Be($"http://localhost/1/collections/{RootCollection.Id}?page=2&pageSize=2");
+    }
+    
+    [Fact]
     public async Task Get_RootFlat_ReturnsSeeOther_WhenNoAuthOrCsHeader()
     {
         // Act

--- a/src/IIIFPresentation/API/Features/Storage/StorageController.cs
+++ b/src/IIIFPresentation/API/Features/Storage/StorageController.cs
@@ -14,6 +14,7 @@ using IIIF.Serialisation;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Options;
 using Models.API.Collection.Upsert;
 using Newtonsoft.Json;
@@ -36,7 +37,9 @@ public class StorageController(IAuthenticator authenticator, IOptions<ApiSetting
 
         if (Request.HasShowExtraHeader() && await authenticator.ValidateRequest(Request) == AuthResult.Success)
         {
-            return SeeOther(storageRoot.Collection.GenerateFlatCollectionId(GetUrlRoots()));
+            var relativeUrl = storageRoot.Collection.GenerateFlatCollectionId(GetUrlRoots());
+            relativeUrl = QueryHelpers.AddQueryString(relativeUrl, Request.Query);
+            return SeeOther(relativeUrl);
         }
 
         return storageRoot.StoredCollection == null


### PR DESCRIPTION
Adds query if present in original request, see #66 for details.

Also added a test to check specifically for this case.