### PR TITLE
Validate hierarchical manifest parent

### DIFF
--- a/src/IIIFPresentation/API.Tests/Converters/ManifestConverterTests.cs
+++ b/src/IIIFPresentation/API.Tests/Converters/ManifestConverterTests.cs
@@ -107,7 +107,7 @@ public class ManifestConverterTests
 
         // Assert
         result.Slug.Should().Be("hierarchy-slug");
-        result.Parent.Should().Be("hierarchy-parent");
+        result.Parent.Should().Be("/0/collections/hierarchy-parent", "Always use FlatId");
     }
     
     [Fact]
@@ -137,6 +137,6 @@ public class ManifestConverterTests
 
         // Assert
         result.Slug.Should().Be("other-slug");
-        result.Parent.Should().Be("other-parent");
+        result.Parent.Should().Be("/0/collections/other-parent", "Always use FlatId");
     } 
 }

--- a/src/IIIFPresentation/API.Tests/Helpers/CollectionHelperXTests.cs
+++ b/src/IIIFPresentation/API.Tests/Helpers/CollectionHelperXTests.cs
@@ -162,7 +162,8 @@ public class CollectionHelperXTests
     [Theory]
     [InlineData(ResourceType.StorageCollection)]
     [InlineData(ResourceType.IIIFCollection)]
-    public void GenerateFlatParentId_Correct_Collection(ResourceType resourceType)
+    [InlineData(ResourceType.IIIFManifest)]
+    public void GenerateFlatParentId_Correct(ResourceType resourceType)
     {
         // Arrange
         var hierarchy = new Hierarchy
@@ -177,24 +178,6 @@ public class CollectionHelperXTests
 
         // Assert
         id.Should().Be("http://base/0/collections/parent");
-    }
-    
-    [Fact]
-    public void GenerateFlatParentId_Correct_Manifest()
-    {
-        // Arrange
-        var hierarchy = new Hierarchy
-        {
-            Slug = "slug",
-            Parent = "parent",
-            Type = ResourceType.IIIFManifest
-        };
-
-        // Act
-        var id = hierarchy.GenerateFlatParentId(urlRoots);
-
-        // Assert
-        id.Should().Be("http://base/0/manifests/parent");
     }
     
     [Fact]

--- a/src/IIIFPresentation/API.Tests/Infrastructure/Validation/PresentationValidationTests.cs
+++ b/src/IIIFPresentation/API.Tests/Infrastructure/Validation/PresentationValidationTests.cs
@@ -1,0 +1,54 @@
+﻿using API.Converters;
+using API.Infrastructure.Validation;
+using Models.API;
+using Models.Database.Collections;
+
+namespace API.Tests.Infrastructure.Validation;
+
+public class PresentationValidationTests
+{
+    private readonly UrlRoots urlRoots = new() { BaseUrl = "https://api.tests" };
+    
+    [Fact]
+    public void IsUriParentInvalid_False_IfNotUri()
+    {
+        // Arrange
+        var presentation = new TestPresentation { Parent = "foo" };
+        var parent = new Collection { Id = "bar" };
+        
+        // Assert
+        presentation.IsUriParentInvalid(parent, urlRoots).Should().BeFalse();
+    }
+    
+    [Fact]
+    public void IsUriParentInvalid_False_IfUriAndMatchesParent()
+    {
+        // Arrange
+        var presentation = new TestPresentation { Parent = "https://api.tests/1/collections/parent" };
+        var parent = new Collection { Id = "parent", CustomerId = 1 };
+        
+        // Assert
+        presentation.IsUriParentInvalid(parent, urlRoots).Should().BeFalse();
+    }
+    
+    [Fact]
+    public void IsUriParentInvalid_True_IfUriAndDoesNotMatchParent()
+    {
+        // Arrange
+        var presentation = new TestPresentation { Parent = "https://api.tests/not-parent" };
+        var parent = new Collection { Id = "parent", CustomerId = 1 };
+        
+        // Assert
+        presentation.IsUriParentInvalid(parent, urlRoots).Should().BeTrue();
+    }
+}
+
+public class TestPresentation : IPresentation
+{
+    public string? Slug { get; set; }
+    public string? Parent { get; set; }
+    public DateTime Created { get; set; }
+    public DateTime Modified { get; set; }
+    public string? CreatedBy { get; set; }
+    public string? ModifiedBy { get; set; }
+}

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestTests.cs
@@ -265,10 +265,10 @@ public class ModifyManifestTests: IClassFixture<PresentationAppFactory<Program>>
     }
     
     [Fact]
-    public async Task CreateManifest_Conflict_WhenParentIsInvalidHierarchicalUri()
+    public async Task CreateManifest_BadRequest_WhenParentIsInvalidHierarchicalUri()
     {
         // Arrange
-        var slug = nameof(CreateManifest_Conflict_WhenParentIsInvalidHierarchicalUri);
+        var slug = nameof(CreateManifest_BadRequest_WhenParentIsInvalidHierarchicalUri);
         var manifest = new PresentationManifest
         {
             Parent = "http://different.host/root",
@@ -283,7 +283,7 @@ public class ModifyManifestTests: IClassFixture<PresentationAppFactory<Program>>
         var error = await response.ReadAsPresentationResponseAsync<Error>();
 
         // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         error!.Detail.Should().Be("The parent collection could not be found");
         error.ErrorTypeUri.Should().Be("http://localhost/errors/ModifyCollectionType/ParentCollectionNotFound");
     }

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestTests.cs
@@ -315,7 +315,7 @@ public class ModifyManifestTests: IClassFixture<PresentationAppFactory<Program>>
         responseManifest.Modified.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(2));
         responseManifest.CreatedBy.Should().Be("Admin");
         responseManifest.Slug.Should().Be(slug);
-        responseManifest.Parent.Should().Be(RootCollection.Id);
+        responseManifest.Parent.Should().Be($"http://localhost/1/collections/{RootCollection.Id}");
     }
     
     [Fact]
@@ -345,7 +345,7 @@ public class ModifyManifestTests: IClassFixture<PresentationAppFactory<Program>>
         responseManifest.Modified.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(2));
         responseManifest.CreatedBy.Should().Be("Admin");
         responseManifest.Slug.Should().Be(slug);
-        responseManifest.Parent.Should().Be(RootCollection.Id);
+        responseManifest.Parent.Should().Be($"http://localhost/1/collections/{RootCollection.Id}");
     }
     
     [Fact]

--- a/src/IIIFPresentation/API/Converters/ManifestConverter.cs
+++ b/src/IIIFPresentation/API/Converters/ManifestConverter.cs
@@ -33,7 +33,7 @@ public static class ManifestConverter
         iiifManifest.Modified = dbManifest.Modified.Floor(DateTimeX.Precision.Second);
         iiifManifest.CreatedBy = dbManifest.CreatedBy;
         iiifManifest.ModifiedBy = dbManifest.ModifiedBy;
-        iiifManifest.Parent = hierarchy.Parent;
+        iiifManifest.Parent = hierarchy.GenerateFlatParentId(urlRoots);
         iiifManifest.Slug = hierarchy.Slug;
         iiifManifest.EnsurePresentation3Context();
         iiifManifest.EnsureContext(PresentationJsonLdContext.Context);

--- a/src/IIIFPresentation/API/Converters/ManifestConverter.cs
+++ b/src/IIIFPresentation/API/Converters/ManifestConverter.cs
@@ -4,19 +4,37 @@ using Core.IIIF;
 using IIIF;
 using IIIF.Presentation;
 using Models.API.Manifest;
+using Models.Database.Collections;
+using Models.Database.General;
 
 namespace API.Converters;
 
 public static class ManifestConverter
 {
+    /// <summary>
+    /// Update <see cref="PresentationManifest"/> with values from DB record.
+    /// </summary>
+    /// <param name="iiifManifest">Presentation Manifest to update</param>
+    /// <param name="dbManifest">Database Manifest</param>
+    /// <param name="urlRoots">Current UrlRoots instance</param>
+    /// <param name="hierarchyFactory">
+    /// Optional factory to specify <see cref="Hierarchy"/> to use to get Parent and Slug. Defaults to using .Single()
+    /// </param>
+    /// <returns></returns>
     public static PresentationManifest SetGeneratedFields(this PresentationManifest iiifManifest,
-        Models.Database.Collections.Manifest dbManifest, UrlRoots urlRoots)
+        Manifest dbManifest, UrlRoots urlRoots, Func<Manifest, Hierarchy>? hierarchyFactory = null)
     {
+        hierarchyFactory ??= manifest => manifest.Hierarchy.ThrowIfNull(nameof(manifest.Hierarchy)).Single();
+        
+        var hierarchy = hierarchyFactory(dbManifest);
+        
         iiifManifest.Id = dbManifest.GenerateFlatManifestId(urlRoots);
         iiifManifest.Created = dbManifest.Created.Floor(DateTimeX.Precision.Second);
         iiifManifest.Modified = dbManifest.Modified.Floor(DateTimeX.Precision.Second);
         iiifManifest.CreatedBy = dbManifest.CreatedBy;
         iiifManifest.ModifiedBy = dbManifest.ModifiedBy;
+        iiifManifest.Parent = hierarchy.Parent;
+        iiifManifest.Slug = hierarchy.Slug;
         iiifManifest.EnsurePresentation3Context();
         iiifManifest.EnsureContext(PresentationJsonLdContext.Context);
         

--- a/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
@@ -6,6 +6,7 @@ using API.Features.Storage.Models;
 using API.Helpers;
 using API.Infrastructure.AWS;
 using API.Infrastructure.Requests;
+using API.Infrastructure.Validation;
 using API.Settings;
 using Core;
 using Core.Helpers;
@@ -62,8 +63,7 @@ public class CreateCollectionHandler(
         if (parentCollection == null) return ErrorHelper.NullParentResponse<PresentationCollection>();
 
         // If full URI was used, verify it indeed is pointing to the resolved parent collection
-        if (Uri.IsWellFormedUriString(request.Collection.Parent, UriKind.Absolute)
-            && !parentCollection.GenerateFlatCollectionId(request.UrlRoots).Equals(request.Collection.Parent))
+        if (request.Collection.IsUriParentInvalid(parentCollection, request.UrlRoots))
             return ErrorHelper.NullParentResponse<PresentationCollection>();
         
         string id;

--- a/src/IIIFPresentation/API/Features/Storage/Requests/UpsertCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/UpsertCollection.cs
@@ -6,6 +6,7 @@ using API.Helpers;
 using API.Infrastructure.AWS;
 using API.Infrastructure.Helpers;
 using API.Infrastructure.Requests;
+using API.Infrastructure.Validation;
 using API.Settings;
 using Core;
 using Core.Exceptions;
@@ -82,8 +83,7 @@ public class UpsertCollectionHandler(
             
             if (parentCollection == null) return ErrorHelper.NullParentResponse<PresentationCollection>();
             // If full URI was used, verify it indeed is pointing to the resolved parent collection
-            if (Uri.IsWellFormedUriString(request.Collection.Parent, UriKind.Absolute)
-                && !parentCollection.GenerateFlatCollectionId(request.UrlRoots).Equals(request.Collection.Parent))
+            if (request.Collection.IsUriParentInvalid(parentCollection, request.UrlRoots))
                 return ErrorHelper.NullParentResponse<PresentationCollection>();
 
             databaseCollection = new Collection
@@ -145,8 +145,7 @@ public class UpsertCollectionHandler(
                 if (parentCollection == null) return ErrorHelper.NullParentResponse<PresentationCollection>();
 
                 // If full URI was used, verify it indeed is pointing to the resolved parent collection
-                if (Uri.IsWellFormedUriString(request.Collection.Parent, UriKind.Absolute)
-                    && !parentCollection.GenerateFlatCollectionId(request.UrlRoots).Equals(request.Collection.Parent))
+                if (request.Collection.IsUriParentInvalid(parentCollection, request.UrlRoots)) 
                     return ErrorHelper.NullParentResponse<PresentationCollection>();
 
                 parentId = parentCollection.Id;

--- a/src/IIIFPresentation/API/Helpers/CollectionHelperX.cs
+++ b/src/IIIFPresentation/API/Helpers/CollectionHelperX.cs
@@ -43,10 +43,10 @@ public static class CollectionHelperX
         $"{urlRoots.BaseUrl}/{hierarchy.CustomerId}/{hierarchy.Type.GetSlug()}/{hierarchy.ResourceId}";
     
     /// <summary>
-    /// Get flat id for hierarchy parent 
+    /// Get flat id for parent of <see cref="Hierarchy"/> 
     /// </summary>
     public static string GenerateFlatParentId(this Hierarchy hierarchy, UrlRoots urlRoots) =>
-        $"{urlRoots.BaseUrl}/{hierarchy.CustomerId}/{hierarchy.Type.GetSlug()}/{hierarchy.Parent}";
+        $"{urlRoots.BaseUrl}/{hierarchy.CustomerId}/{CollectionsSlug}/{hierarchy.Parent}";
     
     public static string GenerateFlatCollectionViewId(this Collection collection, UrlRoots urlRoots, 
         int currentPage, int pageSize, string? orderQueryParam) =>

--- a/src/IIIFPresentation/API/Infrastructure/Validation/PresentationValidation.cs
+++ b/src/IIIFPresentation/API/Infrastructure/Validation/PresentationValidation.cs
@@ -1,0 +1,20 @@
+﻿using API.Converters;
+using API.Helpers;
+using Models.API;
+using Models.Database.Collections;
+
+namespace API.Infrastructure.Validation;
+
+public static class PresentationValidation
+{
+    /// <summary>
+    /// If parent is full URI, verify it indeed is pointing to the resolved parent collection
+    /// </summary>
+    /// <param name="presentation">Current <see cref="IPresentation"/> object</param>
+    /// <param name="parent">Parent <see cref="Collection"/> object</param>
+    /// <param name="urlRoots">Current <see cref="UrlRoots"/> object</param>
+    /// <returns>true if parent and invalid URI, else false</returns>
+    public static bool IsUriParentInvalid(this IPresentation presentation, Collection parent, UrlRoots urlRoots) 
+        => Uri.IsWellFormedUriString(presentation.Parent, UriKind.Absolute)
+           && !parent.GenerateFlatCollectionId(urlRoots).Equals(presentation.Parent);
+}


### PR DESCRIPTION
Follows on from #116 - which was rebased onto `main` after #110 had been merged. The latter introduced logic for validating hierarchical parent, this change adds that to `Manifest` handling and refactors to a common helper.

Introduces new `IPresentation.IsUriParentInvalid()` helper which encapsulates this logic.

Also resolves issue where `Manifest.Parent` was returning Id only, rather than Flat path.