### PR TITLE
#150 - delete manifest - implement + tests

### DIFF
--- a/src/IIIFPresentation/API.Tests/Integration/DeleteManifestUpdateTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/DeleteManifestUpdateTests.cs
@@ -1,0 +1,89 @@
+﻿using System.Net;
+using Amazon.S3;
+using API.Infrastructure.Helpers;
+using API.Tests.Integration.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Repository;
+using Test.Helpers.Helpers;
+using Test.Helpers.Integration;
+
+namespace API.Tests.Integration;
+
+[Trait("Category", "Integration")]
+[Collection(CollectionDefinitions.StorageCollection.CollectionName)]
+public class DeleteManifestTests : IClassFixture<PresentationAppFactory<Program>>
+{
+    private readonly HttpClient httpClient;
+    private readonly PresentationContext dbContext;
+    private readonly IAmazonS3 amazonS3;
+    private readonly IETagManager etagManager;
+    private const int Customer = 1;
+
+    public DeleteManifestTests(StorageFixture storageFixture, PresentationAppFactory<Program> factory)
+    {
+        dbContext = storageFixture.DbFixture.DbContext;
+        amazonS3 = storageFixture.LocalStackFixture.AWSS3ClientFactory();
+
+        httpClient = factory.ConfigureBasicIntegrationTestHttpClient(storageFixture.DbFixture,
+            appFactory => appFactory.WithLocalStack(storageFixture.LocalStackFixture));
+
+        etagManager = (IETagManager) factory.Services.GetRequiredService(typeof(IETagManager));
+
+        storageFixture.DbFixture.CleanUp();
+    }
+
+    [Fact]
+    public async Task DeleteManifest_DeletesManifest()
+    {
+        // Arrange
+        var dbManifest = (await dbContext.Manifests.AddTestManifest()).Entity;
+        await dbContext.SaveChangesAsync();
+
+        var requestMessage =
+            HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Delete, $"{Customer}/manifests/{dbManifest.Id}");
+
+        // Act
+        var response = await httpClient.AsCustomer(Customer).SendAsync(requestMessage);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        (await dbContext.Manifests.CountAsync(m => m.Id == dbManifest.Id)).Should().Be(0, "the manifest was deleted");
+    }
+
+    [Fact]
+    public async Task DeleteManifest_NotFound_WhenDoesNotExists()
+    {
+        // Arrange
+        var requestMessage =
+            HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Delete,
+                $"{Customer}/manifests/this_does_not_exist_1610");
+
+        // Act
+        var response = await httpClient.AsCustomer(Customer).SendAsync(requestMessage);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task DeleteManifest_Forbidden_WhenNoAuthOrExtras()
+    {
+        // Arrange
+        var dbManifest = (await dbContext.Manifests.AddTestManifest()).Entity;
+        await dbContext.SaveChangesAsync();
+
+        var requestMessage = new HttpRequestMessage(HttpMethod.Delete, $"{Customer}/manifests/{dbManifest.Id}");
+
+        // Act
+        var response = await httpClient.AsCustomer(Customer).SendAsync(requestMessage);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+
+        // Cleanup
+        dbContext.Manifests.Remove(dbManifest);
+        await dbContext.SaveChangesAsync();
+    }
+}

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestController.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestController.cs
@@ -8,7 +8,6 @@ using API.Infrastructure.Helpers;
 using API.Infrastructure.Requests;
 using API.Settings;
 using Core.IIIF;
-using IIIF;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -77,6 +76,15 @@ public class ManifestController(IOptions<ApiSettings> options, IAuthenticator au
                 new UpsertManifest(customerId, id, Request.Headers.IfMatch, presentationManifest, rawRequestBody, GetUrlRoots()),
             validator,
             cancellationToken: cancellationToken);
+
+    [Authorize]
+    [HttpDelete("manifests/{id}")]
+    public async Task<IActionResult> Delete(int customerId, string id)
+    {
+        if (!Request.HasShowExtraHeader()) return this.Forbidden();
+
+        return await HandleDelete(new DeleteManifest(customerId, id));
+    }
     
     private async Task<IActionResult> ManifestUpsert<T, TEnum>(
         Func<PresentationManifest, string, IRequest<ModifyEntityResult<T, TEnum>>> requestFactory,

--- a/src/IIIFPresentation/API/Features/Manifest/Requests/DeleteManifest.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/Requests/DeleteManifest.cs
@@ -1,0 +1,52 @@
+﻿using Core;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Models.API.General;
+using Repository;
+
+namespace API.Features.Manifest.Requests;
+
+public class DeleteManifest(int customerId, string manifestId)
+    : IRequest<ResultMessage<DeleteResult, DeleteManifestType>>
+{
+    public int CustomerId { get; } = customerId;
+    public string ManifestId { get; } = manifestId;
+}
+
+public class DeleteManifestHandler(
+    PresentationContext dbContext,
+    ILogger<DeleteManifestHandler> logger)
+    : IRequestHandler<DeleteManifest, ResultMessage<DeleteResult, DeleteManifestType>>
+{
+    #region Implementation of IRequestHandler<in DeleteManifest,ResultMessage<DeleteResult,DeleteManifestType>>
+
+    public async Task<ResultMessage<DeleteResult, DeleteManifestType>> Handle(DeleteManifest request,
+        CancellationToken cancellationToken)
+    {
+        logger.LogDebug("Deleting collection {ManifestId} for customer {CustomerId}", request.ManifestId,
+            request.CustomerId);
+
+        var manifest = await dbContext.Manifests.Include(c => c.Hierarchy).FirstOrDefaultAsync(m =>
+            m.Id == request.ManifestId && m.CustomerId == request.CustomerId, cancellationToken);
+
+        if (manifest is null) return new(DeleteResult.NotFound);
+
+        dbContext.Manifests.Remove(manifest);
+
+        try
+        {
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateConcurrencyException ex)
+        {
+            logger.LogError(ex, "Error attempting to delete manifest {ManifestId} for customer {CustomerId}",
+                request.ManifestId, request.CustomerId);
+            return new(DeleteResult.Error,
+                DeleteManifestType.Unknown, "Error deleting manifest");
+        }
+
+        return new(DeleteResult.Deleted);
+    }
+
+    #endregion
+}

--- a/src/IIIFPresentation/API/Infrastructure/PresentationController.cs
+++ b/src/IIIFPresentation/API/Infrastructure/PresentationController.cs
@@ -6,7 +6,6 @@ using API.Settings;
 using Core;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
-using Models.API.General;
 
 namespace API.Infrastructure;
 
@@ -83,10 +82,10 @@ public abstract class PresentationController : Controller
     /// error and appropriate status code if failed.
     /// </returns>
     /// <remarks>This will be replaced with overload that takes DeleteEntityResult in future</remarks>
-    protected async Task<IActionResult> HandleDelete(
-        IRequest<ResultMessage<DeleteResult, DeleteCollectionType>> request,
+    protected async Task<IActionResult> HandleDelete<T>(
+        IRequest<ResultMessage<DeleteResult, T>> request,
         string? errorTitle = "Delete failed",
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default) where T : Enum
     {
         return await HandleRequest(async () =>
         {

--- a/src/IIIFPresentation/Models/API/General/DeleteManifestType.cs
+++ b/src/IIIFPresentation/Models/API/General/DeleteManifestType.cs
@@ -1,0 +1,6 @@
+﻿namespace Models.API.General;
+
+public enum DeleteManifestType
+{
+    Unknown = 0
+}


### PR DESCRIPTION
Based on existing code for collections, with simplification as manifests (rn) don't need to worry about their items, afaik.

Added tests for the expected set of responses (forbidden, not found or success: no content)