### PR TITLE
PresentationManifest and Collection gain FlatId

### DIFF
--- a/src/IIIFPresentation/API.Tests/Converters/CollectionConverterTests.cs
+++ b/src/IIIFPresentation/API.Tests/Converters/CollectionConverterTests.cs
@@ -100,6 +100,7 @@ public class CollectionConverterTests
 
         // Assert
         flatCollection.Id.Should().Be("http://base/1/collections/some-id");
+        flatCollection.FlatId.Should().Be("some-id");
         flatCollection.PublicId.Should().Be("http://base/1");
         flatCollection.Label!.Count.Should().Be(1);
         flatCollection.Label["en"].Should().Contain("repository root");
@@ -129,6 +130,7 @@ public class CollectionConverterTests
 
         // Assert
         flatCollection.Id.Should().Be("http://base/1/collections/some-id");
+        flatCollection.FlatId.Should().Be("some-id");
         flatCollection.PublicId.Should().Be("http://base/1/top/some-id");
         flatCollection.Label!.Count.Should().Be(1);
         flatCollection.Label["en"].Should().Contain("repository root");
@@ -160,6 +162,7 @@ public class CollectionConverterTests
 
         // Assert
         flatCollection.Id.Should().Be("http://base/1/collections/some-id");
+        flatCollection.FlatId.Should().Be("some-id");
         flatCollection.PublicId.Should().Be("http://base/1/top/some-id");
         flatCollection.Label!.Count.Should().Be(1);
         flatCollection.Label["en"].Should().Contain("repository root");

--- a/src/IIIFPresentation/API.Tests/Helpers/PresentationX.cs
+++ b/src/IIIFPresentation/API.Tests/Helpers/PresentationX.cs
@@ -29,6 +29,8 @@ public class PresentationX
     
     public class TestPresentation : IPresentation
     {
+        public string? PublicId { get; set; }
+        public string? FlatId { get; set; }
         public string? Slug { get; set; }
         public string? Parent { get; set; }
         public DateTime Created { get; set; }

--- a/src/IIIFPresentation/API.Tests/Infrastructure/Validation/PresentationValidationTests.cs
+++ b/src/IIIFPresentation/API.Tests/Infrastructure/Validation/PresentationValidationTests.cs
@@ -45,6 +45,8 @@ public class PresentationValidationTests
 
 public class TestPresentation : IPresentation
 {
+    public string? PublicId { get; set; }
+    public string? FlatId { get; set; }
     public string? Slug { get; set; }
     public string? Parent { get; set; }
     public DateTime Created { get; set; }

--- a/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
@@ -210,6 +210,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         collection!.Id.Should().Be($"http://localhost/1/collections/{RootCollection.Id}");
+        collection.FlatId.Should().Be(RootCollection.Id);
         collection.PublicId.Should().Be("http://localhost/1");
         collection.Items!.Count.Should().Be(TotalDatabaseChildItems);
         collection.Items.OfType<Collection>().First().Id.Should().Be("http://localhost/1/collections/FirstChildCollection");
@@ -245,6 +246,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         collection!.Id.Should().Be("http://localhost/1/collections/FirstChildCollection");
+        collection.FlatId.Should().Be("FirstChildCollection");
         collection.PublicId.Should().Be("http://localhost/1/first-child");
         collection.Items!.Count.Should().Be(1);
         collection.Items.OfType<Collection>().First().Id.Should().Be("http://localhost/1/collections/SecondChildCollection");
@@ -269,6 +271,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         // Assert
         flatResponse.StatusCode.Should().Be(HttpStatusCode.OK);
         flatCollection!.Id.Should().Be("http://localhost/1/collections/NonPublic");
+        flatCollection.FlatId.Should().Be("NonPublic");
         flatCollection.PublicId.Should().Be("http://localhost/1/non-public");
         flatCollection.Items!.Count.Should().Be(0);
         flatCollection.CreatedBy.Should().Be("admin");

--- a/src/IIIFPresentation/API.Tests/Integration/GetManifestTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/GetManifestTests.cs
@@ -43,6 +43,7 @@ public class GetManifestTests : IClassFixture<PresentationAppFactory<Program>>
         manifest!.Type.Should().Be("Manifest");
         manifest.Id.Should().Be("http://localhost/1/manifests/FirstChildManifest", "requested by flat URI");
         manifest.Items.Should().HaveCount(3, "the test content contains 3 children");
+        manifest.FlatId.Should().Be("FirstChildManifest");
         manifest.PublicId.Should().Be("http://localhost/1/iiif-manifest", "iiif-manifest is slug and under root");
     }
 

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestCreateTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestCreateTests.cs
@@ -828,6 +828,7 @@ public class ModifyManifestCreateTests: IClassFixture<PresentationAppFactory<Pro
         responseManifest.Slug.Should().Be(slug);
         responseManifest.Parent.Should().Be("http://localhost/1/collections/root");
         responseManifest.PublicId.Should().Be($"http://localhost/1/{slug}");
+        responseManifest.FlatId.Should().Be(id);
     }
     
     [Fact]

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestUpdateTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestUpdateTests.cs
@@ -254,6 +254,7 @@ public class ModifyManifestUpdateTests : IClassFixture<PresentationAppFactory<Pr
         responseManifest.Slug.Should().Be(slug);
         responseManifest.Parent.Should().Be(parent);
         responseManifest.PublicId.Should().Be($"http://localhost/1/{slug}");
+        responseManifest.FlatId.Should().Be(dbManifest.Id);
     }
     
     [Fact]

--- a/src/IIIFPresentation/API/Converters/CollectionConverter.cs
+++ b/src/IIIFPresentation/API/Converters/CollectionConverter.cs
@@ -48,6 +48,7 @@ public static class CollectionConverter
             Id = dbAsset.GenerateFlatCollectionId(urlRoots),
             Context = GenerateContext(),
             Label = dbAsset.Label,
+            FlatId = dbAsset.Id,
             PublicId = dbAsset.GenerateHierarchicalCollectionId(urlRoots),
             Behavior = GenerateBehavior(dbAsset),
             Slug = hierarchy.Slug,

--- a/src/IIIFPresentation/API/Converters/ManifestConverter.cs
+++ b/src/IIIFPresentation/API/Converters/ManifestConverter.cs
@@ -29,6 +29,7 @@ public static class ManifestConverter
         var hierarchy = hierarchyFactory(dbManifest);
         
         iiifManifest.Id = dbManifest.GenerateFlatManifestId(urlRoots);
+        iiifManifest.FlatId = dbManifest.Id;
         iiifManifest.PublicId = hierarchy.GenerateHierarchicalId(urlRoots);
         iiifManifest.Created = dbManifest.Created.Floor(DateTimeX.Precision.Second);
         iiifManifest.Modified = dbManifest.Modified.Floor(DateTimeX.Precision.Second);

--- a/src/IIIFPresentation/API/Features/Storage/Helpers/PresentationCollectionX.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Helpers/PresentationCollectionX.cs
@@ -38,6 +38,7 @@ public static class PresentationCollectionX
         presentationCollection.Items ??= CollectionConverter.GenerateItems(urlRoots, items);
         presentationCollection.TotalItems = totalItems;
 
+        presentationCollection.FlatId = collection.Id;
         presentationCollection.Id = collection.GenerateFlatCollectionId(urlRoots);
         presentationCollection.PublicId = collection.GenerateHierarchicalCollectionId(urlRoots);
         presentationCollection.Parent = CollectionConverter.GeneratePresentationCollectionParent(urlRoots, hierarchy);

--- a/src/IIIFPresentation/Models/API/Collection/PresentationCollection.cs
+++ b/src/IIIFPresentation/Models/API/Collection/PresentationCollection.cs
@@ -7,6 +7,7 @@ namespace Models.API.Collection;
 public class PresentationCollection : IIIF.Presentation.V3.Collection, IPresentation
 {
     public string? PublicId { get; set; }
+    public string? FlatId { get; set; }
     
     public string? Slug { get; set; }
     

--- a/src/IIIFPresentation/Models/API/IPresentation.cs
+++ b/src/IIIFPresentation/Models/API/IPresentation.cs
@@ -6,6 +6,8 @@
 /// <remarks>Shared items should be added to this as required</remarks>
 public interface IPresentation
 {
+    public string? PublicId { get; set; }
+    public string? FlatId { get; set; }
     string? Slug { get; set; }
     string? Parent { get; set; }
     public DateTime Created { get; set; }

--- a/src/IIIFPresentation/Models/API/Manifest/PresentationManifest.cs
+++ b/src/IIIFPresentation/Models/API/Manifest/PresentationManifest.cs
@@ -5,6 +5,7 @@ namespace Models.API.Manifest;
 public class PresentationManifest : IIIF.Presentation.V3.Manifest, IPresentation
 {
     public string? PublicId { get; set; }
+    public string? FlatId { get; set; }
     public string? Slug { get; set; }
     public string? Parent { get; set; }
     public DateTime Created { get; set; }


### PR DESCRIPTION
`"flatId"` is now output on `PresentationManifest` and `PresentationCollection` objects. 

This saves parsing the `"id"` to get the last slug, for now they match but could differ in the future.