### PR TITLE
Generate ETags for responses unconditionally

### DIFF
--- a/src/IIIFPresentation/API.Tests/Attributes/ETagCachingAttributeTests.cs
+++ b/src/IIIFPresentation/API.Tests/Attributes/ETagCachingAttributeTests.cs
@@ -63,6 +63,7 @@ public class ETagCachingAttributeTests
 
         // Assert
         Assert.Single(context.HttpContext.Response.Headers.CacheControl, "no-cache");
+        Assert.Single(context.HttpContext.Response.Headers.ETag, "\"abc\"");
     }
 
     [Fact]
@@ -86,7 +87,8 @@ public class ETagCachingAttributeTests
         Assert.Single(context.HttpContext.Response.Headers.ETag, "\"1B2M2Y8AsgTpgAmY7PhCfg==\"");
     }
     
-    [Fact]
+    [Fact(Skip = "public caching is currently disabled")]
+
     public async Task Should_Use_MaxAge_Cache_For_Large_Content()
     {
         // See limit in API.Attributes.ETagCachingAttribute.IsEtagSupported
@@ -114,7 +116,7 @@ public class ETagCachingAttributeTests
         Assert.Single(context.HttpContext.Response.Headers.CacheControl, "max-age=10");
     }
     
-    [Fact]
+    [Fact(Skip = "public caching is currently disabled")]
     public async Task Should_Use_PublicMaxAge_Cache_For_Large_Content_With_ShowExtras()
     {
         // See limit in API.Attributes.ETagCachingAttribute.IsEtagSupported


### PR DESCRIPTION
This is a temporary workaround for ETags being missing on larger responses (first 20KB, now 256KB). I've investigated what's involved in propagating the ETag from S3 and unfortunately it's not that simple due to:

```csharp
        manifest = manifest.SetGeneratedFields(dbManifest, request.UrlRoots,
            m => m.Hierarchy!.Single(h => h.Canonical));
```

We modify the manifest after we get it from S3 with fields from the database -- so the ETag isn't guaranteed to be a valid checksum.