### PR TITLE
Handle customer created

### DIFF
--- a/src/IIIFPresentation/API.Tests/Features/CustomerCreation/CustomerCreationMessageHandlerTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/CustomerCreation/CustomerCreationMessageHandlerTests.cs
@@ -1,0 +1,81 @@
+﻿using API.Features.CustomerCreation;
+using API.Tests.Integration.Infrastructure;
+using AWS.SQS;
+using Microsoft.Extensions.Logging.Abstractions;
+using Models.Database.General;
+using Repository;
+using Test.Helpers.Integration;
+
+namespace API.Tests.Features.CustomerCreation;
+
+[Trait("Category", "Database")]
+[Collection(CollectionDefinitions.DatabaseCollection.CollectionName)]
+public class CustomerCreationMessageHandlerTests
+{
+    private readonly PresentationContext dbContext;
+    private readonly CustomerCreatedMessageHandler sut;
+
+    public CustomerCreationMessageHandlerTests(PresentationContextFixture dbFixture)
+    {
+        dbContext = dbFixture.DbContext;
+        sut = new CustomerCreatedMessageHandler(dbFixture.DbContext, new NullLogger<CustomerCreatedMessageHandler>());
+    }
+    
+    [Fact]
+    public async Task HandleMessage_False_IfMessageInvalid()
+    {
+        // Arrange
+        var message = GetMessage("not-json");
+        
+        // Act
+        (await sut.HandleMessage(message, CancellationToken.None)).Should().BeFalse();
+    }
+    
+    [Fact]
+    public async Task HandleMessage_True_IfRootExistsForCustomer()
+    {
+        // Arrange
+        dbContext.Collections.Add(GetCollection(-10));
+        await dbContext.SaveChangesAsync();
+        var message = GetMessage("{\"name\":\"test\",\"id\":-10}");
+        
+        // Act
+        (await sut.HandleMessage(message, CancellationToken.None)).Should().BeTrue();
+    }
+    
+    [Fact]
+    public async Task HandleMessage_True_AndCreatesRoot_IfDoesnotExists()
+    {
+        // Arrange
+        var message = GetMessage("{\"name\":\"test\",\"id\":-100}");
+        
+        // Act
+        (await sut.HandleMessage(message, CancellationToken.None)).Should().BeTrue();
+
+        var root = await dbContext.Collections.FindAsync("root", -100);
+        root.Should().NotBeNull();
+        var hierarchy = root.Hierarchy.Single();
+        hierarchy.Parent.Should().BeNull();
+        hierarchy.Slug.Should().BeEmpty();
+        hierarchy.Canonical.Should().BeTrue();
+        hierarchy.Type.Should().Be(ResourceType.StorageCollection);
+    }
+
+    private static QueueMessage GetMessage(string body) => new(body, new Dictionary<string, string>(), "foo");
+
+    private static Models.Database.Collections.Collection GetCollection(int customerId)
+        => new()
+        {
+            CustomerId = customerId,
+            Id = "root",
+            Hierarchy =
+            [
+                new Hierarchy
+                {
+                    Slug = string.Empty,
+                    Canonical = true,
+                    Type = ResourceType.StorageCollection,
+                }
+            ]
+        };
+}

--- a/src/IIIFPresentation/API/Features/CustomerCreation/CustomerCreatedListenerService.cs
+++ b/src/IIIFPresentation/API/Features/CustomerCreation/CustomerCreatedListenerService.cs
@@ -1,0 +1,26 @@
+﻿using AWS.Settings;
+using AWS.SQS;
+using Core.Helpers;
+using Microsoft.Extensions.Options;
+
+namespace API.Features.CustomerCreation;
+
+/// <summary>
+/// Background service that monitors SQS queue for incoming messages that customer has been created
+/// </summary>
+public class CustomerCreatedListenerService(
+    SqsListener sqsListener,
+    IOptions<AWSSettings> awsSettings,
+    ILogger<CustomerCreatedListenerService> logger)
+    : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var customerCreatedQueueName =
+            awsSettings.Value.SQS.CustomerCreatedQueueName?.ThrowIfNullOrWhiteSpace("queueName")!;
+
+        logger.LogInformation("CustomerCreatedListenerService ExecuteAsync. Listening to {QueueName}",
+            customerCreatedQueueName);
+        await sqsListener.StartListenLoop<CustomerCreatedMessageHandler>(customerCreatedQueueName, stoppingToken);
+    }
+}

--- a/src/IIIFPresentation/API/Features/CustomerCreation/CustomerCreatedMessage.cs
+++ b/src/IIIFPresentation/API/Features/CustomerCreation/CustomerCreatedMessage.cs
@@ -1,0 +1,3 @@
+namespace API.Features.CustomerCreation;
+
+public record CustomerCreatedMessage(int Id, string Name);

--- a/src/IIIFPresentation/API/Features/CustomerCreation/CustomerCreatedMessageHandler.cs
+++ b/src/IIIFPresentation/API/Features/CustomerCreation/CustomerCreatedMessageHandler.cs
@@ -1,0 +1,87 @@
+﻿using System.Text.Json;
+using API.Auth;
+using AWS.SQS;
+using Core.Helpers;
+using IIIF.Presentation.V3.Strings;
+using Microsoft.EntityFrameworkCore;
+using Models.Database.Collections;
+using Models.Database.General;
+using Repository;
+
+namespace API.Features.CustomerCreation;
+
+/// <summary>
+/// Handler for customer created messages
+/// </summary>
+public class CustomerCreatedMessageHandler(
+    PresentationContext dbContext,
+    ILogger<CustomerCreatedMessageHandler> logger)
+    : IMessageHandler
+{
+    private static readonly JsonSerializerOptions JsonSerializerOptions = new(JsonSerializerDefaults.Web);
+
+    public async Task<bool> HandleMessage(QueueMessage message, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var customerCreatedMessage = DeserializeMessage(message);
+
+            await EnsureRootCollection(customerCreatedMessage, cancellationToken);
+            
+            return true;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error handling customer-created message {MessageId}", message.MessageId);
+        }
+
+        return false;
+    }
+
+    private async Task EnsureRootCollection(CustomerCreatedMessage customerCreatedMessage, CancellationToken cancellationToken)
+    {
+        var customerId = customerCreatedMessage.Id;
+        
+        logger.LogInformation("Ensuring new customer {CustomerId} has root collection", customerId);
+
+        if (await dbContext.Collections.AnyAsync(
+                c => c.Id == KnownCollections.RootCollection && c.CustomerId == customerId,
+                cancellationToken))
+        {
+            logger.LogInformation("Customer {CustomerId} already has root collection, no-op", customerId);
+            return;
+        }
+        
+        var dateCreated = DateTime.UtcNow;
+        var collection = new Collection
+        {
+            Id = KnownCollections.RootCollection,
+            UsePath = true,
+            Created = dateCreated,
+            Modified = dateCreated,
+            CreatedBy = Authorizer.GetUser(),
+            CustomerId = customerId,
+            IsPublic = true,
+            IsStorageCollection = true,
+            Label = new LanguageMap("en", "(repository root)"),
+            Hierarchy =
+            [
+                new Hierarchy
+                {
+                    Slug = string.Empty,
+                    Canonical = true,
+                    Type = ResourceType.StorageCollection,
+                }
+            ]
+        };
+
+        await dbContext.Collections.AddAsync(collection, cancellationToken);
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    private static CustomerCreatedMessage DeserializeMessage(QueueMessage message)
+    {
+        var deserialized = JsonSerializer.Deserialize<CustomerCreatedMessage>(message.Body, JsonSerializerOptions);
+        return deserialized.ThrowIfNull(nameof(deserialized));
+    }
+}

--- a/src/IIIFPresentation/API/Features/Storage/Requests/DeleteCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/DeleteCollection.cs
@@ -18,14 +18,12 @@ public class DeleteCollectionHandler(
     ILogger<DeleteCollectionHandler> logger)
     : IRequestHandler<DeleteCollection, ResultMessage<DeleteResult, DeleteCollectionType>>
 {
-    private const string RootCollection = "root";
-    
     public async Task<ResultMessage<DeleteResult, DeleteCollectionType>> Handle(DeleteCollection request, CancellationToken cancellationToken)
     {
         logger.LogDebug("Deleting collection {CollectionId} for customer {CustomerId}", request.CollectionId,
             request.CustomerId);
         
-        if (request.CollectionId.Equals(RootCollection, StringComparison.OrdinalIgnoreCase))
+        if (request.CollectionId.Equals(KnownCollections.RootCollection, StringComparison.OrdinalIgnoreCase))
         {
             return new ResultMessage<DeleteResult, DeleteCollectionType>(DeleteResult.BadRequest,
                 DeleteCollectionType.CannotDeleteRootCollection, "Cannot delete a root collection");

--- a/src/IIIFPresentation/API/Infrastructure/ServiceCollectionX.cs
+++ b/src/IIIFPresentation/API/Infrastructure/ServiceCollectionX.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using API.Features.CustomerCreation;
 using API.Infrastructure.AWS;
 using API.Infrastructure.IdGenerator;
 using API.Infrastructure.Mediatr.Behaviours;
@@ -6,6 +7,8 @@ using API.Infrastructure.Requests.Pipelines;
 using API.Settings;
 using AWS.Configuration;
 using AWS.S3;
+using AWS.Settings;
+using AWS.SQS;
 using MediatR;
 using Repository;
 using Sqids;
@@ -59,14 +62,27 @@ public static class ServiceCollectionX
     /// Add required AWS services
     /// </summary>
     public static IServiceCollection AddAws(this IServiceCollection services,
-        IConfiguration configuration, IWebHostEnvironment webHostEnvironment)
+        IConfiguration configuration, IWebHostEnvironment webHostEnvironment, AWSSettings aws)
     {
         services
             .AddSingleton<IBucketReader, S3BucketReader>()
             .AddSingleton<IBucketWriter, S3BucketWriter>()
-            .AddSingleton<IIIFS3Service>()
+            .AddSingleton<IIIFS3Service>();
+
+        var awsBuilder = services
             .SetupAWS(configuration, webHostEnvironment)
             .WithAmazonS3();
+
+        if (!string.IsNullOrEmpty(aws.SQS.CustomerCreatedQueueName))
+        {
+            services
+                .AddSingleton<SqsListener>()
+                .AddSingleton<SqsQueueUtilities>()
+                .AddHostedService<CustomerCreatedListenerService>()
+                .AddScoped<CustomerCreatedMessageHandler>();
+
+            awsBuilder.WithAmazonSQS();
+        }
 
         return services;
     }

--- a/src/IIIFPresentation/API/KnownCollections.cs
+++ b/src/IIIFPresentation/API/KnownCollections.cs
@@ -1,0 +1,9 @@
+﻿namespace API;
+
+public static class KnownCollections
+{
+    /// <summary>
+    /// The id of root collection
+    /// </summary>
+    public const string RootCollection = "root";
+}

--- a/src/IIIFPresentation/API/Program.cs
+++ b/src/IIIFPresentation/API/Program.cs
@@ -4,6 +4,7 @@ using API.Features.Storage.Validators;
 using API.Infrastructure;
 using API.Infrastructure.Helpers;
 using API.Settings;
+using AWS.Settings;
 using FluentValidation;
 using Microsoft.AspNetCore.HttpOverrides;
 using Newtonsoft.Json;
@@ -41,6 +42,8 @@ builder.Services.Configure<DlcsSettings>(dlcsSettings);
 var cacheSettings = builder.Configuration.GetSection(nameof(CacheSettings)).Get<CacheSettings>() ?? new CacheSettings();
 var dlcs = dlcsSettings.Get<DlcsSettings>()!;
 
+var aws = builder.Configuration.GetSection("AWS").Get<AWSSettings>() ?? new AWSSettings();
+
 builder.Services.AddDelegatedAuthHandler(dlcs, opts =>
 {
     opts.Realm = "DLCS-API";
@@ -52,7 +55,7 @@ builder.Services.AddSingleton<IETagManager, ETagManager>();
 builder.Services.ConfigureMediatR();
 builder.Services.ConfigureIdGenerator();
 builder.Services.AddHealthChecks();
-builder.Services.AddAws(builder.Configuration, builder.Environment);
+builder.Services.AddAws(builder.Configuration, builder.Environment, aws);
 builder.Services.Configure<ForwardedHeadersOptions>(opts =>
 {
     opts.ForwardedHeaders = ForwardedHeaders.XForwardedHost | ForwardedHeaders.XForwardedProto;

--- a/src/IIIFPresentation/AWS/AWS.csproj
+++ b/src/IIIFPresentation/AWS/AWS.csproj
@@ -14,6 +14,7 @@
       <FrameworkReference Include="Microsoft.AspNetCore.App" />
       <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.301" />
       <PackageReference Include="AWSSDK.S3" Version="3.7.403.3" />
+      <PackageReference Include="AWSSDK.SQS" Version="3.7.400.46" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     </ItemGroup>
 

--- a/src/IIIFPresentation/AWS/Configuration/AWSConfiguration.cs
+++ b/src/IIIFPresentation/AWS/Configuration/AWSConfiguration.cs
@@ -1,6 +1,7 @@
 using Amazon;
 using Amazon.Runtime;
 using Amazon.S3;
+using Amazon.SQS;
 using AWS.Settings;
 using Core.Helpers;
 using Microsoft.Extensions.Configuration;
@@ -82,6 +83,36 @@ public class AwsBuilder
         else
         {
             services.AddAWSService<IAmazonS3>(lifetime);
+        }
+        
+        return this;
+    }
+    
+    /// <summary>
+    /// Add <see cref="IAmazonSQS"/> to service collection with specified lifetime.
+    /// </summary>
+    /// <param name="lifetime">ServiceLifetime for dependency</param>
+    /// <returns>Current <see cref="AwsBuilder"/> instance</returns>
+    public AwsBuilder WithAmazonSQS(ServiceLifetime lifetime = ServiceLifetime.Singleton)
+    {
+        if (useLocalStack)
+        {
+            var serviceDescriptor = ServiceDescriptor.Describe(typeof(IAmazonSQS), _ =>
+            {
+                var amazonS3Config = new AmazonSQSConfig
+                {
+                    UseHttp = true,
+                    RegionEndpoint = RegionEndpoint.USEast1,
+                    ServiceURL =
+                        awsSettings.SQS?.ServiceUrl.ThrowIfNullOrWhiteSpace(nameof(awsSettings.SQS.ServiceUrl)),
+                };
+                return new AmazonSQSClient(new BasicAWSCredentials("foo", "bar"), amazonS3Config);
+            }, lifetime);
+            services.Add(serviceDescriptor);
+        }
+        else
+        {
+            services.AddAWSService<IAmazonSQS>(lifetime);
         }
         
         return this;

--- a/src/IIIFPresentation/AWS/SQS/IMessageHandler.cs
+++ b/src/IIIFPresentation/AWS/SQS/IMessageHandler.cs
@@ -1,0 +1,12 @@
+﻿namespace AWS.SQS;
+
+/// <summary>
+/// Marker interface for SQS message handling logic 
+/// </summary>
+public interface IMessageHandler
+{
+    /// <summary>
+    /// Handle message, returning success/failure 
+    /// </summary>
+    Task<bool> HandleMessage(QueueMessage message, CancellationToken cancellationToken);
+}

--- a/src/IIIFPresentation/AWS/SQS/QueueMessage.cs
+++ b/src/IIIFPresentation/AWS/SQS/QueueMessage.cs
@@ -1,0 +1,20 @@
+﻿namespace AWS.SQS;
+
+/// <summary>
+/// Generic representation of message pulled from queue.
+/// </summary>
+public class QueueMessage
+{
+    public string Body { get; }
+
+    public Dictionary<string, string> Attributes { get; }
+        
+    public string MessageId { get; }
+
+    public QueueMessage(string body, Dictionary<string, string> attributes, string messageId)
+    {
+        Body = body;
+        Attributes = attributes;
+        MessageId = messageId;
+    }
+}

--- a/src/IIIFPresentation/AWS/SQS/SqsListener.cs
+++ b/src/IIIFPresentation/AWS/SQS/SqsListener.cs
@@ -1,0 +1,138 @@
+﻿using System.Text.Json.Nodes;
+using Amazon.SQS;
+using Amazon.SQS.Model;
+using AWS.Settings;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace AWS.SQS;
+
+/// <summary>
+/// Subscribes to SQS, using long polling to receive messages
+/// </summary>
+public class SqsListener
+{
+    private readonly IAmazonSQS client;
+    private readonly AWSSettings options;
+    private readonly IServiceScopeFactory serviceScopeFactory;
+    private readonly SqsQueueUtilities queueUtilities;
+    private readonly ILogger<SqsListener> logger;
+
+    // if that differs IngestHandler will need to be something smarter
+    public SqsListener(
+        IAmazonSQS client, 
+        IOptions<AWSSettings> options,
+        IServiceScopeFactory serviceScopeFactory,
+        SqsQueueUtilities queueUtilities,
+        ILogger<SqsListener> logger)
+    {
+        this.client = client;
+        this.options = options.Value;
+        this.serviceScopeFactory = serviceScopeFactory;
+        this.queueUtilities = queueUtilities;
+        this.logger = logger;
+    }
+        
+    /// <summary>
+    /// Start listening to specified queue.
+    /// On receipt a handler of type {T} is created DI container and used to handle request.
+    /// On successful handle message is deleted from queue.
+    /// </summary>
+    /// <param name="queueName">Queue to monitor</param>
+    /// <param name="cancellationToken">Current cancellation token</param>
+    /// <typeparam name="T">Type of message handler</typeparam>
+    public async Task StartListenLoop<T>(string queueName, CancellationToken cancellationToken)
+        where T : IMessageHandler
+    {
+        var queueUrl = await queueUtilities.GetQueueUrl(queueName, cancellationToken);
+
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            ReceiveMessageResponse? response = null;
+            int messageCount = 0;
+            try
+            {
+                response = await GetMessagesFromQueue(queueUrl, cancellationToken);
+                messageCount = response.Messages?.Count ?? 0;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error receiving messages on queue {Queue}", queueUrl);
+            }
+
+            if (messageCount == 0) continue;
+
+            try
+            {
+                foreach (var message in response!.Messages!)
+                {
+                    if (cancellationToken.IsCancellationRequested) return;
+
+                    var processed = await HandleMessage<T>(queueUrl, message, cancellationToken);
+
+                    if (processed)
+                    {
+                        await DeleteMessage(queueUrl, message, cancellationToken);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error in listen loop for queue {Queue}", queueUrl);
+            }
+        }
+    }
+
+    private Task<ReceiveMessageResponse> GetMessagesFromQueue(string queueUrl, CancellationToken cancellationToken)
+        => client.ReceiveMessageAsync(new ReceiveMessageRequest
+        {
+            QueueUrl = queueUrl,
+            WaitTimeSeconds = options.SQS.WaitTimeSecs,
+            MaxNumberOfMessages = options.SQS.MaxNumberOfMessages,
+        }, cancellationToken);
+
+    private async Task<bool> HandleMessage<T>(string queueUrl, Message message, CancellationToken cancellationToken)
+        where T : IMessageHandler
+    {
+        try
+        {
+            var queueMessage = new QueueMessage(GetJsonPayload(message), message.Attributes, message.MessageId);
+
+            // create a new scope to avoid issues with Scoped dependencies
+            using var listenerScope = serviceScopeFactory.CreateScope();
+            var handler = listenerScope.ServiceProvider.GetRequiredService<T>();
+
+            var processed = await handler.HandleMessage(queueMessage, cancellationToken);
+            return processed;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error handling message {MessageId} from queue {Queue}", message.MessageId,
+                queueUrl);
+            return false;
+        }
+    }
+
+    private string GetJsonPayload(Message message)
+    {
+        var messageBody = JsonNode.Parse(message.Body)!.AsObject();
+        const string messageKey = "Message";
+        if (messageBody.ContainsKey("TopicArn") && messageBody.ContainsKey(messageKey))
+        {
+            // From SNS without Raw Message Delivery
+            var value = messageBody[messageKey]!.GetValue<string>();
+            return value;
+        }
+        
+        // From SQS or SNS with Raw Message Delivery
+        return messageBody.ToString();
+    }
+
+    private Task DeleteMessage(string queueUrl, Message message, CancellationToken cancellationToken)
+        => client.DeleteMessageAsync(new DeleteMessageRequest
+        {
+            QueueUrl = queueUrl,
+            ReceiptHandle = message.ReceiptHandle
+        }, cancellationToken);
+}

--- a/src/IIIFPresentation/AWS/SQS/SqsQueueUtilities.cs
+++ b/src/IIIFPresentation/AWS/SQS/SqsQueueUtilities.cs
@@ -1,0 +1,62 @@
+﻿using Amazon.SQS;
+using Amazon.SQS.Model;
+using AWS.Settings;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace AWS.SQS;
+
+/// <summary>
+/// A collection of helper utilities for working with SQS queues
+/// </summary>
+public class SqsQueueUtilities
+{
+    private readonly IAmazonSQS client;
+    private readonly ILogger<SqsQueueUtilities> logger;
+    private readonly AWSSettings options;
+
+    public SqsQueueUtilities(
+        IAmazonSQS client,
+        IOptions<AWSSettings> options,
+        ILogger<SqsQueueUtilities> logger)
+    {
+        this.client = client;
+        this.logger = logger;
+        this.options = options.Value;
+    }
+        
+    /// <summary>
+    /// Get the URL of queue for specified name.
+    /// </summary>
+    /// <param name="queueName">Queue name to get URL for</param>
+    /// <returns>SQS URL for queue</returns>
+    public async Task<string> GetQueueUrl(string queueName, CancellationToken cancellationToken)
+    {
+        // Having this here isn't great; alternative is a different entrypoint with similar logic
+        var usingLocalStack = options.UseLocalStack;
+        var count = 0;
+
+        do
+        {
+            try
+            {
+                var result = await client.GetQueueUrlAsync(queueName, cancellationToken);
+                return result.QueueUrl;
+            }
+            catch (QueueDoesNotExistException qEx)
+            {
+                logger.LogError(qEx, "Attempt to get url for queue '{Queue}' but it doesn't exist", queueName);
+                if (!usingLocalStack) throw;
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "General error attempting to get url for queue '{Queue}'", queueName);
+                if (!usingLocalStack) throw;
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(10), cancellationToken);
+        } while (usingLocalStack && count++ < 10);
+
+        throw new ApplicationException("Using localStack but unable to get queue Id after 10 attempts");
+    }
+}

--- a/src/IIIFPresentation/AWS/Settings/AWSSettings.cs
+++ b/src/IIIFPresentation/AWS/Settings/AWSSettings.cs
@@ -11,4 +11,9 @@ public class AWSSettings
     /// S3 Settings
     /// </summary>
     public S3Settings S3 { get; set; } = new();
+    
+    /// <summary>
+    /// SQS Settings
+    /// </summary>
+    public SQSSettings SQS { get; set; } = new();
 }

--- a/src/IIIFPresentation/AWS/Settings/SQSSettings.cs
+++ b/src/IIIFPresentation/AWS/Settings/SQSSettings.cs
@@ -1,0 +1,24 @@
+namespace AWS.Settings;
+
+public class SQSSettings
+{
+    /// <summary>
+    /// Name of queue that will receive notifications when a new customer is created 
+    /// </summary>
+    public string? CustomerCreatedQueueName { get; set; }
+    
+    /// <summary>
+    /// The duration (in seconds) for which the call waits for a message to arrive in the queue before returning
+    /// </summary>
+    public int WaitTimeSecs { get; set; } = 20;
+
+    /// <summary>
+    /// The maximum number of messages to fetch from SQS in single request (valid 1-10)
+    /// </summary>
+    public int MaxNumberOfMessages { get; set; } = 10;
+    
+    /// <summary>
+    /// Service root for SQS. Ignored if not running LocalStack
+    /// </summary>
+    public string ServiceUrl { get; set; } = "http://localhost:4566/";
+}

--- a/src/IIIFPresentation/Core/Helpers/GuardX.cs
+++ b/src/IIIFPresentation/Core/Helpers/GuardX.cs
@@ -52,7 +52,7 @@ public static class GuardX
     /// <param name="argName">Name of argument.</param>
     /// <returns>Passed string, if not null.</returns>
     /// <exception cref="ArgumentNullException">Thrown if provided argument is null.</exception>
-    public static string ThrowIfNullOrWhiteSpace(this string argument, string argName)
+    public static string ThrowIfNullOrWhiteSpace(this string? argument, string argName)
     {
         if (string.IsNullOrWhiteSpace(argument))
         {


### PR DESCRIPTION
Add SQS listener for 'customer created' notification from Protagonist, on receipt ensure a Root collection exists for customer. Implementation is basically a `BackgroundWorker` in the API project, handling logic is all in `CustomerCreatedMessageHandler`.

Lots of this PR is boilerplate for SQS listening, based on previous project.

Note that if the SQS queue name setting isn't set the background worker won't run - this can be default in dedicated instances or for local dev.

Related (publishing side) - https://github.com/dlcs/protagonist/pull/914