### PR TITLE
Impl #201 - Create Space if manifest asset posted w/o space

### DIFF
--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
@@ -62,10 +62,11 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
     }
     
     [Fact]
-    public async Task CreateManifest_BadRequest_WhenNoSpaceHeader()
+    public async Task CreateManifest_CreateSpace_ForSpacelessAssets_WhenNoSpaceHeader()
     {
+        const string postedAssetId = "theAssetId";
         // Arrange
-        var slug = nameof(CreateManifest_BadRequest_WhenNoSpaceHeader);
+        var slug = nameof(CreateManifest_CreateSpace_ForSpacelessAssets_WhenNoSpaceHeader);
         var manifest = new PresentationManifest
         {
             Parent = $"http://localhost/1/collections/{RootCollection.Id}",
@@ -78,7 +79,7 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
                     {
                         CanvasId = "https://iiif.example/manifest.json"
                     },
-                    Asset = new(new JProperty("id", "perhapsId"))
+                    Asset = new(new JProperty("id", postedAssetId), new JProperty("batch", 123))
                 }
             }
         };
@@ -90,10 +91,22 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
         var response = await httpClient.AsCustomer().SendAsync(requestMessage);
 
         // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-        var error = await response.ReadAsPresentationResponseAsync<Error>();
-        error!.Detail.Should().Be("A request with assets requires the space header to be set");
-        error.ErrorTypeUri.Should().Be("http://localhost/errors/ModifyCollectionType/RequiresSpaceHeader");
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        response.Headers.Location.Should().NotBeNull();
+
+        requestMessage =
+            HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get, response.Headers.Location!.ToString());
+        response = await httpClient.AsCustomer().SendAsync(requestMessage);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var responseManifest = await response.ReadAsPresentationResponseAsync<PresentationManifest>();
+        responseManifest.Should().NotBeNull();
+        responseManifest!.PaintedResources.Should().NotBeNull();
+        responseManifest.PaintedResources!.Count.Should().Be(1);
+        responseManifest.PaintedResources.Single().Asset!.TryGetValue("@id", out var assetId).Should().BeTrue();
+        assetId!.Type.Should().Be(JTokenType.String);
+        assetId!.Value<string>().Should()
+            .EndWith($"/customers/{Customer}/spaces/{NewlyCreatedSpace}/images/{postedAssetId}");
     }
     
     [Fact]

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
@@ -6,8 +6,8 @@ using DLCS.API;
 using DLCS.Exceptions;
 using DLCS.Models;
 using FakeItEasy;
+using IIIF.Presentation.V3;
 using IIIF.Serialisation;
-using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Models.API.General;
@@ -78,7 +78,7 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
                     {
                         CanvasId = "https://iiif.example/manifest.json"
                     },
-                    Asset = new JObject()
+                    Asset = new(new JProperty("id", "perhapsId"))
                 }
             }
         };
@@ -195,7 +195,7 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
         var savedS3 =
             await amazonS3.GetObjectAsync(LocalStackFixture.StorageBucketName,
                 $"{Customer}/manifests/{dbManifest.Id}");
-        var s3Manifest = savedS3.ResponseStream.FromJsonStream<IIIF.Presentation.V3.Manifest>();
+        var s3Manifest = savedS3.ResponseStream.FromJsonStream<Manifest>();
         s3Manifest.Id.Should().EndWith(dbManifest.Id);
         s3Manifest.Items.Should().BeNull();
     }
@@ -297,7 +297,7 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
         var savedS3 =
             await amazonS3.GetObjectAsync(LocalStackFixture.StorageBucketName,
                 $"{Customer}/manifests/{dbManifest.Id}");
-        var s3Manifest = savedS3.ResponseStream.FromJsonStream<IIIF.Presentation.V3.Manifest>();
+        var s3Manifest = savedS3.ResponseStream.FromJsonStream<Manifest>();
         s3Manifest.Id.Should().EndWith(dbManifest.Id);
         s3Manifest.Items.Should().BeNull();
     }
@@ -392,7 +392,7 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
         var savedS3 =
             await amazonS3.GetObjectAsync(LocalStackFixture.StorageBucketName,
                 $"{Customer}/manifests/{dbManifest.Id}");
-        var s3Manifest = savedS3.ResponseStream.FromJsonStream<IIIF.Presentation.V3.Manifest>();
+        var s3Manifest = savedS3.ResponseStream.FromJsonStream<Manifest>();
         s3Manifest.Id.Should().EndWith(dbManifest.Id);
         s3Manifest.Items.Should().BeNull();
     }

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestService.cs
@@ -216,7 +216,7 @@ public class ManifestService(
                 // Either you want a space or we detected you need a space regardless
                 spaceId = await CreateSpace(request.CustomerId, manifestId, cancellationToken);
                 if (!spaceId.HasValue)
-                    return (ErrorHelper.CouldNotRetrieveAssetId<PresentationManifest>(), null);
+                    return (ErrorHelper.ErrorCreatingSpace<PresentationManifest>(), null);
 
                 foreach (var asset in assetsWithoutSpaces)
                     asset.Add(spaceProperty, spaceId.Value);

--- a/src/IIIFPresentation/API/Helpers/BatchHelper.cs
+++ b/src/IIIFPresentation/API/Helpers/BatchHelper.cs
@@ -1,7 +1,7 @@
 ﻿using Core.Helpers;
-using Models.Database.Collections;
 using Models.Database.General;
 using Repository;
+using Batch = DLCS.Models.Batch;
 
 namespace API.Helpers;
 
@@ -10,16 +10,16 @@ public static class BatchHelper
     /// <summary>
     /// This method adds, but does not save batches to the batches table
     /// </summary>
-    public static async Task AddBatchesToDatabase(this List<DLCS.Models.Batch> batches, 
-        Manifest manifest, PresentationContext dbContext, CancellationToken cancellationToken = default)
+    public static async Task AddBatchesToDatabase(this List<Batch> batches,
+        int customerId, string manifestId, PresentationContext dbContext, CancellationToken cancellationToken = default)
     {
         var dbBatches = batches.Select(b => new Models.Database.General.Batch
         {
             Id = Convert.ToInt32(b.ResourceId!.GetLastPathElement()),
-            CustomerId = manifest.CustomerId,
+            CustomerId = customerId,
             Submitted = b.Submitted.ToUniversalTime(),
             Status = BatchStatus.Ingesting,
-            ManifestId = manifest.Id
+            ManifestId = manifestId
         });
         
         await dbContext.Batches.AddRangeAsync(dbBatches, cancellationToken);


### PR DESCRIPTION
Implements #201 

As per clarifications on slack, changed the BadRequest response into "create space and continue" that leads to 201 Created.

- **Change order of operations to reduce risk of creating unused DLCS space**
- **Manifest-Asset-Post - Change test for prev behaviour into the updated one**
- **If asset with no space posted, create space**
