### PR TITLE
Ignore painted resource when items are also present

### DIFF
--- a/src/IIIFPresentation/API.Tests/Features/Manifest/Validators/PresentationManifestValidatorTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Manifest/Validators/PresentationManifestValidatorTests.cs
@@ -1,12 +1,24 @@
 ﻿using API.Features.Manifest.Validators;
+using API.Settings;
+using AWS.Settings;
+using DLCS;
 using FluentValidation.TestHelper;
+using IIIF.Presentation.V3;
+using Microsoft.Extensions.Options;
 using Models.API.Manifest;
 
 namespace API.Tests.Features.Manifest.Validators;
 
 public class PresentationManifestValidatorTests
 {
-    private readonly PresentationManifestValidator sut = new();
+    private readonly PresentationManifestValidator sut = new(Options.Create(new ApiSettings()
+    {
+        AWS = new AWSSettings(),
+        DLCS = new DlcsSettings
+        {
+            ApiUri = new Uri("https://localhost")
+        }
+    }));
 
     [Theory]
     [InlineData(null)]
@@ -28,5 +40,71 @@ public class PresentationManifestValidatorTests
         
         var result = sut.TestValidate(manifest);
         result.ShouldHaveValidationErrorFor(m => m.Parent);
+    }
+    
+    [Fact]
+    public void CanvasPaintingAndItems_Manifest_ErrorWhenDefaultSettings()
+    {
+        var manifest = new PresentationManifest
+        {
+            Items = new List<Canvas>()
+            {
+                new ()
+                {
+                    Id = "someId",
+                }
+            },
+            PaintedResources = new List<PaintedResource>()
+            {
+                new ()
+                {
+                    CanvasPainting = new CanvasPainting()
+                    {
+                        CanvasId = "someCanvasId"
+                    }
+                }
+            },
+        };
+        
+        var result = sut.TestValidate(manifest);
+        result.ShouldHaveValidationErrorFor(m => m.Items);
+    }
+    
+    [Fact]
+    public void CanvasPaintingAndItems_Manifest_NoErrorWhenSettings()
+    {
+        var sutAllowedItemsAndPaintedResource = new  PresentationManifestValidator(Options.Create(new ApiSettings()
+        {
+            AWS = new AWSSettings(),
+            IgnorePaintedResourcesWithItems = true,
+            DLCS = new DlcsSettings
+            {
+                ApiUri = new Uri("https://localhost")
+            }
+        }));
+        
+        var manifest = new PresentationManifest
+        {
+            Items = new List<Canvas>()
+            {
+                new ()
+                {
+                    Id = "someId",
+                }
+            },
+            PaintedResources = new List<PaintedResource>()
+            {
+                new ()
+                {
+                    CanvasPainting = new CanvasPainting()
+                    {
+                        CanvasId = "someCanvasId"
+                    }
+                }
+            },
+        };
+        
+        var result = sutAllowedItemsAndPaintedResource.TestValidate(manifest);
+        result.ShouldNotHaveValidationErrorFor(m => m.Items);
     }
 }

--- a/src/IIIFPresentation/API.Tests/appsettings.Testing.json
+++ b/src/IIIFPresentation/API.Tests/appsettings.Testing.json
@@ -3,6 +3,7 @@
   "ResourceRoot": "https://localhost:7230",
   "PageSize": 20,
   "MaxPageSize": 100,
+  "IgnorePaintedResourcesWithItems": true,
   "AWS": {
     "S3": {
       "StorageBucket": "presentation-storage"

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestService.cs
@@ -10,20 +10,15 @@ using API.Infrastructure.Validation;
 using Core;
 using Core.Auth;
 using Core.Helpers;
-using DLCS;
 using DLCS.API;
 using DLCS.Exceptions;
 using IIIF.Serialisation;
-using Microsoft.Extensions.Options;
 using Models.API.General;
 using Models.API.Manifest;
 using Models.Database.Collections;
 using Models.Database.General;
-using Newtonsoft.Json.Linq;
 using Repository;
 using Repository.Helpers;
-using Batch = DLCS.Models.Batch;
-using CanvasPainting = Models.Database.CanvasPainting;
 using Collection = Models.Database.Collections.Collection;
 using DbManifest = Models.Database.Collections.Manifest;
 using PresUpdateResult = API.Infrastructure.Requests.ModifyEntityResult<Models.API.Manifest.PresentationManifest, Models.API.General.ModifyCollectionType>;
@@ -122,6 +117,12 @@ public class ManifestService(
     {
         var (parentErrors, parentCollection) = await TryGetParent(request, cancellationToken);
         if (parentErrors != null) return parentErrors;
+
+        if (!request.PresentationManifest.Items.IsNullOrEmpty() && 
+            !request.PresentationManifest.PaintedResources.IsNullOrEmpty())
+        {
+            request.PresentationManifest.PaintedResources = null;
+        }
 
         using (logger.BeginScope("Creating Manifest for Customer {CustomerId}", request.CustomerId))
         {

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestService.cs
@@ -7,12 +7,14 @@ using API.Infrastructure.AWS;
 using API.Infrastructure.Helpers;
 using API.Infrastructure.IdGenerator;
 using API.Infrastructure.Validation;
+using API.Settings;
 using Core;
 using Core.Auth;
 using Core.Helpers;
 using DLCS.API;
 using DLCS.Exceptions;
 using IIIF.Serialisation;
+using Microsoft.Extensions.Options;
 using Models.API.General;
 using Models.API.Manifest;
 using Models.Database.Collections;
@@ -54,10 +56,13 @@ public class ManifestService(
     IIIFS3Service iiifS3,
     IETagManager eTagManager,
     CanvasPaintingResolver canvasPaintingResolver,
+    IOptions<ApiSettings> options,
     IPathGenerator pathGenerator,
     IDlcsApiClient dlcsApiClient,
     ILogger<ManifestService> logger)
 {
+    private readonly ApiSettings settings = options.Value;
+    
     /// <summary>
     /// Create or update full manifest, using details provided in request object
     /// </summary>
@@ -119,7 +124,7 @@ public class ManifestService(
         if (parentErrors != null) return parentErrors;
 
         // can't have both items and painted resources, so items takes precedence
-        if (!request.PresentationManifest.Items.IsNullOrEmpty() && 
+        if (settings.IgnorePaintedResourcesWithItems && !request.PresentationManifest.Items.IsNullOrEmpty() && 
             !request.PresentationManifest.PaintedResources.IsNullOrEmpty())
         {
             request.PresentationManifest.PaintedResources = null;

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestService.cs
@@ -118,6 +118,7 @@ public class ManifestService(
         var (parentErrors, parentCollection) = await TryGetParent(request, cancellationToken);
         if (parentErrors != null) return parentErrors;
 
+        // can't have both items and painted resources, so items takes precedence
         if (!request.PresentationManifest.Items.IsNullOrEmpty() && 
             !request.PresentationManifest.PaintedResources.IsNullOrEmpty())
         {

--- a/src/IIIFPresentation/API/Features/Manifest/Validators/PresentationManifestValidator.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/Validators/PresentationManifestValidator.cs
@@ -1,16 +1,28 @@
 using API.Infrastructure.Validation;
+using API.Settings;
+using Core.Helpers;
+using DLCS;
 using FluentValidation;
+using Microsoft.Extensions.Options;
 using Models.API.Manifest;
 
 namespace API.Features.Manifest.Validators;
 
 public class PresentationManifestValidator : AbstractValidator<PresentationManifest>
 {
-    public PresentationManifestValidator()
+    public PresentationManifestValidator(IOptions<ApiSettings> options)
     {
+        var settings = options.Value;
+        
         RuleFor(f => f.Parent).NotEmpty().WithMessage("Requires a 'parent' to be set");
         RuleFor(f => f.Slug).NotEmpty().WithMessage("Requires a 'slug' to be set")
             .Must(slug => !SpecConstants.ProhibitedSlugs.Contains(slug!))
             .WithMessage("'slug' cannot be one of prohibited terms: '{PropertyValue}'");
+        if (!settings.IgnorePaintedResourcesWithItems)
+        {
+            RuleFor(f => f.Items).Empty()
+                .When(f => !f.PaintedResources.IsNullOrEmpty())
+                .WithMessage("The properties \"items\" and \"paintedResource\" cannot be used at the same time");
+        }
     }
 }

--- a/src/IIIFPresentation/API/Features/Manifest/Validators/PresentationManifestValidator.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/Validators/PresentationManifestValidator.cs
@@ -1,5 +1,4 @@
 using API.Infrastructure.Validation;
-using Core.Helpers;
 using FluentValidation;
 using Models.API.Manifest;
 
@@ -13,9 +12,5 @@ public class PresentationManifestValidator : AbstractValidator<PresentationManif
         RuleFor(f => f.Slug).NotEmpty().WithMessage("Requires a 'slug' to be set")
             .Must(slug => !SpecConstants.ProhibitedSlugs.Contains(slug!))
             .WithMessage("'slug' cannot be one of prohibited terms: '{PropertyValue}'");
-        RuleFor(f => f.Items).Empty()
-            .When(f => !f.PaintedResources.IsNullOrEmpty())
-            .WithMessage("The properties \"items\" and \"paintedResource\" cannot be used at the same time");
-        
     }
 }

--- a/src/IIIFPresentation/API/Settings/ApiSettings.cs
+++ b/src/IIIFPresentation/API/Settings/ApiSettings.cs
@@ -17,6 +17,11 @@ public class ApiSettings
     
     public string? PathBase { get; set; }
     
+    /// <summary>
+    /// Whether painted resources should be ignored when there are also items
+    /// </summary>
+    public bool IgnorePaintedResourcesWithItems { get; set; }
+    
     public required AWSSettings AWS { get; set; }
 
     public required DlcsSettings DLCS { get; set; }


### PR DESCRIPTION
Resolves #215

This PR changes manifests with painted resources and items present to ignore the painted resource section of a request, instead of responding with a bad request