### PR TITLE
Impl #203 - retrieve asset details from DLCS when responding to Create Manifest

### DIFF
--- a/src/IIIFPresentation/API.Tests/Converters/ManifestConverterTests.cs
+++ b/src/IIIFPresentation/API.Tests/Converters/ManifestConverterTests.cs
@@ -139,7 +139,8 @@ public class ManifestConverterTests
         };
         
         // Act
-        var result = iiifManifest.SetGeneratedFields(dbManifest, pathGenerator, manifest => manifest.Hierarchy.Last());
+        var result =
+            iiifManifest.SetGeneratedFields(dbManifest, pathGenerator, null, manifest => manifest.Hierarchy.Last());
 
         // Assert
         result.Slug.Should().Be("other-slug");

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
@@ -51,6 +51,57 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
         A.CallTo(() => dlcsApiClient.IngestAssets(Customer,
             A<List<JObject>>.That.Matches(o => o.First().GetValue("id").ToString() == "returnError"),
             A<CancellationToken>._)).Throws(new DlcsException("DLCS exception"));
+
+        A.CallTo(() => dlcsApiClient.GetBatchAssets(Customer, 2137, A<CancellationToken>._))
+            .ReturnsLazily(() =>
+            [
+                JObject.Parse(
+                    """
+                    {
+                           "@context": "https://localhost/contexts/Image.jsonld",
+                           "@id": "https://localhost:7230/customers/1/spaces/999/images/2025_01_16_0758",
+                           "@type": "vocab:Image",
+                           "id": "2025_01_16_0758",
+                           "space": 15,
+                           "imageService": "https://localhost/iiif-img/1/15/2025_01_16_0758",
+                           "thumbnailImageService": "https://localhost/thumbs/1/15/2025_01_16_0758",
+                           "created": "2025-01-20T15:54:43.290925Z",
+                           "origin": "https://example.com/photos/example.jpg",
+                           "maxUnauthorised": -1,
+                           "duration": 0,
+                           "width": 0,
+                           "height": 0,
+                           "ingesting": true,
+                           "error": "",
+                           "tags": [],
+                           "string1": "",
+                           "string2": "",
+                           "string3": "",
+                           "number1": 0,
+                           "number2": 0,
+                           "number3": 0,
+                           "roles": [],
+                           "batch": "https://localhost/customers/1/queue/batches/2137",
+                           "metadata": "https://localhost/customers/1/spaces/15/images/2025_01_16_0758/metadata",
+                           "storage": "https://localhost/customers/1/spaces/15/images/2025_01_16_0758/storage",
+                           "mediaType": "image/jpeg",
+                           "family": "I",
+                           "deliveryChannels": [
+                             {
+                               "@type": "vocab:DeliveryChannel",
+                               "channel": "iiif-img",
+                               "policy": "default"
+                             },
+                             {
+                               "@type": "vocab:DeliveryChannel",
+                               "channel": "thumbs",
+                               "policy": "https://localhost/customers/1/deliveryChannelPolicies/thumbs/default"
+                             }
+                           ]
+                         }
+                    """
+                )
+            ]);
         
         dbContext = storageFixture.DbFixture.DbContext;
 
@@ -211,6 +262,64 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
         var s3Manifest = savedS3.ResponseStream.FromJsonStream<Manifest>();
         s3Manifest.Id.Should().EndWith(dbManifest.Id);
         s3Manifest.Items.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CreateManifest_ReturnsAssetDetails_FromGetBatchAssets()
+    {
+        // Arrange
+        var slug = nameof(CreateManifest_ReturnsAssetDetails_FromGetBatchAssets);
+        var space = 15;
+        var assetId = "testAssetByPresentation-assetDetails";
+        var batchId = 2137;
+        var manifestWithSpace =
+            $$"""
+              {
+                  "type": "Manifest",
+                  "parent": "root",
+                  "slug": "{{slug}}",
+                  "rights": "https://creativecommons.org/licenses/by/4.0/",
+                  "label": {
+                      "en": [
+                          "I have assets"
+                      ]
+                  },
+                  "paintedResources": [
+                      {
+                          "asset": {
+                              "id": "2025_01_16_0758",
+                              "batch": 2137,
+                              "origin": "https://example.com/photos/example.jpg",
+                              "mediaType": "image/jpeg"
+                          }
+                      }
+                  ]
+              }
+              """;
+
+        var requestMessage =
+            HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Post, $"{Customer}/manifests", manifestWithSpace);
+        requestMessage.Headers.Add("Link", "<https://dlcs.io/vocab#Space>;rel=\"DCTERMS.requires\"");
+
+        // Act
+        var response = await httpClient.AsCustomer().SendAsync(requestMessage);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var responseManifest = await response.ReadAsPresentationResponseAsync<PresentationManifest>();
+
+        responseManifest!.Id.Should().NotBeNull();
+        responseManifest.Created.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(2));
+        responseManifest.Modified.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(2));
+        responseManifest.CreatedBy.Should().Be("Admin");
+        responseManifest.Slug.Should().Be(slug);
+        responseManifest.Parent.Should().Be($"http://localhost/1/collections/{RootCollection.Id}");
+
+        responseManifest.PaintedResources.Should().NotBeNull();
+        responseManifest.PaintedResources.Should().HaveCount(1);
+        responseManifest.PaintedResources!.Single().Asset.Should().NotBeNull();
+        responseManifest.PaintedResources!.Single().Asset!.GetValue("batch")!.Value<string>().Should()
+            .Be("https://localhost/customers/1/queue/batches/2137");
     }
     
     [Fact]

--- a/src/IIIFPresentation/API/Converters/ManifestConverter.cs
+++ b/src/IIIFPresentation/API/Converters/ManifestConverter.cs
@@ -1,13 +1,13 @@
 ﻿using API.Helpers;
 using Core.Helpers;
 using Core.IIIF;
-using DLCS.Models;
 using IIIF;
 using IIIF.Presentation;
 using Models.API.Manifest;
 using Models.Database.Collections;
 using Models.Database.General;
 using Newtonsoft.Json.Linq;
+using CanvasPainting = Models.Database.CanvasPainting;
 
 namespace API.Converters;
 
@@ -19,11 +19,13 @@ public static class ManifestConverter
     /// <param name="iiifManifest">Presentation Manifest to update</param>
     /// <param name="dbManifest">Database Manifest</param>
     /// <param name="pathGenerator">used to generate paths</param>
+    /// <param name="assets"></param>
     /// <param name="hierarchyFactory">
-    /// Optional factory to specify <see cref="Hierarchy"/> to use to get Parent and Slug. Defaults to using .Single()
+    ///     Optional factory to specify <see cref="Hierarchy"/> to use to get Parent and Slug. Defaults to using .Single()
     /// </param>
     public static PresentationManifest SetGeneratedFields(this PresentationManifest iiifManifest,
-        Manifest dbManifest, IPathGenerator pathGenerator, Func<Manifest, Hierarchy>? hierarchyFactory = null)
+        Manifest dbManifest, IPathGenerator pathGenerator, Dictionary<string, JObject>? assets = null,
+        Func<Manifest, Hierarchy>? hierarchyFactory = null)
     {
         hierarchyFactory ??= manifest => manifest.Hierarchy.ThrowIfNull(nameof(manifest.Hierarchy)).Single();
         
@@ -38,7 +40,7 @@ public static class ManifestConverter
         iiifManifest.ModifiedBy = dbManifest.ModifiedBy;
         iiifManifest.Parent = pathGenerator.GenerateFlatParentId(hierarchy);
         iiifManifest.Slug = hierarchy.Slug;
-        iiifManifest.PaintedResources = dbManifest.GetPaintedResources(pathGenerator);
+        iiifManifest.PaintedResources = dbManifest.GetPaintedResources(pathGenerator, assets);
         iiifManifest.Space = pathGenerator.GenerateSpaceUri(dbManifest)?.ToString();
         iiifManifest.EnsurePresentation3Context();
         iiifManifest.EnsureContext(PresentationJsonLdContext.Context);
@@ -46,13 +48,14 @@ public static class ManifestConverter
         return iiifManifest;
     }
 
-    private static List<PaintedResource>? GetPaintedResources(this Manifest dbManifest, IPathGenerator pathGenerator)
+    private static List<PaintedResource>? GetPaintedResources(this Manifest dbManifest, IPathGenerator pathGenerator,
+        Dictionary<string, JObject>? assets)
     {
         if (dbManifest.CanvasPaintings.IsNullOrEmpty()) return null;
 
         return dbManifest.CanvasPaintings.Select(cp => new PaintedResource
         {
-            CanvasPainting = new CanvasPainting
+            CanvasPainting = new Models.API.Manifest.CanvasPainting
             {
                 CanvasId = pathGenerator.GenerateCanvasId(cp),
                 Thumbnail = cp.Thumbnail?.ToString(),
@@ -65,10 +68,25 @@ public static class ManifestConverter
                 CanvasOriginalId = cp.CanvasOriginalId?.ToString(),
                 CanvasLabel = cp.CanvasLabel,
             },
-            Asset = cp.AssetId == null ? null : new JObject
-            {
-                ["@id"] = pathGenerator.GenerateAssetUri(cp)?.ToString()
-            }
+            Asset = GetAsset(cp, pathGenerator, assets)
         }).ToList();
+    }
+
+    private static JObject? GetAsset(CanvasPainting cp, IPathGenerator pathGenerator,
+        Dictionary<string, JObject>? assets)
+    {
+        if (cp.AssetId == null)
+            return null;
+
+        var fullAssetId = pathGenerator.GenerateAssetUri(cp)?.ToString();
+        if (fullAssetId == null)
+            return null;
+
+        return assets is not null && assets.TryGetValue(fullAssetId, out var asset)
+            ? asset
+            : new()
+            {
+                ["@id"] = fullAssetId
+            };
     }
 }

--- a/src/IIIFPresentation/API/Converters/ManifestConverter.cs
+++ b/src/IIIFPresentation/API/Converters/ManifestConverter.cs
@@ -82,11 +82,19 @@ public static class ManifestConverter
         if (fullAssetId == null)
             return null;
 
-        return assets is not null && assets.TryGetValue(fullAssetId, out var asset)
+        if (assets is null)
+            return new()
+            {
+                ["@id"] = fullAssetId,
+                ["error"] = "Unable to retrieve asset details"
+            };
+
+        return assets.TryGetValue(fullAssetId, out var asset)
             ? asset
             : new()
             {
-                ["@id"] = fullAssetId
+                ["@id"] = fullAssetId,
+                ["error"] = "Asset not found"
             };
     }
 }

--- a/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingResolver.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingResolver.cs
@@ -2,16 +2,12 @@
 using API.Features.Storage.Helpers;
 using API.Helpers;
 using API.Infrastructure.IdGenerator;
-using Core;
 using Core.Helpers;
 using DLCS;
-using IIIF.Presentation.V3.Strings;
 using Microsoft.Extensions.Options;
-using Models.API.General;
 using Models.API.Manifest;
 using Models.Database;
 using Models.DLCS;
-using Newtonsoft.Json.Linq;
 using Repository.Manifests;
 using CanvasPainting = Models.Database.CanvasPainting;
 using DbManifest = Models.Database.Collections.Manifest;

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestService.cs
@@ -165,14 +165,8 @@ public class ManifestService(
             await SaveToS3(dbManifest!, request, cancellationToken);
 
             return PresUpdateResult.Success(
-                request.PresentationManifest.SetGeneratedFields(dbManifest!, pathGenerator, null), WriteResult.Updated);
+                request.PresentationManifest.SetGeneratedFields(dbManifest!, pathGenerator));
         }
-    }
-
-    private bool CheckForItemsAndPaintedResources(PresentationManifest presentationManifest)
-    {
-        return !presentationManifest.Items.IsNullOrEmpty() &&
-               !presentationManifest.PaintedResources.IsNullOrEmpty();
     }
 
     private async Task<(PresUpdateResult? parentErrors, Collection? parentCollection)> TryGetParent(

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestService.cs
@@ -22,7 +22,6 @@ using Models.Database.General;
 using Newtonsoft.Json.Linq;
 using Repository;
 using Repository.Helpers;
-using Batch = DLCS.Models.Batch;
 using Collection = Models.Database.Collections.Collection;
 using DbManifest = Models.Database.Collections.Manifest;
 using PresUpdateResult = API.Infrastructure.Requests.ModifyEntityResult<Models.API.Manifest.PresentationManifest, Models.API.General.ModifyCollectionType>;
@@ -134,13 +133,43 @@ public class ManifestService(
 
         using (logger.BeginScope("Creating Manifest for Customer {CustomerId}", request.CustomerId))
         {
-            var (error, dbManifest, assets) =
+            var (error, dbManifest) =
                 await CreateDatabaseRecordAndIiifCloudServicesInteractions(request, parentCollection!, manifestId, cancellationToken);
             if (error != null) return error;
-
+                
             await SaveToS3(dbManifest!, request, cancellationToken);
+            
             return PresUpdateResult.Success(
-                request.PresentationManifest.SetGeneratedFields(dbManifest!, pathGenerator, assets), WriteResult.Created);
+                request.PresentationManifest.SetGeneratedFields(dbManifest!, pathGenerator,
+                    await GetAssets(request.CustomerId, dbManifest)),
+                WriteResult.Created);
+        }
+    }
+
+    private async Task<Dictionary<string, JObject>?> GetAssets(int customerId, DbManifest? dbManifest)
+    {
+        var assetIds = dbManifest?.CanvasPaintings?.Select(cp => cp.AssetId?.ToString())
+            .OfType<string>().ToArray();
+
+        if (assetIds == null) return null;
+
+        try
+        {
+            var assets = await dlcsApiClient.GetCustomerImages(customerId, assetIds);
+
+            return assets.Select(a => (asset: a,
+                    id: a.TryGetValue("@id", out var value) && value.Type == JTokenType.String
+                        ? value.Value<string>()
+                        : null))
+                .Where(tuple => tuple.id is {Length: > 0})
+                .ToDictionary(tuple => tuple.id!, tuple => tuple.asset);
+        }
+        catch (DlcsException dlcsException)
+        {
+            logger.LogError(dlcsException, "Error retrieving selected asset details for Customer {CustomerId}",
+                customerId);
+
+            return null;
         }
     }
 
@@ -184,8 +213,8 @@ public class ManifestService(
         return (null, parentCollection);
     }
 
-    private async Task<(PresUpdateResult?, DbManifest?, Dictionary<string, JObject>? assets)>
-        CreateDatabaseRecordAndIiifCloudServicesInteractions(WriteManifestRequest request,
+    private async Task<(PresUpdateResult?, DbManifest?)> CreateDatabaseRecordAndIiifCloudServicesInteractions(
+        WriteManifestRequest request,
         Collection parentCollection, string? requestedId, CancellationToken cancellationToken)
     {
         const string spaceProperty = "space";
@@ -199,12 +228,12 @@ public class ManifestService(
         int? spaceId = null;
 
         var manifestId = requestedId ?? await GenerateUniqueManifestId(request, cancellationToken);
-        if (manifestId == null) return (ErrorHelper.CannotGenerateUniqueId<PresentationManifest>(), null, null);
+        if (manifestId == null) return (ErrorHelper.CannotGenerateUniqueId<PresentationManifest>(), null);
 
         if (request.CreateSpace || assets.Count > 0)
         {
             if (assets.Any(a => !a.HasValues))
-                return (ErrorHelper.CouldNotRetrieveAssetId<PresentationManifest>(), null, null);
+                return (ErrorHelper.CouldNotRetrieveAssetId<PresentationManifest>(), null);
 
             var assetsWithoutSpaces = assets.Where(a => !a.TryGetValue(spaceProperty, out _)).ToArray();
             if (request.CreateSpace || (string.IsNullOrEmpty(manifestSpace) && assetsWithoutSpaces.Length > 0))
@@ -212,7 +241,7 @@ public class ManifestService(
                 // Either you want a space or we detected you need a space regardless
                 spaceId = await CreateSpace(request.CustomerId, manifestId, cancellationToken);
                 if (!spaceId.HasValue)
-                    return (ErrorHelper.ErrorCreatingSpace<PresentationManifest>(), null, null);
+                    return (ErrorHelper.ErrorCreatingSpace<PresentationManifest>(), null);
 
                 foreach (var asset in assetsWithoutSpaces)
                     asset.Add(spaceProperty, spaceId.Value);
@@ -221,7 +250,6 @@ public class ManifestService(
 
         var timeStamp = DateTime.UtcNow;
 
-        IList<int>? batchIds = null;
         if (!assets.IsNullOrEmpty())
         {
             try
@@ -231,21 +259,19 @@ public class ManifestService(
                     cancellationToken);
 
                 await batches.AddBatchesToDatabase(request.CustomerId, manifestId, dbContext, cancellationToken);
-                batchIds = GetBatchesIds(batches).ToArray();
             }
             catch (DlcsException exception)
             {
                 logger.LogError(exception, "Error creating batch request for customer {CustomerId}", request.CustomerId);
                 return (PresUpdateResult.Failure(exception.Message, ModifyCollectionType.DlcsException,
-                    WriteResult.Error), null, null);
+                    WriteResult.Error), null);
             }
         }
-
-        var fetchBatchAssets = GetBatchAssets(request.CustomerId, batchIds, cancellationToken);
+        
         var (canvasPaintingsError, canvasPaintings) =
             await canvasPaintingResolver.GenerateCanvasPaintings(request.CustomerId, request.PresentationManifest,
                 spaceId, cancellationToken);
-        if (canvasPaintingsError != null) return (canvasPaintingsError, null, null);
+        if (canvasPaintingsError != null) return (canvasPaintingsError, null);
 
         var dbManifest = new DbManifest
         {
@@ -272,45 +298,9 @@ public class ManifestService(
         await dbContext.AddAsync(dbManifest, cancellationToken);
 
         var saveErrors = await SaveAndPopulateEntity(request, dbManifest, cancellationToken);
-        return (saveErrors, dbManifest, await fetchBatchAssets);
+        return (saveErrors, dbManifest);
     }
-
-    private async Task<Dictionary<string, JObject>> GetBatchAssets(int customerId, IList<int>? batchIds,
-        CancellationToken cancellationToken)
-    {
-        if (batchIds == null) return new();
-        List<JObject> assets = [];
-        foreach (var batchId in batchIds)
-            assets.AddRange(await dlcsApiClient.GetBatchAssets(customerId, batchId, cancellationToken));
-
-        return assets.Select(a => (asset: a, id: a.TryGetValue("@id", out var value) && value.Type == JTokenType.String
-                ? value.Value<string>()
-                : null))
-            .Where(tuple => tuple.id is {Length: > 0})
-            .ToDictionary(tuple => tuple.id!, tuple => tuple.asset);
-    }
-
-    private static IEnumerable<int> GetBatchesIds(IEnumerable<Batch> batches)
-    {
-        foreach (var batch in batches)
-        {
-            if (batch.ResourceId is not {Length: > 0} resourceId)
-                continue;
-
-            if (batch.ResourceId.All(char.IsDigit) && int.TryParse(batch.ResourceId, out var pureId))
-                yield return pureId;
-            
-            if (!Uri.TryCreate(resourceId, UriKind.Absolute, out var uri))
-                continue;
-            if (uri.Segments is not [.., {Length: > 0} last])
-                continue;
-            if (!int.TryParse(last, out var batchId))
-                continue;
-
-            yield return batchId;
-        }
-    }
-
+    
     private async Task<int?> CreateSpace(int customerId, string manifestId,
         CancellationToken cancellationToken)
     {

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestService.cs
@@ -296,6 +296,10 @@ public class ManifestService(
         {
             if (batch.ResourceId is not {Length: > 0} resourceId)
                 continue;
+
+            if (batch.ResourceId.All(char.IsDigit) && int.TryParse(batch.ResourceId, out var pureId))
+                yield return pureId;
+            
             if (!Uri.TryCreate(resourceId, UriKind.Absolute, out var uri))
                 continue;
             if (uri.Segments is not [.., {Length: > 0} last])

--- a/src/IIIFPresentation/API/Features/Manifest/Requests/GetManifest.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/Requests/GetManifest.cs
@@ -50,7 +50,7 @@ public class GetManifestHandler(
             return FetchEntityResult<PresentationManifest>.Failure(
                 "Unable to read and deserialize manifest from storage");
 
-        manifest = manifest.SetGeneratedFields(dbManifest, pathGenerator,
+        manifest = manifest.SetGeneratedFields(dbManifest, pathGenerator, null,
             m => m.Hierarchy!.Single(h => h.Canonical));
 
         return FetchEntityResult<PresentationManifest>.Success(manifest);

--- a/src/IIIFPresentation/DLCS/API/DlcsApiClient.cs
+++ b/src/IIIFPresentation/DLCS/API/DlcsApiClient.cs
@@ -5,6 +5,7 @@ using DLCS.Handlers;
 using DLCS.Models;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Newtonsoft.Json.Linq;
 
 namespace DLCS.API;
 
@@ -25,6 +26,9 @@ public interface IDlcsApiClient
     /// </summary>
     public Task<List<Batch>> IngestAssets<T>(int customerId, List<T> images,
         CancellationToken cancellationToken = default);
+
+    Task<List<JObject>> GetBatchAssets(int customerId, int batchId,
+        CancellationToken cancellationToken);
 }
 
 /// <summary>
@@ -52,8 +56,8 @@ internal class DlcsApiClient(
         logger.LogTrace("Creating new space for customer {CustomerId}, {SpaceName}", customerId, name);
         var spacePath = $"/customers/{customerId}/spaces";
         var payload = new Space { Name = name };
-        
-        var space = await CallDlcsApi<Space>(HttpMethod.Post, spacePath, payload, cancellationToken);
+
+        var space = await CallDlcsApiFor<Space>(HttpMethod.Post, spacePath, payload, cancellationToken);
         return space ?? throw new DlcsException("Failed to create space");
     }
     
@@ -69,8 +73,8 @@ internal class DlcsApiClient(
         var tasks = chunkedImageList.Select(async chunkedImages =>
         {
             var hydraImages = new HydraCollection<T>(chunkedImages);
-            
-            var batch = await CallDlcsApi<Batch>(HttpMethod.Post, queuePath, hydraImages, cancellationToken);
+
+            var batch = await CallDlcsApiFor<Batch>(HttpMethod.Post, queuePath, hydraImages, cancellationToken);
             if (batch == null)
             {
                 logger.LogError("Could not understand the batch response for customer {CustomerId}", customerId);
@@ -84,13 +88,45 @@ internal class DlcsApiClient(
         return batches.ToList();
     }
 
-    private async Task<T?> CallDlcsApi<T>(HttpMethod httpMethod, string path, object payload,
+    public async Task<List<JObject>> GetBatchAssets(int customerId, int batchId,
+        CancellationToken cancellationToken = default)
+    {
+        logger.LogTrace("Requesting assets for batch {BatchId} for customer {CustomerId}", batchId, customerId);
+        var endpoint = $"/customers/{customerId}/queue/batches/{batchId}/assets";
+
+        var assets = await CallDlcsApiForJson(HttpMethod.Get, endpoint, null, cancellationToken);
+
+        return assets switch
+        {
+            null => [],
+            not null when assets.TryGetValue("member", out var member)
+                          && member.Type == JTokenType.Array => member.OfType<JObject>().ToList(),
+            _ => []
+        };
+    }
+
+    private async Task<JObject?> CallDlcsApiForJson(HttpMethod httpMethod, string path, object? payload,
+        CancellationToken cancellationToken)
+    {
+        var response = await CallDlcsApi(httpMethod, path, payload, cancellationToken);
+        return await response.ReadAsJsonResponse(cancellationToken);
+    }
+
+    private async Task<T?> CallDlcsApiFor<T>(HttpMethod httpMethod, string path, object? payload,
+        CancellationToken cancellationToken)
+    {
+        var response = await CallDlcsApi(httpMethod, path, payload, cancellationToken);
+        return await response.ReadAsDlcsResponse<T>(cancellationToken);
+    }
+
+    private async Task<HttpResponseMessage> CallDlcsApi(HttpMethod httpMethod, string path, object? payload,
         CancellationToken cancellationToken)
     {
         var request = new HttpRequestMessage(httpMethod, path);
-        request.Content = DlcsHttpContent.GenerateJsonContent(payload);
+        if (payload != null)
+            request.Content = DlcsHttpContent.GenerateJsonContent(payload);
 
         var response = await httpClient.SendAsync(request, cancellationToken);
-        return await response.ReadAsDlcsResponse<T>(cancellationToken);
+        return response;
     }
 }

--- a/src/IIIFPresentation/DLCS/API/DlcsHttpContent.cs
+++ b/src/IIIFPresentation/DLCS/API/DlcsHttpContent.cs
@@ -7,7 +7,10 @@ using DLCS.Converters;
 using DLCS.Exceptions;
 using DLCS.Models;
 using IIIF.Serialisation;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using JsonLdBase = IIIF.JsonLdBase;
+using JsonSerializer = System.Text.Json.JsonSerializer;
 
 namespace DLCS.API;
 
@@ -41,6 +44,22 @@ internal static class DlcsHttpContent
         }
 
         throw await CheckAndThrowResponseError(response, cancellationToken);
+    }
+
+    public static async Task<JObject?> ReadAsJsonResponse(this HttpResponseMessage response,
+        CancellationToken cancellationToken = default)
+    {
+        if (!response.IsSuccessStatusCode)
+            throw await CheckAndThrowResponseError(response, cancellationToken);
+
+        try
+        {
+            return JObject.Parse(await response.Content.ReadAsStringAsync(cancellationToken));
+        }
+        catch (JsonReaderException jre)
+        {
+            throw new DlcsException("Error reading DLCS response", jre);
+        }
     }
     
     public static async Task<T?> ReadAsIIIFResponse<T>(this HttpResponseMessage response,

--- a/src/IIIFPresentation/DLCS/DlcsSettings.cs
+++ b/src/IIIFPresentation/DLCS/DlcsSettings.cs
@@ -33,4 +33,9 @@ public class DlcsSettings
     /// The name of the query used for retrieving images
     /// </summary>
     public string ManifestNamedQueryName { get; set; } = "batch-query";
+
+    /// <summary>
+    ///     The maximum number of images that can be requested
+    /// </summary>
+    public int MaxImageListSize { get; set; } = 500;
 }


### PR DESCRIPTION
#203 
- **Add ReadAsJson helper to handle not-deserialised responses from DLCS**
- **Add GetBatchAssets call to DLCS client**
- **Add ability to use provided asset dictionary during canvas painting supplementation in manifest create**
- **Code cleanup**
- **Test + fix for asset detail in manifest creation response**