### PR TITLE
Fix null behavior returning internal server error

### DIFF
--- a/src/IIIFPresentation/API.Tests/Features/Storage/Helpers/BehaviourXTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Storage/Helpers/BehaviourXTests.cs
@@ -1,0 +1,42 @@
+﻿
+using API.Features.Storage.Helpers;
+using Models.Infrastucture;
+
+namespace API.Tests.Features.Storage.Helpers;
+
+public class BehaviourXTests
+{
+    [Fact]
+    public void Behaviors_ShouldBeFalseWhenEmptyList()
+    {
+        // Arrange
+        var behaviors = new List<string>();
+        
+        behaviors.IsPublic().Should().BeFalse();
+        behaviors.IsStorageCollection().Should().BeFalse();
+    }
+    
+    [Fact]
+    public void Behaviors_ShouldBeTrueWhenExists()
+    {
+        // Arrange
+        var behaviors = new List<string>()
+        {
+            Behavior.IsPublic,
+            Behavior.IsStorageCollection
+        };
+        
+        behaviors.IsPublic().Should().BeTrue();
+        behaviors.IsStorageCollection().Should().BeTrue();
+    }
+    
+    [Fact]
+    public void Behaviors_ShouldBeFalseWhenNull()
+    {
+        // Arrange
+        List<string>? behaviors = null;
+        
+        behaviors.IsPublic().Should().BeFalse();
+        behaviors.IsStorageCollection().Should().BeFalse();
+    }
+}

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyCollectionTests.cs
@@ -635,6 +635,68 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
     }
+    
+    [Fact]
+    public async Task CreateCollection_CreatesNonPublicIIIFCollection_WhenNullBehavior()
+    {
+        // Arrange
+        var slug = nameof(CreateCollection_CreatesNonPublicIIIFCollection_WhenNullBehavior);
+        var collection = $@"{{
+   ""type"": ""Collection"",
+   ""label"": {{
+       ""en"": [
+           ""iiif post""
+       ]
+   }},
+    ""slug"": ""{slug}"",
+    ""parent"": ""{parent}"",
+    ""tags"": ""some, tags"",
+    ""itemsOrder"": 1,
+    ""thumbnail"": [
+        {{
+          ""id"": ""https://example.org/img/thumb.jpg"",
+          ""type"": ""Image"",
+          ""format"": ""image/jpeg"",
+          ""width"": 300,
+          ""height"": 200
+        }}
+    ]
+}}";
+        var requestMessage = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Post, $"{Customer}/collections",
+            collection);
+
+        // Act
+        var response = await httpClient.AsCustomer().SendAsync(requestMessage);
+
+        var responseCollection = await response.ReadAsPresentationResponseAsync<PresentationCollection>();
+
+        var id = responseCollection!.Id!.Split('/', StringSplitOptions.TrimEntries).Last();
+
+        var fromDatabase = dbContext.Collections.First(c => c.Id == id);
+        var hierarchyFromDatabase = dbContext.Hierarchy.First(h => h.CustomerId == 1 && h.CollectionId == id);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        fromDatabase.Id.Length.Should().BeGreaterThan(6);
+        hierarchyFromDatabase.Parent.Should().Be(parent);
+        fromDatabase.Label!.Values.First()[0].Should().Be("iiif post");
+        hierarchyFromDatabase.Slug.Should().Be(slug);
+        hierarchyFromDatabase.ItemsOrder.Should().Be(1);
+        fromDatabase.Thumbnail.Should().Be("https://example.org/img/thumb.jpg");
+        fromDatabase.IsPublic.Should().BeFalse();
+        fromDatabase.IsStorageCollection.Should().BeFalse();
+        fromDatabase.Modified.Should().Be(fromDatabase.Created);
+        responseCollection!.View!.PageSize.Should().Be(20);
+        responseCollection.View.Page.Should().Be(1);
+        responseCollection.View.Id.Should().Contain("?page=1&pageSize=20");
+        responseCollection.PartOf.Single().Id.Should().Be("http://localhost/1/collections/root");
+        responseCollection.PartOf.Single().Label["en"].Single().Should().Be("repository root");
+        
+        var context = (JArray)responseCollection.Context;
+        context.First.Value<string>().Should().Be("http://tbc.org/iiif-repository/1/context.json");
+        context.Last.Value<string>().Should().Be("http://iiif.io/api/presentation/3/context.json");
+        
+    }
 
     [Fact]
     public async Task UpdateCollection_ReturnsUnauthorized_WhenCalledWithoutAuth()
@@ -1671,6 +1733,55 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         error.Detail.Should().Be("Could not deserialize collection");
     }
+    
+    [Fact]
+    public async Task UpdateCollection_CreatesNonPublicIIIFCollection_WhenNoBehavior()
+    {
+        // Arrange
+        var updatedCollection = new PresentationCollection()
+        {
+            Label = new LanguageMap("en", ["test collection - create from update"]),
+            Slug = "create-from-update",
+            Parent = parent,
+            ItemsOrder = 1,
+            PresentationThumbnail = "some/location/2",
+            Tags = "some, tags, 2",
+        };
+
+        var updateRequestMessage = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Put,
+            $"{Customer}/collections/createFromUpdate", updatedCollection.AsJson());
+        
+        // Act
+        var response = await httpClient.AsCustomer().SendAsync(updateRequestMessage);
+
+        var responseCollection = await response.ReadAsPresentationResponseAsync<PresentationCollection>();
+
+        var id = responseCollection!.Id!.Split('/', StringSplitOptions.TrimEntries).Last();
+
+        var fromDatabase = dbContext.Collections.First(c => c.Id == id);
+        var hierarchyFromDatabase = dbContext.Hierarchy.First(h => h.CustomerId == 1 && h.CollectionId == id);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        fromDatabase.Id.Should().Be("createFromUpdate");
+        hierarchyFromDatabase.Parent.Should().Be(parent);
+        fromDatabase.Label!.Values.First()[0].Should().Be("test collection - create from update");
+        hierarchyFromDatabase.Slug.Should().Be("create-from-update");
+        hierarchyFromDatabase.ItemsOrder.Should().Be(1);
+        fromDatabase.Thumbnail.Should().Be("some/location/2");
+        fromDatabase.Tags.Should().Be("some, tags, 2");
+        fromDatabase.IsPublic.Should().BeFalse();
+        fromDatabase.IsStorageCollection.Should().BeFalse();
+        responseCollection!.View!.PageSize.Should().Be(20);
+        responseCollection.View.Page.Should().Be(1);
+        responseCollection.View.Id.Should().Contain("?page=1&pageSize=20");
+        responseCollection.PartOf.Single().Id.Should().Be("http://localhost/1/collections/root");
+        responseCollection.PartOf.Single().Label["en"].Single().Should().Be("repository root");
+        
+        var context = (JArray)responseCollection.Context;
+        context.First.Value<string>().Should().Be("http://tbc.org/iiif-repository/1/context.json");
+        context.Last.Value<string>().Should().Be("http://iiif.io/api/presentation/3/context.json");
+    }
 
     [Fact]
     public async Task CreateCollection_CreatesMinimalCollection_ViaHierarchicalCollection()
@@ -1927,7 +2038,7 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
         s3Manifest.Id.Should().EndWith(fromDatabase.Id, "Stored Id is flat path");
         (s3Manifest.Context as string).Should()
             .Be("http://iiif.io/api/presentation/3/context.json", "Context set automatically");
-    }
+    }  
     
     private void SetCorrectEtag(HttpRequestMessage requestMessage, Collection dbCollection)
     {

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyCollectionTests.cs
@@ -1737,11 +1737,14 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
     [Fact]
     public async Task UpdateCollection_CreatesNonPublicIIIFCollection_WhenNoBehavior()
     {
+        var collectionId = "noBehavior";
+        var slug = nameof(UpdateCollection_CreatesNonPublicIIIFCollection_WhenNoBehavior);
+        
         // Arrange
         var updatedCollection = new PresentationCollection()
         {
             Label = new LanguageMap("en", ["test collection - create from update"]),
-            Slug = "create-from-update",
+            Slug = slug,
             Parent = parent,
             ItemsOrder = 1,
             PresentationThumbnail = "some/location/2",
@@ -1749,7 +1752,7 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
         };
 
         var updateRequestMessage = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Put,
-            $"{Customer}/collections/createFromUpdate", updatedCollection.AsJson());
+            $"{Customer}/collections/{collectionId}", updatedCollection.AsJson());
         
         // Act
         var response = await httpClient.AsCustomer().SendAsync(updateRequestMessage);
@@ -1763,10 +1766,10 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        fromDatabase.Id.Should().Be("createFromUpdate");
+        fromDatabase.Id.Should().Be(collectionId);
         hierarchyFromDatabase.Parent.Should().Be(parent);
         fromDatabase.Label!.Values.First()[0].Should().Be("test collection - create from update");
-        hierarchyFromDatabase.Slug.Should().Be("create-from-update");
+        hierarchyFromDatabase.Slug.Should().Be(slug);
         hierarchyFromDatabase.ItemsOrder.Should().Be(1);
         fromDatabase.Thumbnail.Should().Be("some/location/2");
         fromDatabase.Tags.Should().Be("some, tags, 2");

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyCollectionTests.cs
@@ -2041,7 +2041,7 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
         s3Manifest.Id.Should().EndWith(fromDatabase.Id, "Stored Id is flat path");
         (s3Manifest.Context as string).Should()
             .Be("http://iiif.io/api/presentation/3/context.json", "Context set automatically");
-    }  
+    }
     
     private void SetCorrectEtag(HttpRequestMessage requestMessage, Collection dbCollection)
     {

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
@@ -93,7 +93,7 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         var error = await response.ReadAsPresentationResponseAsync<Error>();
         error!.Detail.Should().Be("A request with assets requires the space header to be set");
-        error.ErrorTypeUri.Should().Be("http://localhost/errors/ModifyCollectionType/RequiresSpace");
+        error.ErrorTypeUri.Should().Be("http://localhost/errors/ModifyCollectionType/RequiresSpaceHeader");
     }
     
     [Fact]

--- a/src/IIIFPresentation/API/Features/Storage/Helpers/BehaviorX.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Helpers/BehaviorX.cs
@@ -4,13 +4,13 @@ namespace API.Features.Storage.Helpers;
 
 public static class BehaviorX
 {
-    public static bool IsPublic(this List<string> behaviors)
+    public static bool IsPublic(this List<string>? behaviors)
     {
-        return behaviors.Contains(Behavior.IsPublic);
+        return behaviors?.Contains(Behavior.IsPublic) ?? false;
     }
     
-    public static bool IsStorageCollection(this List<string> behaviors)
+    public static bool IsStorageCollection(this List<string>? behaviors)
     {
-        return behaviors.Contains(Behavior.IsStorageCollection);
+        return behaviors?.Contains(Behavior.IsStorageCollection) ?? false;
     }
 }

--- a/src/IIIFPresentation/API/Features/Storage/Helpers/ErrorHelper.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Helpers/ErrorHelper.cs
@@ -60,7 +60,7 @@ public static class ErrorHelper
     public static ModifyEntityResult<T, ModifyCollectionType> SpaceRequired<T>()
         where T : class
         => ModifyEntityResult<T, ModifyCollectionType>.Failure(
-            "A request with assets requires the space header to be set", ModifyCollectionType.RequiresSpace,
+            "A request with assets requires the space header to be set", ModifyCollectionType.RequiresSpaceHeader,
             WriteResult.BadRequest);
     
     public static ModifyEntityResult<T, ModifyCollectionType> CouldNotRetrieveAssetId<T>()

--- a/src/IIIFPresentation/Models/API/General/ModifyCollectionType.cs
+++ b/src/IIIFPresentation/Models/API/General/ModifyCollectionType.cs
@@ -13,7 +13,7 @@ public enum ModifyCollectionType
     ParentMustBeStorageCollection = 9,
     CannotChangeCollectionType = 10,
     ErrorCreatingSpace = 11,
-    RequiresSpace = 12,
+    RequiresSpaceHeader = 12,
     CouldNotRetrieveAssetId = 13,
     DlcsException = 14,
     ValidationFailed = 15,


### PR DESCRIPTION
resolves #165 

This PR creates a fallback value of `false` for `behavior` extension methods, causing them to not throw an error when `behavior` is null