### PR TITLE
When no items returned, set totalItems from db

### DIFF
--- a/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
@@ -494,6 +494,27 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
     }
 
     [Fact]
+    public async Task Get_ChildFlat_CorrectTotalItems_WhenPageOutOfBOunds()
+    {
+        // Arrange
+        var requestMessage =
+            HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get,
+                $"1/collections/{RootCollection.Id}?page=7&pageSize=15");
+
+        // Act
+        var response = await httpClient.AsCustomer(1).SendAsync(requestMessage);
+
+        var collection = await response.ReadAsPresentationJsonAsync<PresentationCollection>();
+
+        // Assert
+        collection.TotalItems.Should().Be(TotalDatabaseChildItems);
+        collection.View!.PageSize.Should().Be(15);
+        collection.View.Page.Should().Be(7);
+        collection.View.TotalPages.Should().Be(1);
+        collection.Items.Should().BeNullOrEmpty();
+    }
+
+    [Fact]
     public async Task Get_ChildFlat_Returns_Vary_Header()
     {
         // Arrange

--- a/src/IIIFPresentation/API/Features/Storage/Helpers/PresentationContextX.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Helpers/PresentationContextX.cs
@@ -124,7 +124,7 @@ public static class PresentationContextX
         Collection collection, int itemCount, int pageSize, int pageNo, CancellationToken cancellationToken = default)
     {
         int total;
-        if (itemCount < pageSize)
+        if (itemCount > 0 && itemCount < pageSize)
         {
             // there can't be more as we've asked for PageSize and got less 
             total = itemCount + (pageNo - 1) * pageSize;


### PR DESCRIPTION
...because it means the page/pageSize could be out of bounds
