### PR TITLE
Initialize hierarchy with `StorageCollection` type in `UpsertCollection` 

### DIFF
--- a/src/IIIFPresentation/API/Features/Storage/Requests/UpsertCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/UpsertCollection.cs
@@ -88,7 +88,7 @@ public class UpsertCollectionHandler(
             hierarchy = new Hierarchy
             {
                 CollectionId = request.CollectionId,
-                Type = ResourceType.IIIFCollection,
+                Type = ResourceType.StorageCollection,
                 Slug = request.Collection.Slug,
                 CustomerId = request.CustomerId,
                 Canonical = true,


### PR DESCRIPTION
This PR fixes a bug that prevented storage collections created via PUT from being read via their hierarchal URL, caused by `UpsertCollectionHandler` setting the default hierarchy type to `ResourceType.IIIFCollection`.