### PR TITLE
Bump iiif-net package

### DIFF
--- a/src/IIIFPresentation/API/API.csproj
+++ b/src/IIIFPresentation/API/API.csproj
@@ -11,7 +11,7 @@
     <ItemGroup>
         <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.400.25" />
         <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.10.0" />
-        <PackageReference Include="iiif-net" Version="0.2.9" />
+        <PackageReference Include="iiif-net" Version="0.3.1" />
         <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.8" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.7" />

--- a/src/IIIFPresentation/Core/Core.csproj
+++ b/src/IIIFPresentation/Core/Core.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="iiif-net" Version="0.2.9" />
+      <PackageReference Include="iiif-net" Version="0.3.1" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>
 

--- a/src/IIIFPresentation/Models/Models.csproj
+++ b/src/IIIFPresentation/Models/Models.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="iiif-net" Version="0.2.9" />
+      <PackageReference Include="iiif-net" Version="0.3.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/IIIFPresentation/Repository/Repository.csproj
+++ b/src/IIIFPresentation/Repository/Repository.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="EFCore.NamingConventions" Version="8.0.3" />
-        <PackageReference Include="iiif-net" Version="0.2.9" />
+        <PackageReference Include="iiif-net" Version="0.3.1" />
         <PackageReference Include="MediatR" Version="12.4.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.4" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />


### PR DESCRIPTION
Bump iiif-net to latest version, specifically looking for improved deserialization of Service elements that we don't have strongly typed models for. 

Brings in changes introduced in the following versions of iiif-net:

* https://github.com/digirati-co-uk/iiif-net/releases/tag/v0.3.1
* https://github.com/digirati-co-uk/iiif-net/releases/tag/v0.3.0