### PR TITLE
Add behavior to items in collection retrieval calls

### DIFF
--- a/src/IIIFPresentation/API.Tests/Converters/CollectionConverterTests.cs
+++ b/src/IIIFPresentation/API.Tests/Converters/CollectionConverterTests.cs
@@ -189,7 +189,12 @@ public class CollectionConverterTests
                 CollectionId = "some-child",
                 CustomerId = 1,
                 Slug = "root",
-                Type = ResourceType.StorageCollection
+                Type = ResourceType.StorageCollection,
+                Collection = new Collection
+                {
+                    Id = "someId",
+                    IsPublic = true,
+                }
             }
         };
         

--- a/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
@@ -40,6 +40,8 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         collection.Items.Count.Should().Be(TotalDatabaseChildItems);
         var firstItem = (Collection)collection.Items[0];
         firstItem.Id.Should().Be("http://localhost/1/first-child");
+        firstItem.Behavior.Should().Contain("public-iiif");
+        firstItem.Behavior.Should().Contain("storage-collection");
     }
     
     [Fact]

--- a/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
@@ -225,7 +225,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         secondItem.Behavior.Should().NotContain("public-iiif");
         secondItem.Behavior.Should().Contain("storage-collection");
         var thirdItem = (Collection)collection.Items[2];
-        thirdItem.Id.Should().Be("http://localhost/1/iiifCollection");
+        thirdItem.Id.Should().Be("http://localhost/1/collections/IiifCollection");
         thirdItem.Behavior.Should().Contain("public-iiif");
         thirdItem.Behavior.Should().NotContain("storage-collection");
     }

--- a/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
@@ -40,12 +40,10 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         collection.Items.Count.Should().Be(TotalDatabaseChildItems);
         var firstItem = (Collection)collection.Items[0];
         firstItem.Id.Should().Be("http://localhost/1/first-child");
-        firstItem.Behavior.Should().Contain("public-iiif");
-        firstItem.Behavior.Should().Contain("storage-collection");
+        firstItem.Behavior.Should().BeNull();
         var secondItem = (Collection)collection.Items[1];
         secondItem.Id.Should().Be("http://localhost/1/iiif-collection");
-        secondItem.Behavior.Should().Contain("public-iiif");
-        secondItem.Behavior.Should().NotContain("storage-collection");
+        secondItem.Behavior.Should().BeNull();
     }
     
     [Fact]
@@ -218,6 +216,18 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         collection.TotalItems.Should().Be(TotalDatabaseChildItems);
         collection.CreatedBy.Should().Be("admin");
         collection.Behavior.Should().Contain("public-iiif");
+        var firstItem = (Collection)collection.Items[0];
+        firstItem.Id.Should().Be("http://localhost/1/collections/FirstChildCollection");
+        firstItem.Behavior.Should().Contain("public-iiif");
+        firstItem.Behavior.Should().Contain("storage-collection");
+        var secondItem = (Collection)collection.Items[1];
+        secondItem.Id.Should().Be("http://localhost/1/collections/NonPublic");
+        secondItem.Behavior.Should().NotContain("public-iiif");
+        secondItem.Behavior.Should().Contain("storage-collection");
+        var thirdItem = (Collection)collection.Items[2];
+        thirdItem.Id.Should().Be("http://localhost/1/iiifCollection");
+        thirdItem.Behavior.Should().Contain("public-iiif");
+        thirdItem.Behavior.Should().NotContain("storage-collection");
     }
     
     [Fact]

--- a/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
@@ -42,6 +42,10 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         firstItem.Id.Should().Be("http://localhost/1/first-child");
         firstItem.Behavior.Should().Contain("public-iiif");
         firstItem.Behavior.Should().Contain("storage-collection");
+        var secondItem = (Collection)collection.Items[1];
+        secondItem.Id.Should().Be("http://localhost/1/iiif-collection");
+        secondItem.Behavior.Should().Contain("public-iiif");
+        secondItem.Behavior.Should().NotContain("storage-collection");
     }
     
     [Fact]

--- a/src/IIIFPresentation/API/Converters/CollectionConverter.cs
+++ b/src/IIIFPresentation/API/Converters/CollectionConverter.cs
@@ -70,12 +70,15 @@ public static class CollectionConverter
             return new Manifest { Id = id };
         }
 
-        return new Collection
+        var collection = new Collection
         {
             Id = id,
             Label = hierarchy.Collection?.Label,
-            Behavior = GenerateBehavior(hierarchy.Collection!)
         };
+
+        if (flatId) collection.Behavior = GenerateBehavior(hierarchy.Collection!);
+            
+        return collection;
     }
 
     /// <summary>

--- a/src/IIIFPresentation/API/Converters/CollectionConverter.cs
+++ b/src/IIIFPresentation/API/Converters/CollectionConverter.cs
@@ -73,7 +73,8 @@ public static class CollectionConverter
         return new Collection
         {
             Id = id,
-            Label = hierarchy.Collection?.Label
+            Label = hierarchy.Collection?.Label,
+            Behavior = GenerateBehavior(hierarchy.Collection!)
         };
     }
 


### PR DESCRIPTION
This PR adds `behavior sections` to items in retrieve by flat URL's so that storage collections and IIIF collections can be distinguished by the UI

I.E.:

```json
{
    "publicId": "https://localhost:7230/1",
    "slug": "",
    "items": [
        {
            "id": "https://localhost:7230/1/collections/swq5jt88zov1p1pbbpa",
            "type": "Collection",
            "label": {
                "en": [
                    "post testing"
                ]
            }
        }
    ]
}
```
becomes

```json
{
    "publicId": "https://localhost:7230/1",
    "slug": "",
    "items": [
        {
            "id": "https://localhost:7230/1/collections/swq5jt88zov1p1pbbpa",
            "type": "Collection",
            "label": {
                "en": [
                    "post testing"
                ]
            },
            "behavior": [
                "public-iiif",
                "storage-collection"
            ]
        }
    ]
}
```