### PR TITLE
Better error handling when deserializing IIIF Json

### DIFF
--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestTests.cs
@@ -91,18 +91,20 @@ public class ModifyManifestTests: IClassFixture<PresentationAppFactory<Program>>
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
     
-    [Fact]
-    public async Task CreateManifest_BadRequest_IfInvalid()
+    [Theory]
+    [InlineData("{\"id\":\"123", "Unterminated string property")]
+    [InlineData("{\"id\":\"123\"", "Missing JSON closing bracket")]
+    public async Task CreateManifest_BadRequest_IfInvalid(string invalidJson, string because)
     {
         // Arrange
         var requestMessage =
-            HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Post, $"{Customer}/manifests", "{\"id\":\"123");
+            HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Post, $"{Customer}/manifests", invalidJson);
         
         // Act
         var response = await httpClient.AsCustomer(1).SendAsync(requestMessage);
 
         // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest, because);
     }
     
     [Fact]

--- a/src/IIIFPresentation/Core/IIIF/IIIFResponseX.cs
+++ b/src/IIIFPresentation/Core/IIIF/IIIFResponseX.cs
@@ -41,7 +41,7 @@ public static class IIIFResponseX
             serializer.Populate(jsonReader, result);
             return result;
         }
-        catch (JsonReaderException)
+        catch (JsonException)
         {
             return default;
         }


### PR DESCRIPTION
Different invalid payloads could result in different exception types from Newtonsoft. e.g.

`{"id": "123` - `JsonReaderException`
`{"id": "123"` - `JsonSerializationException`

Catch base exception `JsonException` instead as both inherit from this.

Change introduced in #116