### PR TITLE
Fixing serialization error to provide a nicer error

### DIFF
--- a/src/IIIFPresentation/API/Features/Manifest/ManifestController.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestController.cs
@@ -103,7 +103,7 @@ public class ManifestController(IOptions<ApiSettings> options, IAuthenticator au
 
         var rawRequestBody = await Request.GetRawRequestBodyAsync(cancellationToken);
         var presentationManifest = await rawRequestBody.TryDeserializePresentation<PresentationManifest>();
-        
+
         if (presentationManifest.Error)
         {
             return this.PresentationProblem("Could not deserialize manifest", null, (int) HttpStatusCode.BadRequest,

--- a/src/IIIFPresentation/API/Features/Storage/CollectionController.cs
+++ b/src/IIIFPresentation/API/Features/Storage/CollectionController.cs
@@ -97,7 +97,8 @@ public class CollectionController(
 
         var rawRequestBody = await Request.GetRawRequestBodyAsync();
 
-        var deserializedCollection = await rawRequestBody.TryDeserializePresentationCollection();
+        var deserializedCollection =
+            await rawRequestBody.TryDeserializePresentation<PresentationCollection>();
         if (deserializedCollection.Error)
         {
             return DeserializeValidationResult<PresentationCollection>.Failure(PresentationUnableToSerialize());

--- a/src/IIIFPresentation/API/Features/Storage/Helpers/RequestBodyX.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Helpers/RequestBodyX.cs
@@ -2,6 +2,7 @@
 using Core.IIIF;
 using IIIF;
 using IIIF.Serialisation;
+using Models.API;
 using Models.API.Collection;
 
 namespace API.Features.Storage.Helpers;
@@ -35,19 +36,20 @@ public static class RequestBodyX
     /// </summary>
     /// <param name="requestBody">The raw request body to convert</param>
     /// <returns>A result containing the deserialized collection, or a failure</returns>
-    public static async Task<TryConvertIIIFResult<PresentationCollection>> TryDeserializePresentationCollection(this string requestBody) 
+    public static async Task<TryConvertIIIFResult<T>> TryDeserializePresentation<T>(this string requestBody) 
+        where T : JsonLdBase, new()
     {
         try
         {
-            var collection = await requestBody.ToPresentation<PresentationCollection>();
+            var collection = await requestBody.ToPresentation<T>();
             
             return collection == null
-                ? TryConvertIIIFResult<PresentationCollection>.Failure()
-                : TryConvertIIIFResult<PresentationCollection>.Success(collection);
+                ? TryConvertIIIFResult<T>.Failure()
+                : TryConvertIIIFResult<T>.Success(collection);
         }
         catch (Exception)
         {
-            return TryConvertIIIFResult<PresentationCollection>.Failure();
+            return TryConvertIIIFResult<T>.Failure();
         }
     }
 }


### PR DESCRIPTION
Resolves #196

This PR updates PUT manifest to use the `TryDeserialize` method which improves handling of serialization errors so that a `BadRequest` is returned instead of an `InternalServerError`