### PR TITLE
Flat manifest gains public_id

### DIFF
--- a/src/IIIFPresentation/API.Tests/Helpers/CollectionHelperXTests.cs
+++ b/src/IIIFPresentation/API.Tests/Helpers/CollectionHelperXTests.cs
@@ -35,8 +35,6 @@ public class CollectionHelperXTests
     [InlineData("slug", "")]
     public void GenerateHierarchicalCollectionParent_Correct_ParentId(string fullPath, string outputUrl)
     {
-        
-        
         // Arrange
         var collection = new Collection
         {

--- a/src/IIIFPresentation/API.Tests/Integration/GetManifestTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/GetManifestTests.cs
@@ -4,6 +4,7 @@ using System.Net;
 using API.Tests.Integration.Infrastructure;
 using Core.Response;
 using IIIF.Presentation.V3;
+using Models.API.Manifest;
 using Test.Helpers.Integration;
 
 namespace API.Tests.Integration;
@@ -25,14 +26,14 @@ public class GetManifestTests : IClassFixture<PresentationAppFactory<Program>>
 
 
     [Fact]
-    public async Task Get_IiifManifest_Flat_ReturnsManifestFromS3()
+    public async Task Get_IiifManifest_Flat_ReturnsManifestFromS3_DecoratedWithDbValues()
     {
         // Arrange and Act
         var requestMessage =
             HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get, "1/manifests/FirstChildManifest");
         var response = await httpClient.AsCustomer(1).SendAsync(requestMessage);
 
-        var manifest = await response.ReadAsPresentationJsonAsync<Manifest>();
+        var manifest = await response.ReadAsPresentationJsonAsync<PresentationManifest>();
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -40,6 +41,7 @@ public class GetManifestTests : IClassFixture<PresentationAppFactory<Program>>
         manifest!.Type.Should().Be("Manifest");
         manifest.Id.Should().Be("http://localhost/1/manifests/FirstChildManifest", "requested by flat URI");
         manifest.Items.Should().HaveCount(3, "the test content contains 3 children");
+        manifest.PublicId.Should().Be("http://localhost/1/iiif-manifest", "iiif-manifest is slug and under root");
     }
 
     [Fact]

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestCreateTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestCreateTests.cs
@@ -799,6 +799,7 @@ public class ModifyManifestCreateTests: IClassFixture<PresentationAppFactory<Pro
         responseManifest.CreatedBy.Should().Be("Admin");
         responseManifest.Slug.Should().Be(slug);
         responseManifest.Parent.Should().Be("http://localhost/1/collections/root");
+        responseManifest.PublicId.Should().Be($"http://localhost/1/{slug}");
     }
     
     [Fact]

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestUpdateTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestUpdateTests.cs
@@ -225,6 +225,7 @@ public class ModifyManifestUpdateTests : IClassFixture<PresentationAppFactory<Pr
         responseManifest.CreatedBy.Should().Be("Admin");
         responseManifest.Slug.Should().Be(slug);
         responseManifest.Parent.Should().Be(parent);
+        responseManifest.PublicId.Should().Be($"http://localhost/1/{slug}");
     }
     
     [Fact]

--- a/src/IIIFPresentation/API/Converters/ManifestConverter.cs
+++ b/src/IIIFPresentation/API/Converters/ManifestConverter.cs
@@ -29,6 +29,7 @@ public static class ManifestConverter
         var hierarchy = hierarchyFactory(dbManifest);
         
         iiifManifest.Id = dbManifest.GenerateFlatManifestId(urlRoots);
+        iiifManifest.PublicId = hierarchy.GenerateHierarchicalId(urlRoots);
         iiifManifest.Created = dbManifest.Created.Floor(DateTimeX.Precision.Second);
         iiifManifest.Modified = dbManifest.Modified.Floor(DateTimeX.Precision.Second);
         iiifManifest.CreatedBy = dbManifest.CreatedBy;

--- a/src/IIIFPresentation/API/Features/Manifest/Requests/GetManifest.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/Requests/GetManifest.cs
@@ -35,7 +35,7 @@ public class GetManifestHandler(
 
         var fetchFullPath = ManifestRetrieval.RetrieveFullPathForManifest(dbManifest.Id, dbManifest.CustomerId,
             dbContext, cancellationToken);
-        
+
         if (request.PathOnly)
             return FetchEntityResult<PresentationManifest>.Success(new()
             {
@@ -43,6 +43,7 @@ public class GetManifestHandler(
             });
 
         var manifest = await iiifS3.ReadIIIFFromS3<PresentationManifest>(dbManifest, cancellationToken);
+        dbManifest.Hierarchy.Single().FullPath = await fetchFullPath;
 
         // PK: Will this even happen? Should we log or even throw here?
         if (manifest == null)

--- a/src/IIIFPresentation/API/Helpers/CollectionHelperX.cs
+++ b/src/IIIFPresentation/API/Helpers/CollectionHelperX.cs
@@ -18,14 +18,13 @@ public static class CollectionHelperX
     
     public static string GenerateHierarchicalCollectionId(this Collection collection, UrlRoots urlRoots) =>
         $"{urlRoots.BaseUrl}/{collection.CustomerId}{(string.IsNullOrEmpty(collection.FullPath) ? string.Empty : $"/{collection.FullPath}")}";
-
+    
     public static string GenerateHierarchicalCollectionParent(this Collection collection, Hierarchy hierarchy, UrlRoots urlRoots)
     {
         var parentPath = collection.FullPath![..^hierarchy.Slug.Length].TrimEnd('/');
 
         return $"{urlRoots.BaseUrl}/{collection.CustomerId}{(string.IsNullOrEmpty(parentPath) ? string.Empty : $"/{parentPath}")}";
     }
-    
     
     public static string GenerateFlatCollectionId(this Collection collection, UrlRoots urlRoots) =>
         $"{urlRoots.BaseUrl}/{collection.CustomerId}/collections/{collection.Id}";

--- a/src/IIIFPresentation/Models/API/Manifest/PresentationManifest.cs
+++ b/src/IIIFPresentation/Models/API/Manifest/PresentationManifest.cs
@@ -4,8 +4,8 @@ namespace Models.API.Manifest;
 
 public class PresentationManifest : IIIF.Presentation.V3.Manifest, IPresentation
 {
+    public string? PublicId { get; set; }
     public string? Slug { get; set; }
-    
     public string? Parent { get; set; }
     public DateTime Created { get; set; }
     public DateTime Modified { get; set; }


### PR DESCRIPTION
Manifest will return `publicId` property from:
* GET flat
* POST flat
* PUT flat

Note - I've intentionally used `dbManifest.Hierarchy.Single()` knowing it will break when we add handling for non-canonical paths. Felt safer to get an upfront error than possibly miss some logic.