### PR TITLE
Fix #164 - Redirect trailing slash

### DIFF
--- a/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
@@ -45,6 +45,28 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         secondItem.Id.Should().Be("http://localhost/1/iiif-collection");
         secondItem.Behavior.Should().BeNull();
     }
+
+    [Fact]
+    public async Task Get_RootHierarchical_Returns_TrailingSlashRedirect()
+    {
+        // Act
+        var response = await httpClient.GetAsync("1/");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Found);
+        response.Headers.Location!.Should().Be("/1");
+    }
+
+    [Fact]
+    public async Task Get_ChildHierarchical_Returns_TrailingSlashRedirect()
+    {
+        // Act
+        var response = await httpClient.GetAsync("1/first-child/");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Found);
+        response.Headers.Location!.Should().Be("/1/first-child");
+    }
     
     [Fact]
     public async Task Get_ChildHierarchical_Returns_Child()

--- a/src/IIIFPresentation/API.Tests/Integration/GetManifestTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/GetManifestTests.cs
@@ -4,8 +4,8 @@ using System.Net;
 using API.Tests.Integration.Infrastructure;
 using Core.Response;
 using IIIF.Presentation.V3;
-using Models.API.Manifest;
 using Microsoft.Net.Http.Headers;
+using Models.API.Manifest;
 using Test.Helpers.Integration;
 
 namespace API.Tests.Integration;
@@ -44,6 +44,17 @@ public class GetManifestTests : IClassFixture<PresentationAppFactory<Program>>
         manifest.Items.Should().HaveCount(3, "the test content contains 3 children");
         manifest.FlatId.Should().Be("FirstChildManifest");
         manifest.PublicId.Should().Be("http://localhost/1/iiif-manifest", "iiif-manifest is slug and under root");
+    }
+
+    [Fact]
+    public async Task Get_IiifManifest_Hierarchical_Returns_TrailingSlashRedirect()
+    {
+        // Arrange and Act
+        var response = await httpClient.GetAsync("1/iiif-manifest/");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Found);
+        response.Headers.Location!.Should().Be("/1/iiif-manifest");
     }
 
     [Fact]

--- a/src/IIIFPresentation/API/Program.cs
+++ b/src/IIIFPresentation/API/Program.cs
@@ -1,7 +1,6 @@
 using System.Text.Json.Serialization;
 using API.Auth;
 using API.Features.Manifest;
-using API.Features.Storage.Validators;
 using API.Helpers;
 using API.Infrastructure;
 using API.Infrastructure.Helpers;
@@ -9,6 +8,7 @@ using API.Settings;
 using AWS.Settings;
 using FluentValidation;
 using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.AspNetCore.Rewrite;
 using Newtonsoft.Json;
 using Repository;
 using Serilog;
@@ -88,7 +88,11 @@ if (app.Environment.IsDevelopment())
     app.UseSwaggerUI();
 }
 
+var rewriteOptions = new RewriteOptions()
+    .AddRedirect("(.*)/$", "$1");
+
 app
+    .UseRewriter(rewriteOptions)
     .UseHttpsRedirection()
     .UseAuthentication()
     .UseAuthorization()


### PR DESCRIPTION
- **#164 trailing slash tests**
- **Set global redirect rule to remove trailing slash**

Note, that if we happen to require more granular controls there's 1001 ways to do this, but I didn't want to overengineer sth that might never be needed.