### PR TITLE
Fix bug where hierarchical collection has no context

### DIFF
--- a/src/IIIFPresentation/API/Infrastructure/AWS/IIIFS3Service.cs
+++ b/src/IIIFPresentation/API/Infrastructure/AWS/IIIFS3Service.cs
@@ -2,11 +2,13 @@
 using API.Settings;
 using AWS.S3;
 using AWS.S3.Models;
+using Core.Helpers;
 using IIIF.Presentation;
 using IIIF.Presentation.V3;
 using IIIF.Serialisation;
 using Microsoft.Extensions.Options;
 using Models.Database.Collections;
+using Models.Infrastucture;
 
 namespace API.Infrastructure.AWS;
 
@@ -34,5 +36,15 @@ public class IIIFS3Service(IBucketWriter bucketWriter, ILogger<IIIFS3Service> lo
         // writing data to S3
         iiifResource.Id = flatId;
         iiifResource.EnsurePresentation3Context();
+        
+        RemovePresentationBehaviours(iiifResource);
+    }
+
+    private static void RemovePresentationBehaviours(ResourceBase iiifResource)
+    {
+        var toRemove = new[] { Behavior.IsStorageCollection, Behavior.IsPublic };
+        if (iiifResource.Behavior.IsNullOrEmpty()) return;
+        
+        iiifResource.Behavior = iiifResource.Behavior.Where(b => !toRemove.Contains(b)).ToList();
     }
 }

--- a/src/IIIFPresentation/Core.Tests/Helpers/CollectionXTests.cs
+++ b/src/IIIFPresentation/Core.Tests/Helpers/CollectionXTests.cs
@@ -1,0 +1,31 @@
+﻿using Core.Helpers;
+using FluentAssertions;
+
+namespace Core.Tests.Helpers;
+
+public class CollectionXTests
+{
+    [Fact]
+    public void IsNullOrEmpty_True_IfNull()
+    {
+        List<int> coll = null;
+
+        coll.IsNullOrEmpty().Should().BeTrue();
+    }
+    
+    [Fact]
+    public void IsNullOrEmpty_True_IfEmpty()
+    {
+        var coll = new List<int>();
+
+        coll.IsNullOrEmpty().Should().BeTrue();
+    }
+    
+    [Fact]
+    public void IsNullOrEmpty_False_IfHasValues()
+    {
+        var coll = new List<int> {2};
+
+        coll.IsNullOrEmpty().Should().BeFalse();
+    }
+}

--- a/src/IIIFPresentation/Core/Helpers/CollectionX.cs
+++ b/src/IIIFPresentation/Core/Helpers/CollectionX.cs
@@ -1,0 +1,13 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Core.Helpers;
+
+public static class CollectionX
+{
+    /// <summary>
+    /// Check if IList is null or empty
+    /// </summary>
+    /// <returns>true if null or empty, else false</returns>
+    public static bool IsNullOrEmpty<T>([NotNullWhen(false)] this IList<T>? collection)
+        => collection == null || collection.Count == 0;
+}


### PR DESCRIPTION
Set `@context` and remove any known presentation behaviours when writing to S3.

Also modified `PostHierarchicalCollection` to use some reusable methods/classes introduced in previous PRs (ie `.ConvertCollectionToIIIF()` and `IIIFS3Service`).

Fixes #125