### PR TITLE
Set Cache-Control: no-cache for responses with an ETag

### DIFF
--- a/src/IIIFPresentation/API.Tests/Attributes/ETagCachingAttributeTests.cs
+++ b/src/IIIFPresentation/API.Tests/Attributes/ETagCachingAttributeTests.cs
@@ -111,7 +111,7 @@ public class ETagCachingAttributeTests
         });
 
         // Assert
-        Assert.Single(context.HttpContext.Response.Headers.CacheControl.ToList(), "max-age=10");
+        Assert.Single(context.HttpContext.Response.Headers.CacheControl, "max-age=10");
     }
     
     [Fact]
@@ -141,6 +141,6 @@ public class ETagCachingAttributeTests
         });
 
         // Assert
-        Assert.Single(context.HttpContext.Response.Headers.CacheControl.ToList(), "public, max-age=10");
+        Assert.Single(context.HttpContext.Response.Headers.CacheControl, "public, max-age=10");
     }
 }

--- a/src/IIIFPresentation/API.Tests/Attributes/ETagCachingAttributeTests.cs
+++ b/src/IIIFPresentation/API.Tests/Attributes/ETagCachingAttributeTests.cs
@@ -1,0 +1,152 @@
+using API.Attributes;
+using API.Infrastructure.Helpers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+using Microsoft.Net.Http.Headers;
+using Models.Database.Collections;
+
+namespace API.Tests.Attributes;
+
+public class ETagCachingAttributeTests
+{
+    private static ActionContext CreateActionContext(HttpContext context) => new(context, new(), new());
+
+    private static ResultExecutedContext CreateResultExecutedContext(HttpContext context) =>
+        new ResultExecutedContext(CreateActionContext(context), [], new ObjectResult(null), new object());
+
+    private static ResultExecutingContext CreateResultExecutingContext(HttpContext context) =>
+        new ResultExecutingContext(CreateActionContext(context), [], new ObjectResult(null), new object());
+
+    private class StubController : Controller;
+
+    private class StubETagManager : IETagManager
+    {
+        public int CacheTimeoutSeconds => 10;
+
+        public bool TryGetETag(string id, out string? eTag)
+        {
+            eTag = null;
+            return false;
+        }
+
+        public bool TryGetETag<T>(T resource, out string? eTag) where T : IHierarchyResource
+        {
+            eTag = null;
+            return false;
+        }
+
+        public void UpsertETag(string resourcePath, string eTag)
+        {
+
+        }
+    }
+
+    [Fact]
+    // https://github.com/dlcs/iiif-presentation/pull/141
+    public async Task Should_Reuse_Response_Etag()
+    {
+        // Arrange
+        var filter = new ETagCachingAttribute();
+        var services = new ServiceCollection();
+        services.AddSingleton<IETagManager>(new StubETagManager());
+
+        var context = CreateResultExecutingContext(new DefaultHttpContext
+        {
+            RequestServices = services.BuildServiceProvider()
+        });
+
+        var responseHeaders = context.HttpContext.Response.GetTypedHeaders();
+        responseHeaders.ETag = new EntityTagHeaderValue("\"abc\"");
+
+        // Act
+        await filter.OnResultExecutionAsync(context, () => Task.FromResult(CreateResultExecutedContext(context.HttpContext)));
+
+        // Assert
+        Assert.Single(context.HttpContext.Response.Headers.CacheControl, "no-cache");
+    }
+
+    [Fact]
+    public async Task Should_Generate_Etag_For_Small_Content()
+    {
+        var filter = new ETagCachingAttribute();
+        var services = new ServiceCollection();
+        services.AddSingleton<IETagManager>(new StubETagManager());
+
+        var context = CreateResultExecutingContext(new DefaultHttpContext
+        {
+            RequestServices = services.BuildServiceProvider()
+        });
+
+        // Act
+        await filter.OnResultExecutionAsync(context, () => Task.FromResult(CreateResultExecutedContext(context.HttpContext)));
+
+        // Assert
+        
+        // This ETag is of an empty body.
+        Assert.Single(context.HttpContext.Response.Headers.ETag, "\"1B2M2Y8AsgTpgAmY7PhCfg==\"");
+    }
+    
+    [Fact]
+    public async Task Should_Use_MaxAge_Cache_For_Large_Content()
+    {
+        // See limit in API.Attributes.ETagCachingAttribute.IsEtagSupported
+        var filter = new ETagCachingAttribute();
+        var services = new ServiceCollection();
+        services.AddSingleton<IETagManager>(new StubETagManager());
+        
+        var context = CreateResultExecutingContext(new DefaultHttpContext
+        {
+            RequestServices = services.BuildServiceProvider(),
+        });
+
+        // Act
+        await filter.OnResultExecutionAsync(context, () =>
+        {
+            var largeContentThreshold = 64 * 1024;
+            var stream = new MemoryStream(new byte[largeContentThreshold]);;
+            stream.SetLength(largeContentThreshold);
+            context.HttpContext.Response.Body = stream;
+            
+            return Task.FromResult(CreateResultExecutedContext(context.HttpContext));
+        });
+
+        // Assert
+        Assert.Single(context.HttpContext.Response.Headers.CacheControl.ToList(), "max-age=10");
+    }
+    
+    [Fact]
+    public async Task Should_Use_PublicMaxAge_Cache_For_Large_Content_With_ShowExtras()
+    {
+        // See limit in API.Attributes.ETagCachingAttribute.IsEtagSupported
+        var filter = new ETagCachingAttribute();
+        var services = new ServiceCollection();
+        
+        services.AddSingleton<IETagManager>(new StubETagManager());
+
+        var context = CreateResultExecutingContext(new DefaultHttpContext
+        {
+            RequestServices = services.BuildServiceProvider(),
+        });
+
+        // Act
+        await filter.OnResultExecutionAsync(context, () =>
+        {
+            var largeContentThreshold = 64 * 1024;
+            var stream = new MemoryStream(new byte[largeContentThreshold]);;
+            stream.SetLength(largeContentThreshold);
+            context.HttpContext.Response.Body = stream;
+            context.HttpContext.Request.Headers["X-IIIF-CS-Show-Extras"] = "All";
+            
+            return Task.FromResult(CreateResultExecutedContext(context.HttpContext));
+        });
+
+        // Assert
+        Assert.Single(context.HttpContext.Response.Headers.CacheControl.ToList(), "public, max-age=10");
+    }
+}

--- a/src/IIIFPresentation/API.Tests/Attributes/ETagCachingAttributeTests.cs
+++ b/src/IIIFPresentation/API.Tests/Attributes/ETagCachingAttributeTests.cs
@@ -2,12 +2,8 @@ using API.Attributes;
 using API.Infrastructure.Helpers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Filters;
-using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Options;
 using Microsoft.Net.Http.Headers;
 using Models.Database.Collections;
 
@@ -22,8 +18,6 @@ public class ETagCachingAttributeTests
 
     private static ResultExecutingContext CreateResultExecutingContext(HttpContext context) =>
         new ResultExecutingContext(CreateActionContext(context), [], new ObjectResult(null), new object());
-
-    private class StubController : Controller;
 
     private class StubETagManager : IETagManager
     {

--- a/src/IIIFPresentation/API.Tests/Attributes/ETagCachingAttributeTests.cs
+++ b/src/IIIFPresentation/API.Tests/Attributes/ETagCachingAttributeTests.cs
@@ -102,7 +102,7 @@ public class ETagCachingAttributeTests
         // Act
         await filter.OnResultExecutionAsync(context, () =>
         {
-            var largeContentThreshold = 64 * 1024;
+            var largeContentThreshold = 512 * 1024;
             var stream = new MemoryStream(new byte[largeContentThreshold]);;
             stream.SetLength(largeContentThreshold);
             context.HttpContext.Response.Body = stream;
@@ -131,7 +131,7 @@ public class ETagCachingAttributeTests
         // Act
         await filter.OnResultExecutionAsync(context, () =>
         {
-            var largeContentThreshold = 64 * 1024;
+            var largeContentThreshold = 512 * 1024;
             var stream = new MemoryStream(new byte[largeContentThreshold]);;
             stream.SetLength(largeContentThreshold);
             context.HttpContext.Response.Body = stream;

--- a/src/IIIFPresentation/API.Tests/Integration/GetManifestTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/GetManifestTests.cs
@@ -4,6 +4,7 @@ using System.Net;
 using API.Tests.Integration.Infrastructure;
 using Core.Response;
 using IIIF.Presentation.V3;
+using Microsoft.Net.Http.Headers;
 using Test.Helpers.Integration;
 
 namespace API.Tests.Integration;
@@ -36,6 +37,7 @@ public class GetManifestTests : IClassFixture<PresentationAppFactory<Program>>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.Should().ContainKey(HeaderNames.ETag);
         manifest.Should().NotBeNull();
         manifest!.Type.Should().Be("Manifest");
         manifest.Id.Should().Be("http://localhost/1/manifests/FirstChildManifest", "requested by flat URI");
@@ -52,6 +54,7 @@ public class GetManifestTests : IClassFixture<PresentationAppFactory<Program>>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.Should().ContainKey(HeaderNames.ETag);
         manifest.Should().NotBeNull();
         manifest!.Type.Should().Be("Manifest");
         manifest.Id.Should().Be("http://localhost/1/iiif-manifest", "requested by hierarchical URI");

--- a/src/IIIFPresentation/API/Attributes/EtagCachingAttribute.cs
+++ b/src/IIIFPresentation/API/Attributes/EtagCachingAttribute.cs
@@ -92,7 +92,7 @@ public class ETagCachingAttribute : ActionFilterAttribute
         if (response.Headers.ContainsKey(HeaderNames.ETag)) return true;
         
         // 20kb length limit - can be changed
-        if (response.Body.Length > 20 * 1024) return false;
+        if (response.Body.Length > 256 * 1024) return false;
 
 
         return true;

--- a/src/IIIFPresentation/API/Attributes/EtagCachingAttribute.cs
+++ b/src/IIIFPresentation/API/Attributes/EtagCachingAttribute.cs
@@ -41,26 +41,29 @@ public class ETagCachingAttribute : ActionFilterAttribute
         {
             var responseHeaders = response.GetTypedHeaders();
 
-            if (IsEtagSupported(response)) {
+            if (IsEtagSupported(response))
+            {
                 // The no-cache response directive indicates that the response can be stored in caches,
                 // but the response must be validated with the origin server before each reuse,
                 // even when the cache is disconnected from the origin server.
-                responseHeaders.CacheControl = new CacheControlHeaderValue() {
-                    MustRevalidate = true
+                responseHeaders.CacheControl = new CacheControlHeaderValue
+                {
+                    NoCache = true
                 };
                 
-                responseHeaders.ETag ??=
-                    GenerateETag(memoryStream,
-                        request.Path, eTagManager); // This request generates a hash from the response - this would come from S3 in live
+                // This request generates a hash from the response - this would come from S3 in live
+                responseHeaders.ETag ??= GenerateETag(memoryStream, request.Path, eTagManager); 
             }
-            else {
-                responseHeaders.CacheControl = new CacheControlHeaderValue() // how long clients should cache the response
-                {
-                    Public = request.HasShowExtraHeader(),
-                    MaxAge = TimeSpan.FromSeconds(eTagManager.CacheTimeoutSeconds)
-                };
+            else
+            {
+                responseHeaders.CacheControl =
+                    new CacheControlHeaderValue() // how long clients should cache the response
+                    {
+                        Public = request.HasShowExtraHeader(),
+                        MaxAge = TimeSpan.FromSeconds(eTagManager.CacheTimeoutSeconds)
+                    };
             }
-            
+
             var requestHeaders = request.GetTypedHeaders();
 
             if (IsClientCacheValid(requestHeaders, responseHeaders))
@@ -71,7 +74,7 @@ public class ETagCachingAttribute : ActionFilterAttribute
                 foreach (var header in response.Headers)
                     if (!HeadersToKeepFor304.Contains(header.Key))
                     {
-                        response.Headers.Remove(header.Key);   
+                        response.Headers.Remove(header.Key);
                     }
 
                 return;
@@ -82,13 +85,15 @@ public class ETagCachingAttribute : ActionFilterAttribute
             .CopyToAsync(
                 originalStream); // Writes anything the later middleware wrote to the body (and by extension our `memoryStream`) to the original response body stream, so that it will be sent back to the client as the response body.
     }
-    
+
     private static bool IsEtagSupported(HttpResponse response)
     {
+        // Response already has an e-tag, we'll use it as-is, even if the content is large.
+        if (response.Headers.ContainsKey(HeaderNames.ETag)) return true;
+        
         // 20kb length limit - can be changed
         if (response.Body.Length > 20 * 1024) return false;
 
-        if (response.Headers.ContainsKey(HeaderNames.ETag)) return false;
 
         return true;
     }
@@ -110,8 +115,8 @@ public class ETagCachingAttribute : ActionFilterAttribute
         // If both `If-None-Match` and `If-Modified-Since` are present in a request, `If-None-Match` takes precedence and `If-Modified-Since` is ignored (provided, of course, that the resource supports entity-tags, hence the second condition after the `&&` operator in the following `if`). See https://datatracker.ietf.org/doc/html/rfc7232#section-3.3:~:text=A%20recipient%20MUST%20ignore%20If%2DModified%2DSince%20if
         if (reqHeaders.IfNoneMatch.Any() && resHeaders.ETag is not null)
             return reqHeaders.IfNoneMatch.Any(etag =>
-                    etag.Compare(resHeaders.ETag,
-                        false)
+                etag.Compare(resHeaders.ETag,
+                    false)
             );
 
         if (reqHeaders.IfModifiedSince is not null && resHeaders.LastModified is not null)

--- a/src/IIIFPresentation/API/Attributes/EtagCachingAttribute.cs
+++ b/src/IIIFPresentation/API/Attributes/EtagCachingAttribute.cs
@@ -46,7 +46,7 @@ public class ETagCachingAttribute : ActionFilterAttribute
                 // but the response must be validated with the origin server before each reuse,
                 // even when the cache is disconnected from the origin server.
                 responseHeaders.CacheControl = new CacheControlHeaderValue() {
-                    NoCache = true
+                    MustRevalidate = true
                 };
                 
                 responseHeaders.ETag ??=


### PR DESCRIPTION
Background: right now browsers will cache IIIF resources to disk for the caching period before checking if new content is available. That means we're never sending up an `If-None-Match` and getting a corresponding 304, so we end up with stale data in the browser. This change makes clients always send an `If-None-Match` before using the local cache.

Related to https://github.com/dlcs/iiif-presentation/issues/140