### PR TITLE
Fix for #108 - handle full URI parents

### DIFF
--- a/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
@@ -94,7 +94,7 @@ public class CreateCollectionHandler(
             CustomerId = request.CustomerId,
             Canonical = true,
             ItemsOrder = request.Collection.ItemsOrder,
-            Parent = request.Collection.Parent
+            Parent = parentCollection.Id
         };
         
         string? convertedIIIFCollection = null;

--- a/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
@@ -56,6 +56,11 @@ public class CreateCollectionHandler(
 
         if (parentCollection == null) return ErrorHelper.NullParentResponse<PresentationCollection>();
 
+        // If full URI was used, verify it indeed is pointing to the resolved parent collection
+        if (Uri.IsWellFormedUriString(request.Collection.Parent, UriKind.Absolute)
+            && !parentCollection.GenerateFlatCollectionId(request.UrlRoots).Equals(request.Collection.Parent))
+            return ErrorHelper.NullParentResponse<PresentationCollection>();
+        
         var isStorageCollection = request.Collection.Behavior.IsStorageCollection();
         
         string id;

--- a/src/IIIFPresentation/API/Features/Storage/Requests/UpsertCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/UpsertCollection.cs
@@ -70,6 +70,10 @@ public class UpsertCollectionHandler(
                 request.Collection.Parent.GetLastPathElement(), true, cancellationToken);
             
             if (parentCollection == null) return ErrorHelper.NullParentResponse<PresentationCollection>();
+            // If full URI was used, verify it indeed is pointing to the resolved parent collection
+            if (Uri.IsWellFormedUriString(request.Collection.Parent, UriKind.Absolute)
+                && !parentCollection.GenerateFlatCollectionId(request.UrlRoots).Equals(request.Collection.Parent))
+                return ErrorHelper.NullParentResponse<PresentationCollection>();
 
             databaseCollection = new Collection
             {
@@ -123,6 +127,11 @@ public class UpsertCollectionHandler(
                         $"The parent collection could not be found", ModifyCollectionType.ParentCollectionNotFound,
                         WriteResult.BadRequest);
                 }
+
+                // If full URI was used, verify it indeed is pointing to the resolved parent collection
+                if (Uri.IsWellFormedUriString(request.Collection.Parent, UriKind.Absolute)
+                    && !parentCollection.GenerateFlatCollectionId(request.UrlRoots).Equals(request.Collection.Parent))
+                    return ErrorHelper.NullParentResponse<PresentationCollection>();
 
                 parentId = parentCollection.Id;
             }

--- a/src/IIIFPresentation/API/Features/Storage/Requests/UpsertCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/UpsertCollection.cs
@@ -111,6 +111,7 @@ public class UpsertCollectionHandler(
 
             hierarchy = databaseCollection.Hierarchy!.Single(c => c.Canonical);
 
+            var parentId = hierarchy.Parent;
             if (hierarchy.Parent != request.Collection.Parent)
             {
                 var parentCollection = await dbContext.RetrieveCollectionAsync(request.CustomerId,
@@ -122,6 +123,8 @@ public class UpsertCollectionHandler(
                         $"The parent collection could not be found", ModifyCollectionType.ParentCollectionNotFound,
                         WriteResult.BadRequest);
                 }
+
+                parentId = parentCollection.Id;
             }
 
             databaseCollection.Modified = DateTime.UtcNow;
@@ -132,7 +135,7 @@ public class UpsertCollectionHandler(
             databaseCollection.Thumbnail = request.Collection.PresentationThumbnail;
             databaseCollection.Tags = request.Collection.Tags;
 
-            hierarchy.Parent = request.Collection.Parent;
+            hierarchy.Parent = parentId;
             hierarchy.ItemsOrder = request.Collection.ItemsOrder;
             hierarchy.Slug = request.Collection.Slug;
         }


### PR DESCRIPTION
Fixes #108 
- **Use resolved parent id instead of whatever is provided in request**
- **Add verification to weed out hierarchical URIs for parents in create/update**

Covered all 4 cases (create/update with full flat URIs and full hierarchical URIs), seem to do the trick. 