### PR TITLE
Fix bug preventing deeper nested hierach collection creation

### DIFF
--- a/src/IIIFPresentation/API/Features/Storage/Requests/PostHierarchicalCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/PostHierarchicalCollection.cs
@@ -55,7 +55,7 @@ public class PostHierarchicalCollectionHandler(
         
         var splitSlug = request.Slug.Split('/');
 
-        var parentSlug = string.Join(string.Empty, splitSlug.Take(..^1));
+        var parentSlug = string.Join("/", splitSlug.Take(..^1));
         var parentCollection =
             await dbContext.RetrieveHierarchy(request.CustomerId, parentSlug, cancellationToken);
         


### PR DESCRIPTION
Fixes #119. Issue was how slug was concatenated, slash was missing meaning all path segments were concatenated. Using examples from ticket:

* `/nest_test_a` - resulted in looking for parent with slug `""` (root)
* `/nest_test_a/nest_test_b` - resulted in looking for parent with slug `"nest_test_a"` (created above).
* `/nest_test_a/nest_test_b/nest_test_c` - resulted in looking for parent with slug `"nest_test_bnest_test_c"` as segments were joined with `string.Empty` which was not found. Fix is to concatenate elements with `"/"` so we now look for `"nest_test_b/nest_test_c"`

Also added missing tests for `RetrieveHierarchy`