### PR TITLE
Bugfixes - correct partOf and hide non-public items

### DIFF
--- a/src/IIIFPresentation/API.Tests/Converters/CollectionConverterTests.cs
+++ b/src/IIIFPresentation/API.Tests/Converters/CollectionConverterTests.cs
@@ -67,7 +67,7 @@ public class CollectionConverterTests
     }
     
     [Fact]
-    public void ToFlatCollection_ConvertsStorageCollection()
+    public void ToPresentationCollection_ConvertsStorageCollection()
     {
         // Arrange
         var collection = new Collection
@@ -119,7 +119,7 @@ public class CollectionConverterTests
     }
     
     [Fact]
-    public void ToFlatCollection_ConvertsStorageCollection_WithFullPath()
+    public void ToPresentationCollection_ConvertsStorageCollection_WithFullPath()
     {
         // Arrange
         var storageRoot = CreateTestHierarchicalCollection();
@@ -152,7 +152,7 @@ public class CollectionConverterTests
     }
 
     [Fact]
-    public void ToFlatCollection_ConvertsStorageCollection_WithCorrectPaging()
+    public void ToPresentationCollection_ConvertsStorageCollection_WithCorrectPaging()
     {
         // Arrange
         var storageRoot = CreateTestHierarchicalCollection();
@@ -186,7 +186,7 @@ public class CollectionConverterTests
     }
     
     [Fact]
-    public void ToFlatCollection_ConvertsStorageCollection_IncludingPartOfForParent()
+    public void ToPresentationCollection_ConvertsStorageCollection_IncludingPartOfForParent()
     {
         // Arrange
         var storageRoot = CreateTestHierarchicalCollection();

--- a/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
@@ -41,7 +41,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         var firstItem = (Collection)collection.Items[0];
         firstItem.Id.Should().Be("http://localhost/1/first-child");
         firstItem.Behavior.Should().BeNull();
-        var secondItem = (Collection)collection.Items[1];
+        var secondItem = (Collection)collection.Items[2];
         secondItem.Id.Should().Be("http://localhost/1/iiif-collection");
         secondItem.Behavior.Should().BeNull();
     }
@@ -239,6 +239,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         collection.TotalItems.Should().Be(TotalDatabaseChildItems);
         collection.CreatedBy.Should().Be("admin");
         collection.Behavior.Should().Contain("public-iiif");
+        collection.PartOf.Should().BeNull("Root has no parent");
         var firstItem = (Collection)collection.Items[0];
         firstItem.Id.Should().Be("http://localhost/1/collections/FirstChildCollection");
         firstItem.Behavior.Should().Contain("public-iiif");
@@ -276,6 +277,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         collection.CreatedBy.Should().Be("admin");
         collection.Behavior.Should().Contain("public-iiif");
         collection.Parent.Should().Be($"http://localhost/1/collections/{RootCollection.Id}");
+        collection.PartOf.Single().Id.Should().Be("http://localhost/1/collections/root");
     }
     
     [Fact]
@@ -300,6 +302,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         flatCollection.Behavior.Should().Contain("storage-collection");
         flatCollection.Behavior.Should().NotContain("public-iiif");
         flatCollection.Parent.Should().Be($"http://localhost/1/collections/{RootCollection.Id}");
+        flatCollection.PartOf.Single().Id.Should().Be("http://localhost/1/collections/root");
         hierarchicalResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 

--- a/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
@@ -37,11 +37,11 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         collection!.Id.Should().Be("http://localhost/1");
-        collection.Items.Count.Should().Be(TotalDatabaseChildItems);
+        collection.Items.Count.Should().Be(TotalDatabaseChildItems - 1, "One child item is non-public");
         var firstItem = (Collection)collection.Items[0];
         firstItem.Id.Should().Be("http://localhost/1/first-child");
         firstItem.Behavior.Should().BeNull();
-        var secondItem = (Collection)collection.Items[2];
+        var secondItem = (Collection)collection.Items[1];
         secondItem.Id.Should().Be("http://localhost/1/iiif-collection");
         secondItem.Behavior.Should().BeNull();
     }
@@ -94,6 +94,16 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         response.Headers.Vary.Should().HaveCount(2);
+    }
+    
+    [Fact]
+    public async Task Get_ChildHierarchical_ReturnsNotFound_IfNotPublic()
+    {
+        // Act
+        var response = await httpClient.GetAsync("1/non-public");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
     
     [Fact]

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestService.cs
@@ -159,7 +159,7 @@ public class ManifestService(
         WriteManifestRequest request, CancellationToken cancellationToken)
     {
         var manifest = request.PresentationManifest;
-        var parentCollection = await dbContext.RetrieveCollectionAsync(request.CustomerId,
+        var parentCollection = await dbContext.RetrieveCollectionOnlyAsync(request.CustomerId,
             manifest.GetParentSlug(), cancellationToken: cancellationToken);
         
         // Validation

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestService.cs
@@ -159,7 +159,7 @@ public class ManifestService(
         WriteManifestRequest request, CancellationToken cancellationToken)
     {
         var manifest = request.PresentationManifest;
-        var parentCollection = await dbContext.RetrieveCollectionOnlyAsync(request.CustomerId,
+        var parentCollection = await dbContext.RetrieveCollectionAsync(request.CustomerId,
             manifest.GetParentSlug(), cancellationToken: cancellationToken);
         
         // Validation

--- a/src/IIIFPresentation/API/Features/Storage/Helpers/PresentationCollectionX.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Helpers/PresentationCollectionX.cs
@@ -20,12 +20,13 @@ public static class PresentationCollectionX
     /// <param name="currentPage">The current page of items</param>
     /// <param name="totalItems">The total number of items</param>
     /// <param name="items">The list of items that use this collection as a </param>
+    /// <param name="parentCollection">The parent collection current collection is part of</param>
     /// <param name="pathGenerator">A collection path generator</param>
     /// <param name="orderQueryParam">Used to describe the type of ordering done</param>
     /// <returns>An enriched presentation collection</returns>
     public static PresentationCollection EnrichPresentationCollection(this PresentationCollection presentationCollection, 
     Collection collection, int pageSize, int currentPage, int totalItems, List<Hierarchy>? items, 
-    IPathGenerator pathGenerator, string? orderQueryParam = null)
+    Collection parentCollection, IPathGenerator pathGenerator, string? orderQueryParam = null)
     {
         var totalPages = CollectionConverter.GenerateTotalPages(pageSize, totalItems);
 
@@ -43,7 +44,7 @@ public static class PresentationCollectionX
         presentationCollection.Id = pathGenerator.GenerateFlatCollectionId(collection);
         presentationCollection.PublicId = pathGenerator.GenerateHierarchicalCollectionId(collection);
         presentationCollection.Parent = CollectionConverter.GeneratePresentationCollectionParent(pathGenerator, hierarchy);
-        presentationCollection.PartOf = CollectionConverter.GeneratePartOf(hierarchy, collection, pathGenerator);
+        presentationCollection.PartOf = CollectionConverter.GeneratePartOf(parentCollection, pathGenerator);
         presentationCollection.View = CollectionConverter.GenerateView(collection, pathGenerator, pageSize, currentPage,
             totalPages, orderQueryParamConverted);
         presentationCollection.SeeAlso = CollectionConverter.GenerateSeeAlso(collection, pathGenerator);

--- a/src/IIIFPresentation/API/Features/Storage/Helpers/PresentationContextX.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Helpers/PresentationContextX.cs
@@ -72,6 +72,24 @@ public static class PresentationContextX
 
         return dbContextManifests.Retrieve(customerId, manifestId, tracked, cancellationToken);
     }
+    
+    /// <summary>
+    /// Retrieves a 'full' collection from the database, with the Hierarchy records (including Parent)
+    /// </summary>
+    /// <param name="dbContext">The context to pull records from</param>
+    /// <param name="customerId">Customer the record is attached to</param>
+    /// <param name="collectionId">The collection to retrieve</param>
+    /// <param name="tracked">Whether the resource should be tracked or not</param>
+    /// <param name="cancellationToken">A cancellation token</param>
+    /// <returns>The retrieved collection</returns>
+    public static Task<Collection?> RetrieveFullCollectionAsync(this PresentationContext dbContext, int customerId,
+        string collectionId, bool tracked = false, CancellationToken cancellationToken = default)
+    {
+        var collections = tracked ? dbContext.Collections : dbContext.Collections.AsNoTracking();
+        return collections
+            .Include(e => e.Hierarchy)!.ThenInclude(h => h.ParentCollection)
+            .FirstOrDefaultAsync(e => e.CustomerId == customerId && e.Id == collectionId, cancellationToken);
+    }
 
     /// <summary>
     /// Retrieves a collection from the database, with the Hierarchy records included
@@ -82,7 +100,7 @@ public static class PresentationContextX
     /// <param name="tracked">Whether the resource should be tracked or not</param>
     /// <param name="cancellationToken">A cancellation token</param>
     /// <returns>The retrieved collection</returns>
-    public static Task<Collection?> RetrieveCollectionAsync(this PresentationContext dbContext, int customerId,
+    public static Task<Collection?> RetrieveCollectionOnlyAsync(this PresentationContext dbContext, int customerId,
         string collectionId, bool tracked = false, CancellationToken cancellationToken = default)
         => dbContext.Collections.Retrieve(customerId, collectionId, tracked, cancellationToken);
 

--- a/src/IIIFPresentation/API/Features/Storage/Helpers/PresentationContextX.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Helpers/PresentationContextX.cs
@@ -82,7 +82,7 @@ public static class PresentationContextX
     /// <param name="tracked">Whether the resource should be tracked or not</param>
     /// <param name="cancellationToken">A cancellation token</param>
     /// <returns>The retrieved collection</returns>
-    public static Task<Collection?> RetrieveFullCollectionAsync(this PresentationContext dbContext, int customerId,
+    public static Task<Collection?> RetrieveCollectionWithParentAsync(this PresentationContext dbContext, int customerId,
         string collectionId, bool tracked = false, CancellationToken cancellationToken = default)
     {
         var collections = tracked ? dbContext.Collections : dbContext.Collections.AsNoTracking();
@@ -100,7 +100,7 @@ public static class PresentationContextX
     /// <param name="tracked">Whether the resource should be tracked or not</param>
     /// <param name="cancellationToken">A cancellation token</param>
     /// <returns>The retrieved collection</returns>
-    public static Task<Collection?> RetrieveCollectionOnlyAsync(this PresentationContext dbContext, int customerId,
+    public static Task<Collection?> RetrieveCollectionAsync(this PresentationContext dbContext, int customerId,
         string collectionId, bool tracked = false, CancellationToken cancellationToken = default)
         => dbContext.Collections.Retrieve(customerId, collectionId, tracked, cancellationToken);
 

--- a/src/IIIFPresentation/API/Features/Storage/Models/CollectionWithItems.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Models/CollectionWithItems.cs
@@ -9,10 +9,11 @@ public class CollectionWithItems(
     int totalItems,
     string? storedCollection = null)
 {
-    public Collection? Collection { get; init; } = collection;
-    public List<Hierarchy>? Items { get; init; } = items;
-    public int TotalItems { get; init; } = totalItems;
-    public string? StoredCollection { get; init; } = storedCollection;
+    public Collection? Collection { get; } = collection;
+    public List<Hierarchy>? Items { get; } = items;
+    public int TotalItems { get; } = totalItems;
+    public string? StoredCollection { get; } = storedCollection;
+    public Collection? ParentCollection => Collection?.Hierarchy?.SingleOrDefault()?.ParentCollection;
 
     public static CollectionWithItems Empty { get; private set; } = new(null, null, 0);
 }

--- a/src/IIIFPresentation/API/Features/Storage/Models/CollectionWithItems.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Models/CollectionWithItems.cs
@@ -15,5 +15,8 @@ public class CollectionWithItems(
     public string? StoredCollection { get; } = storedCollection;
     public Collection? ParentCollection => Collection?.Hierarchy?.SingleOrDefault()?.ParentCollection;
 
+    /// <summary>
+    /// Returns an empty <see cref="CollectionWithItems"/> object
+    /// </summary>
     public static CollectionWithItems Empty { get; private set; } = new(null, null, 0);
 }

--- a/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
@@ -58,7 +58,7 @@ public class CreateCollectionHandler(
         }
         
         // check parent exists
-        var parentCollection = await dbContext.RetrieveCollectionOnlyAsync(request.CustomerId,
+        var parentCollection = await dbContext.RetrieveCollectionAsync(request.CustomerId,
             request.Collection.Parent.GetLastPathElement(), cancellationToken: cancellationToken);
 
         if (parentCollection == null) return ErrorHelper.NullParentResponse<PresentationCollection>();

--- a/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
@@ -18,16 +18,18 @@ using Models.Database.General;
 using Repository;
 using Repository.Helpers;
 using Collection = Models.Database.Collections.Collection;
-using IIdGenerator = API.Infrastructure.IdGenerator.IIdGenerator;
 
 namespace API.Features.Storage.Requests;
 
+/// <summary>
+/// Create a new Collection (storage or iiif) in DB and upload provided JSON to S3 if iiif-collection
+/// </summary>
 public class CreateCollection(int customerId, PresentationCollection collection, string rawRequestBody)
     : IRequest<ModifyEntityResult<PresentationCollection, ModifyCollectionType>>
 {
     public int CustomerId { get; } = customerId;
 
-    public PresentationCollection? Collection { get; } = collection;
+    public PresentationCollection Collection { get; } = collection;
     
     public string RawRequestBody { get; } = rawRequestBody;
 }
@@ -56,8 +58,8 @@ public class CreateCollectionHandler(
         }
         
         // check parent exists
-        var parentCollection = await dbContext.RetrieveCollectionAsync(request.CustomerId,
-            request.Collection!.Parent.GetLastPathElement(), cancellationToken: cancellationToken);
+        var parentCollection = await dbContext.RetrieveCollectionOnlyAsync(request.CustomerId,
+            request.Collection.Parent.GetLastPathElement(), cancellationToken: cancellationToken);
 
         if (parentCollection == null) return ErrorHelper.NullParentResponse<PresentationCollection>();
 
@@ -90,23 +92,22 @@ public class CreateCollectionHandler(
             IsStorageCollection = isStorageCollection,
             Label = request.Collection.Label,
             Thumbnail = request.Collection.GetThumbnail(),
-        };
-
-        var hierarchy = new Hierarchy
-        {
-            CollectionId = id,
-            Type = isStorageCollection
-                ? ResourceType.StorageCollection
-                : ResourceType.IIIFCollection,
-            Slug = request.Collection.Slug,
-            CustomerId = request.CustomerId,
-            Canonical = true,
-            ItemsOrder = request.Collection.ItemsOrder,
-            Parent = parentCollection.Id
+            Hierarchy =
+            [
+                new Hierarchy
+                {
+                    Type = isStorageCollection
+                        ? ResourceType.StorageCollection
+                        : ResourceType.IIIFCollection,
+                    Slug = request.Collection.Slug,
+                    Canonical = true,
+                    ItemsOrder = request.Collection.ItemsOrder,
+                    Parent = parentCollection.Id
+                }
+            ]
         };
 
         dbContext.Collections.Add(collection);
-        dbContext.Hierarchy.Add(hierarchy);
 
         var saveErrors =
             await dbContext.TrySaveCollection<PresentationCollection>(request.CustomerId, logger,
@@ -120,14 +121,11 @@ public class CreateCollectionHandler(
         await UploadToS3IfRequiredAsync(collection, iiifCollection?.ConvertedIIIF, isStorageCollection,
             cancellationToken);
 
-        if (hierarchy.Parent != null)
-        {
-            collection.FullPath =
-                await CollectionRetrieval.RetrieveFullPathForCollection(collection, dbContext, cancellationToken);
-        }
-        
-        var enrichedPresentationCollection = request.Collection.EnrichPresentationCollection(collection, 
-            settings.PageSize, CurrentPage, 0, [], pathGenerator); // there can be no items attached to this, as it's just been created
+        collection.FullPath =
+            await CollectionRetrieval.RetrieveFullPathForCollection(collection, dbContext, cancellationToken);
+
+        var enrichedPresentationCollection = request.Collection.EnrichPresentationCollection(collection,
+            settings.PageSize, CurrentPage, 0, [], parentCollection, pathGenerator); // there can be no items attached to this, as it's just been created
         
         return ModifyEntityResult<PresentationCollection, ModifyCollectionType>.Success(
             enrichedPresentationCollection,

--- a/src/IIIFPresentation/API/Features/Storage/Requests/DeleteCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/DeleteCollection.cs
@@ -38,16 +38,8 @@ public class DeleteCollectionHandler(
         
         if (collection is null) return new ResultMessage<DeleteResult, DeleteCollectionType>(DeleteResult.NotFound);
         
-        var hierarchy = collection.Hierarchy!.First(c => c.Canonical);
-        
-        if (hierarchy.Parent is null)
-        {
-            return new ResultMessage<DeleteResult, DeleteCollectionType>(DeleteResult.BadRequest,
-                DeleteCollectionType.CannotDeleteRootCollection, "Cannot delete a root collection");
-        }
-
         var hasItems = await dbContext.Hierarchy.AnyAsync(
-            c => c.CustomerId == request.CustomerId && c.Parent == hierarchy.CollectionId,
+            c => c.CustomerId == request.CustomerId && c.Parent == collection.Id,
             cancellationToken: cancellationToken);
 
         if (hasItems)

--- a/src/IIIFPresentation/API/Features/Storage/Requests/DeleteCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/DeleteCollection.cs
@@ -1,4 +1,5 @@
-﻿using API.Infrastructure.AWS;
+﻿using API.Features.Storage.Helpers;
+using API.Infrastructure.AWS;
 using Core;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
@@ -32,8 +33,8 @@ public class DeleteCollectionHandler(
                 DeleteCollectionType.CannotDeleteRootCollection, "Cannot delete a root collection");
         }
 
-        var collection = await dbContext.Collections.Include(c => c.Hierarchy).FirstOrDefaultAsync(c =>
-            c.Id == request.CollectionId && c.CustomerId == request.CustomerId, cancellationToken);
+        var collection =
+            await dbContext.RetrieveCollectionAsync(request.CustomerId, request.CollectionId, true, cancellationToken);
         
         if (collection is null) return new ResultMessage<DeleteResult, DeleteCollectionType>(DeleteResult.NotFound);
         

--- a/src/IIIFPresentation/API/Features/Storage/Requests/GetCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/GetCollection.cs
@@ -32,7 +32,7 @@ public class GetCollectionHandler(PresentationContext dbContext, IPathGenerator 
     public async Task<CollectionWithItems> Handle(GetCollection request,
         CancellationToken cancellationToken)
     {
-        var collection = await dbContext.RetrieveFullCollectionAsync(request.CustomerId, request.Id, cancellationToken: cancellationToken);
+        var collection = await dbContext.RetrieveCollectionWithParentAsync(request.CustomerId, request.Id, cancellationToken: cancellationToken);
         
         if (collection is null) return CollectionWithItems.Empty;
 

--- a/src/IIIFPresentation/API/Features/Storage/Requests/GetCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/GetCollection.cs
@@ -32,7 +32,7 @@ public class GetCollectionHandler(PresentationContext dbContext, IPathGenerator 
     public async Task<CollectionWithItems> Handle(GetCollection request,
         CancellationToken cancellationToken)
     {
-        var collection = await dbContext.RetrieveCollectionAsync(request.CustomerId, request.Id, cancellationToken: cancellationToken);
+        var collection = await dbContext.RetrieveFullCollectionAsync(request.CustomerId, request.Id, cancellationToken: cancellationToken);
         
         if (collection is null) return CollectionWithItems.Empty;
 

--- a/src/IIIFPresentation/API/Features/Storage/Requests/UpsertCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/UpsertCollection.cs
@@ -61,7 +61,7 @@ public class UpsertCollectionHandler(
             if (iiifCollection.Error) return ErrorHelper.CannotValidateIIIF<PresentationCollection>();
         }
         var databaseCollection =
-            await dbContext.RetrieveFullCollectionAsync(request.CustomerId, request.CollectionId, true, cancellationToken);
+            await dbContext.RetrieveCollectionWithParentAsync(request.CustomerId, request.CollectionId, true, cancellationToken);
 
         Collection parentCollection;
         
@@ -72,7 +72,7 @@ public class UpsertCollectionHandler(
 
             var createdDate = DateTime.UtcNow;
             
-            parentCollection = await dbContext.RetrieveCollectionOnlyAsync(request.CustomerId,
+            parentCollection = await dbContext.RetrieveCollectionAsync(request.CustomerId,
                 request.Collection.Parent.GetLastPathElement(), true, cancellationToken);
             
             if (parentCollection == null) return ErrorHelper.NullParentResponse<PresentationCollection>();
@@ -128,7 +128,7 @@ public class UpsertCollectionHandler(
             var parentId = existingHierarchy.Parent;
             if (parentId != request.Collection.Parent)
             {
-                parentCollection = await dbContext.RetrieveCollectionOnlyAsync(request.CustomerId,
+                parentCollection = await dbContext.RetrieveCollectionAsync(request.CustomerId,
                     request.Collection.Parent.GetLastPathElement(), cancellationToken: cancellationToken);
                 logger.LogDebug("Collection {CollectionId} for Customer {CustomerId} is moving parent",
                     request.CollectionId, request.CustomerId);

--- a/src/IIIFPresentation/API/Features/Storage/StorageController.cs
+++ b/src/IIIFPresentation/API/Features/Storage/StorageController.cs
@@ -37,8 +37,7 @@ public class StorageController(
     [VaryHeader]
     public async Task<IActionResult> GetHierarchical(int customerId, string slug = "")
     {
-        var hierarchy =
-            await dbContext.RetrieveHierarchy(customerId, slug);
+        var hierarchy = await dbContext.RetrieveHierarchy(customerId, slug);
 
         switch (hierarchy?.Type)
         {
@@ -53,7 +52,7 @@ public class StorageController(
             case ResourceType.StorageCollection:
                 var storageRoot = await Mediator.Send(new GetHierarchicalCollection(hierarchy, slug));
 
-                if (storageRoot.Collection is not {IsPublic: true}) return this.PresentationNotFound();
+                if (storageRoot.Collection == null) return this.PresentationNotFound();
 
                 if (Request.HasShowExtraHeader() && await authenticator.ValidateRequest(Request) == AuthResult.Success)
                 {

--- a/src/IIIFPresentation/API/Properties/launchSettings.json
+++ b/src/IIIFPresentation/API/Properties/launchSettings.json
@@ -1,18 +1,10 @@
 ﻿{
   "$schema": "http://json.schemastore.org/launchsettings.json",
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:13043",
-      "sslPort": 44325
-    }
-  },
   "profiles": {
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": true,
+      "launchBrowser": false,
       "launchUrl": "swagger",
       "applicationUrl": "http://localhost:5174",
       "environmentVariables": {
@@ -22,17 +14,9 @@
     "https": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": true,
+      "launchBrowser": false,
       "launchUrl": "swagger",
       "applicationUrl": "https://localhost:7230;http://localhost:5174",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "launchUrl": "swagger",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/IIIFPresentation/Models/Database/Collections/Collection.cs
+++ b/src/IIIFPresentation/Models/Database/Collections/Collection.cs
@@ -75,4 +75,9 @@ public class Collection : IHierarchyResource
     /// </summary>
     [NotMapped]
     public string? FullPath { get; set; }
+
+    /// <summary>
+    /// Navigation property for any children, when this Collection is the parent
+    /// </summary>
+    public IEnumerable<Hierarchy>? Children { get; set; }
 }

--- a/src/IIIFPresentation/Models/Database/General/Hierarchy.cs
+++ b/src/IIIFPresentation/Models/Database/General/Hierarchy.cs
@@ -32,7 +32,12 @@ public class Hierarchy
     public string? Parent { get; set; }
     
     /// <summary>
-    /// Used to determine the order of the item when viewed in a collection
+    /// Navigation property for Parent collection
+    /// </summary>
+    public Collection? ParentCollection { get; set; }
+    
+    /// <summary>
+    /// Used to determine the order of the item when viewed in a Collection
     /// </summary>
     public int? ItemsOrder { get; set; }
     

--- a/src/IIIFPresentation/Repository/Migrations/20241206173850_Hierarchy parent fk.Designer.cs
+++ b/src/IIIFPresentation/Repository/Migrations/20241206173850_Hierarchy parent fk.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Repository;
@@ -11,9 +12,11 @@ using Repository;
 namespace Repository.Migrations
 {
     [DbContext(typeof(PresentationContext))]
-    partial class PresentationContextModelSnapshot : ModelSnapshot
+    [Migration("20241206173850_Hierarchy parent fk")]
+    partial class Hierarchyparentfk
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/IIIFPresentation/Repository/Migrations/20241206173850_Hierarchy parent fk.cs
+++ b/src/IIIFPresentation/Repository/Migrations/20241206173850_Hierarchy parent fk.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Repository.Migrations
+{
+    /// <inheritdoc />
+    public partial class Hierarchyparentfk : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddUniqueConstraint(
+                name: "ak_collections_customer_id_id",
+                table: "collections",
+                columns: new[] { "customer_id", "id" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_hierarchy_customer_id_parent",
+                table: "hierarchy",
+                columns: new[] { "customer_id", "parent" });
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_hierarchy_collections_customer_id_parent",
+                table: "hierarchy",
+                columns: new[] { "customer_id", "parent" },
+                principalTable: "collections",
+                principalColumns: new[] { "customer_id", "id" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "fk_hierarchy_collections_customer_id_parent",
+                table: "hierarchy");
+
+            migrationBuilder.DropIndex(
+                name: "ix_hierarchy_customer_id_parent",
+                table: "hierarchy");
+
+            migrationBuilder.DropUniqueConstraint(
+                name: "ak_collections_customer_id_id",
+                table: "collections");
+        }
+    }
+}

--- a/src/IIIFPresentation/Repository/Migrations/20241210091216_Hierarchy parent fk.Designer.cs
+++ b/src/IIIFPresentation/Repository/Migrations/20241210091216_Hierarchy parent fk.Designer.cs
@@ -12,7 +12,7 @@ using Repository;
 namespace Repository.Migrations
 {
     [DbContext(typeof(PresentationContext))]
-    [Migration("20241206173850_Hierarchy parent fk")]
+    [Migration("20241210091216_Hierarchy parent fk")]
     partial class Hierarchyparentfk
     {
         /// <inheritdoc />
@@ -167,9 +167,6 @@ namespace Repository.Migrations
                     b.HasKey("Id", "CustomerId")
                         .HasName("pk_collections");
 
-                    b.HasAlternateKey("CustomerId", "Id")
-                        .HasName("ak_collections_customer_id_id");
-
                     b.ToTable("collections", (string)null);
                 });
 
@@ -262,8 +259,8 @@ namespace Repository.Migrations
                     b.HasKey("Id")
                         .HasName("pk_hierarchy");
 
-                    b.HasIndex("CustomerId", "Parent")
-                        .HasDatabaseName("ix_hierarchy_customer_id_parent");
+                    b.HasIndex("Parent", "CustomerId")
+                        .HasDatabaseName("ix_hierarchy_parent_customer_id");
 
                     b.HasIndex("CollectionId", "CustomerId", "Canonical")
                         .IsUnique()
@@ -305,18 +302,17 @@ namespace Repository.Migrations
                         .OnDelete(DeleteBehavior.Cascade)
                         .HasConstraintName("fk_hierarchy_collections_collection_id_customer_id");
 
-                    b.HasOne("Models.Database.Collections.Collection", "ParentCollection")
-                        .WithMany("Children")
-                        .HasForeignKey("CustomerId", "Parent")
-                        .HasPrincipalKey("CustomerId", "Id")
-                        .OnDelete(DeleteBehavior.NoAction)
-                        .HasConstraintName("fk_hierarchy_collections_customer_id_parent");
-
                     b.HasOne("Models.Database.Collections.Manifest", "Manifest")
                         .WithMany("Hierarchy")
                         .HasForeignKey("ManifestId", "CustomerId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .HasConstraintName("fk_hierarchy_manifests_manifest_id_customer_id");
+
+                    b.HasOne("Models.Database.Collections.Collection", "ParentCollection")
+                        .WithMany("Children")
+                        .HasForeignKey("Parent", "CustomerId")
+                        .OnDelete(DeleteBehavior.NoAction)
+                        .HasConstraintName("fk_hierarchy_collections_parent_customer_id");
 
                     b.Navigation("Collection");
 

--- a/src/IIIFPresentation/Repository/Migrations/20241210091216_Hierarchy parent fk.cs
+++ b/src/IIIFPresentation/Repository/Migrations/20241210091216_Hierarchy parent fk.cs
@@ -10,38 +10,29 @@ namespace Repository.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.AddUniqueConstraint(
-                name: "ak_collections_customer_id_id",
-                table: "collections",
-                columns: new[] { "customer_id", "id" });
-
             migrationBuilder.CreateIndex(
-                name: "ix_hierarchy_customer_id_parent",
+                name: "ix_hierarchy_parent_customer_id",
                 table: "hierarchy",
-                columns: new[] { "customer_id", "parent" });
+                columns: new[] { "parent", "customer_id" });
 
             migrationBuilder.AddForeignKey(
-                name: "fk_hierarchy_collections_customer_id_parent",
+                name: "fk_hierarchy_collections_parent_customer_id",
                 table: "hierarchy",
-                columns: new[] { "customer_id", "parent" },
+                columns: new[] { "parent", "customer_id" },
                 principalTable: "collections",
-                principalColumns: new[] { "customer_id", "id" });
+                principalColumns: new[] { "id", "customer_id" });
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.DropForeignKey(
-                name: "fk_hierarchy_collections_customer_id_parent",
+                name: "fk_hierarchy_collections_parent_customer_id",
                 table: "hierarchy");
 
             migrationBuilder.DropIndex(
-                name: "ix_hierarchy_customer_id_parent",
+                name: "ix_hierarchy_parent_customer_id",
                 table: "hierarchy");
-
-            migrationBuilder.DropUniqueConstraint(
-                name: "ak_collections_customer_id_id",
-                table: "collections");
         }
     }
 }

--- a/src/IIIFPresentation/Repository/Migrations/PresentationContextModelSnapshot.cs
+++ b/src/IIIFPresentation/Repository/Migrations/PresentationContextModelSnapshot.cs
@@ -164,9 +164,6 @@ namespace Repository.Migrations
                     b.HasKey("Id", "CustomerId")
                         .HasName("pk_collections");
 
-                    b.HasAlternateKey("CustomerId", "Id")
-                        .HasName("ak_collections_customer_id_id");
-
                     b.ToTable("collections", (string)null);
                 });
 
@@ -259,8 +256,8 @@ namespace Repository.Migrations
                     b.HasKey("Id")
                         .HasName("pk_hierarchy");
 
-                    b.HasIndex("CustomerId", "Parent")
-                        .HasDatabaseName("ix_hierarchy_customer_id_parent");
+                    b.HasIndex("Parent", "CustomerId")
+                        .HasDatabaseName("ix_hierarchy_parent_customer_id");
 
                     b.HasIndex("CollectionId", "CustomerId", "Canonical")
                         .IsUnique()
@@ -302,18 +299,17 @@ namespace Repository.Migrations
                         .OnDelete(DeleteBehavior.Cascade)
                         .HasConstraintName("fk_hierarchy_collections_collection_id_customer_id");
 
-                    b.HasOne("Models.Database.Collections.Collection", "ParentCollection")
-                        .WithMany("Children")
-                        .HasForeignKey("CustomerId", "Parent")
-                        .HasPrincipalKey("CustomerId", "Id")
-                        .OnDelete(DeleteBehavior.NoAction)
-                        .HasConstraintName("fk_hierarchy_collections_customer_id_parent");
-
                     b.HasOne("Models.Database.Collections.Manifest", "Manifest")
                         .WithMany("Hierarchy")
                         .HasForeignKey("ManifestId", "CustomerId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .HasConstraintName("fk_hierarchy_manifests_manifest_id_customer_id");
+
+                    b.HasOne("Models.Database.Collections.Collection", "ParentCollection")
+                        .WithMany("Children")
+                        .HasForeignKey("Parent", "CustomerId")
+                        .OnDelete(DeleteBehavior.NoAction)
+                        .HasConstraintName("fk_hierarchy_collections_parent_customer_id");
 
                     b.Navigation("Collection");
 

--- a/src/IIIFPresentation/Repository/PresentationContext.cs
+++ b/src/IIIFPresentation/Repository/PresentationContext.cs
@@ -51,8 +51,8 @@ public class PresentationContext : DbContext
 
             entity.HasMany(e => e.Children)
                 .WithOne(e => e.ParentCollection)
-                .HasForeignKey(e => new { e.CustomerId, e.Parent })
-                .HasPrincipalKey(e => new { e.CustomerId, e.Id })
+                .HasForeignKey(e => new { e.Parent, e.CustomerId })
+                .HasPrincipalKey(e => new { e.Id, e.CustomerId })
                 .OnDelete(DeleteBehavior.NoAction);
         });
         

--- a/src/IIIFPresentation/Repository/PresentationContext.cs
+++ b/src/IIIFPresentation/Repository/PresentationContext.cs
@@ -48,6 +48,12 @@ public class PresentationContext : DbContext
                 .HasForeignKey(e => new { e.CollectionId, e.CustomerId })
                 .HasPrincipalKey(e => new { e.Id, e.CustomerId })
                 .OnDelete(DeleteBehavior.Cascade);
+
+            entity.HasMany(e => e.Children)
+                .WithOne(e => e.ParentCollection)
+                .HasForeignKey(e => new { e.CustomerId, e.Parent })
+                .HasPrincipalKey(e => new { e.CustomerId, e.Id })
+                .OnDelete(DeleteBehavior.NoAction);
         });
         
         modelBuilder.Entity<Manifest>(entity =>


### PR DESCRIPTION
Fixes #166 and #167

## #166 - incorrect `"partOf"`

Introduced a couple of navigation properties; `Hierarchy` gains `ParentCollection` and `Collection` gains `Children`. It's unlikely that the latter will be used but it's there should we need it. The former allows us to load the parent of the current collection when rendering collection to set the `"partOf"` - previously it was using current collections label and redirecting to parent hierarchical path - now it's using parent label and parent flat-id.

Renamed `ToFlatCollection` to `ToPresentationCollection` to reflect the name of the return type.

## #167 - exclude non-public from `"items"` in hierarchical collection

This was adding a bool to `RetrieveCollectionItems` in `GetHierarchicalCollection` but also slightly refactored this:
* Rather than checking if collection is public or not in calling controller, encapsulate that logic in the request handler, this shortcuts the request and moves the decision making into the handler.
* Use multiple returns; there are 2 distinct paths for iiif-collection or storage-collection so have a return in each. These fall through to a single `empty` return for any cases that can't be fulfulled