### PR TITLE
Fix #158 - Location header after created collection invalid

### DIFF
--- a/src/IIIFPresentation/API.Tests/Integration/ModifyCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyCollectionTests.cs
@@ -53,6 +53,31 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
     }
 
     [Fact]
+    public async Task CreateCollection_CreatesCollection_Location_Returns_Created()
+    {
+        // Arrange
+        var requestMessage = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Post,
+            $"{Customer}/collections",
+            TestContent.Bug_158.Collection);
+        var response = await httpClient.AsCustomer().SendAsync(requestMessage);
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        response.Headers.Location.Should().NotBeNull();
+        var getUrl = response.Headers.Location!.ToString();
+
+        requestMessage = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get, getUrl);
+
+        // Act
+        response = await httpClient.AsCustomer().SendAsync(requestMessage);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var responseCollection = await response.ReadAsPresentationResponseAsync<PresentationCollection>();
+
+        responseCollection.Should().NotBeNull();
+        responseCollection!.Slug.Should().Be(TestContent.Bug_158.CollectionName);
+    }
+    
+    [Fact]
     public async Task CreateCollection_CreatesCollection_WhenAllValuesProvided()
     {
         var slug = nameof(CreateCollection_CreatesCollection_WhenAllValuesProvided);

--- a/src/IIIFPresentation/API/Infrastructure/ControllerBaseX.cs
+++ b/src/IIIFPresentation/API/Infrastructure/ControllerBaseX.cs
@@ -6,6 +6,8 @@ using Core;
 using Core.Helpers;
 using FluentValidation.Results;
 using IIIF;
+using IIIF.Presentation;
+using IIIF.Presentation.V3;
 using IIIF.Serialisation;
 using Microsoft.AspNetCore.Mvc;
 using Models.API.General;
@@ -175,12 +177,15 @@ public static class ControllerBaseX
     {
         if (value is JsonLdBase jsonLdBase)
         {
+            if (value is ResourceBase {Id: {Length: > 0} id})
+                uri = id;
+            
             controller.Response.Headers.Location = uri;
             
             return new ContentResult
             {
                 Content = jsonLdBase.AsJson(),
-                ContentType = IIIF.Presentation.ContentTypes.V3,
+                ContentType = ContentTypes.V3,
                 StatusCode = 201,
             };
         }

--- a/src/IIIFPresentation/Test.Helpers/Integration/TestContent.cs
+++ b/src/IIIFPresentation/Test.Helpers/Integration/TestContent.cs
@@ -902,4 +902,45 @@ public static class TestContent
           ]
         }
         """;
+
+    public static class Bug_158
+    {
+      public const string CollectionName = "my-collection";
+
+      public const string Collection =
+        """
+        {
+          "type": "Collection",
+          "slug": "my-collection",
+          "label": {
+            "en": [
+             "my-collection"
+            ]
+          },
+          "thumbnail": [
+            {
+              "id": "https://example.com/img/thumb.jpg",
+              "type": "Image",
+              "format": "image/jpeg",
+              "width": 512,
+              "height": 256
+            }
+          ],
+          "items": [
+            {
+              "id": "https://example.com/some-iiif-repo/basic_iiif_collection/collection_a",
+              "type": "Collection"
+            },
+            {
+              "id": "https://example.com/some-iiif-repo/basic_iiif_collection/collection_b",
+              "type": "Collection"
+            }
+          ],
+          "behavior": [
+            "public-iiif"
+          ],
+          "parent": "root"
+        }
+        """;
+    }
 }


### PR DESCRIPTION
Fixes #158 

- **Add unit test as per #158**
- **Use the created resource's Id field to provide Location**

This one is a bit weird - it seems like it assumed that the request was made directly to the resource, like with PUT, so it's probably due to some code unification in the past.

I see how in the future the modified bit of code can become a switch expression with anything specific, but I didn't want to overengineer it until we hit any further issues.