### PR TITLE
Allowing `choiceOrder` to work in an `asset` request and improvements to `canvasOrder`

### DIFF
--- a/src/IIIFPresentation/API.Tests/Features/Manifest/Validators/PresentationManifestValidatorTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Manifest/Validators/PresentationManifestValidatorTests.cs
@@ -109,7 +109,7 @@ public class PresentationManifestValidatorTests
     }
     
     [Fact]
-    public void CanvasPaintingAndItems_Manifest_ErrorWhenDuplicateChoiceWithCanvasOrder()
+    public void PaintedResource_Manifest_ErrorWhenDuplicateChoiceWithCanvasOrder()
     {
         var manifest = new PresentationManifest
         {
@@ -117,7 +117,7 @@ public class PresentationManifestValidatorTests
             [
                 new PaintedResource
                 {
-                    CanvasPainting = new CanvasPainting()
+                    CanvasPainting = new CanvasPainting
                     {
                         CanvasId = "someCanvasId-1",
                         CanvasOrder = 1,
@@ -127,7 +127,7 @@ public class PresentationManifestValidatorTests
 
                 new PaintedResource
                 {
-                    CanvasPainting = new CanvasPainting()
+                    CanvasPainting = new CanvasPainting
                     {
                         CanvasId = "someCanvasId-2",
                         CanvasOrder = 1,
@@ -143,7 +143,7 @@ public class PresentationManifestValidatorTests
     }
     
     [Fact]
-    public void CanvasPaintingAndItems_Manifest_NoErrorWhenNoDuplicateChoiceWithCanvasOrder()
+    public void PaintedResource_Manifest_NoErrorWhenNoDuplicateChoiceWithCanvasOrder()
     {
         var manifest = new PresentationManifest
         {
@@ -151,7 +151,7 @@ public class PresentationManifestValidatorTests
             [
                 new PaintedResource
                 {
-                    CanvasPainting = new CanvasPainting()
+                    CanvasPainting = new CanvasPainting
                     {
                         CanvasId = "someCanvasId-1",
                         CanvasOrder = 1,
@@ -161,7 +161,7 @@ public class PresentationManifestValidatorTests
 
                 new PaintedResource
                 {
-                    CanvasPainting = new CanvasPainting()
+                    CanvasPainting = new CanvasPainting
                     {
                         CanvasId = "someCanvasId-2",
                         CanvasOrder = 2,
@@ -171,23 +171,12 @@ public class PresentationManifestValidatorTests
             ],
         };
         
-        var error = manifest.PaintedResources.GroupBy(pr => pr.CanvasPainting.CanvasOrder)
-            .Any(s =>
-            {
-                if (s.Any(g => g.CanvasPainting.ChoiceOrder == null))
-                {
-                    return true;
-                }
-
-                return false;
-            });
-        
         var result = sut.TestValidate(manifest);
         result.ShouldNotHaveValidationErrorFor(m => m.PaintedResources);
     }
     
     [Fact]
-    public void CanvasPaintingAndItems_Manifest_ErrorWhenNoChoiceWithCanvasOrder()
+    public void PaintedResource_Manifest_ErrorWhenNoChoiceWithCanvasOrder()
     {
         var manifest = new PresentationManifest
         {
@@ -195,7 +184,7 @@ public class PresentationManifestValidatorTests
             [
                 new PaintedResource
                 {
-                    CanvasPainting = new CanvasPainting()
+                    CanvasPainting = new CanvasPainting
                     {
                         CanvasId = "someCanvasId-1",
                         CanvasOrder = 1,
@@ -205,7 +194,7 @@ public class PresentationManifestValidatorTests
 
                 new PaintedResource
                 {
-                    CanvasPainting = new CanvasPainting()
+                    CanvasPainting = new CanvasPainting
                     {
                         CanvasId = "someCanvasId-2",
                         CanvasOrder = 1
@@ -271,6 +260,38 @@ public class PresentationManifestValidatorTests
                     CanvasPainting = new CanvasPainting()
                     {
                         CanvasId = "someCanvasId-2",
+                    }
+                }
+            ],
+        };
+        
+        var result = sut.TestValidate(manifest);
+        result.ShouldNotHaveValidationErrorFor(m => m.PaintedResources);
+    }
+    
+    [Fact]
+    public void PaintedResource_Manifest_NoErrorWhenChoiceOfOne()
+    {
+        var manifest = new PresentationManifest
+        {
+            PaintedResources =
+            [
+                new PaintedResource
+                {
+                    CanvasPainting = new CanvasPainting
+                    {
+                        CanvasId = "someCanvasId-1",
+                        CanvasOrder = 1,
+                        ChoiceOrder = 1
+                    }
+                },
+                new PaintedResource
+                {
+                    CanvasPainting = new CanvasPainting
+                    {
+                        CanvasId = "someCanvasId-2",
+                        CanvasOrder = 2,
+                        ChoiceOrder = 1
                     }
                 }
             ],

--- a/src/IIIFPresentation/API.Tests/Features/Manifest/Validators/PresentationManifestValidatorTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Manifest/Validators/PresentationManifestValidatorTests.cs
@@ -174,9 +174,6 @@ public class PresentationManifestValidatorTests
         var error = manifest.PaintedResources.GroupBy(pr => pr.CanvasPainting.CanvasOrder)
             .Any(s =>
             {
-
-                var test = s.Count(g => g.CanvasPainting.ChoiceOrder == null);
-                    
                 if (s.Any(g => g.CanvasPainting.ChoiceOrder == null))
                 {
                     return true;
@@ -216,16 +213,6 @@ public class PresentationManifestValidatorTests
                 }
             ],
         };
-
-        var stuff = manifest.PaintedResources.Where(pr => pr.CanvasPainting.CanvasOrder != 0);
-        
-        var test = manifest.PaintedResources.Where(pr => pr.CanvasPainting.CanvasOrder != 0).GroupBy(pr => pr.CanvasPainting.CanvasOrder)
-            .Count(s => s.Any(g =>
-            {
-                if (g.CanvasPainting.ChoiceOrder != null)
-                    return false;
-                return true;
-            })) == 0;
         
         var result = sut.TestValidate(manifest);
         result.ShouldHaveValidationErrorFor(m => m.PaintedResources)

--- a/src/IIIFPresentation/API.Tests/Features/Manifest/Validators/PresentationManifestValidatorTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Manifest/Validators/PresentationManifestValidatorTests.cs
@@ -107,4 +107,220 @@ public class PresentationManifestValidatorTests
         var result = sutAllowedItemsAndPaintedResource.TestValidate(manifest);
         result.ShouldNotHaveValidationErrorFor(m => m.Items);
     }
+    
+    [Fact]
+    public void CanvasPaintingAndItems_Manifest_ErrorWhenDuplicateChoiceWithCanvasOrder()
+    {
+        var manifest = new PresentationManifest
+        {
+            PaintedResources =
+            [
+                new PaintedResource
+                {
+                    CanvasPainting = new CanvasPainting()
+                    {
+                        CanvasId = "someCanvasId-1",
+                        CanvasOrder = 1,
+                        ChoiceOrder = 1
+                    }
+                },
+
+                new PaintedResource
+                {
+                    CanvasPainting = new CanvasPainting()
+                    {
+                        CanvasId = "someCanvasId-2",
+                        CanvasOrder = 1,
+                        ChoiceOrder = 1
+                    }
+                }
+            ],
+        };
+        
+        var result = sut.TestValidate(manifest);
+        result.ShouldHaveValidationErrorFor(m => m.PaintedResources)
+            .WithErrorMessage("'choiceOrder' cannot be a duplicate within a 'canvasOrder'");
+    }
+    
+    [Fact]
+    public void CanvasPaintingAndItems_Manifest_NoErrorWhenNoDuplicateChoiceWithCanvasOrder()
+    {
+        var manifest = new PresentationManifest
+        {
+            PaintedResources =
+            [
+                new PaintedResource
+                {
+                    CanvasPainting = new CanvasPainting()
+                    {
+                        CanvasId = "someCanvasId-1",
+                        CanvasOrder = 1,
+                        ChoiceOrder = 1
+                    }
+                },
+
+                new PaintedResource
+                {
+                    CanvasPainting = new CanvasPainting()
+                    {
+                        CanvasId = "someCanvasId-2",
+                        CanvasOrder = 2,
+                        ChoiceOrder = 1
+                    }
+                }
+            ],
+        };
+        
+        var error = manifest.PaintedResources.GroupBy(pr => pr.CanvasPainting.CanvasOrder)
+            .Any(s =>
+            {
+
+                var test = s.Count(g => g.CanvasPainting.ChoiceOrder == null);
+                    
+                if (s.Any(g => g.CanvasPainting.ChoiceOrder == null))
+                {
+                    return true;
+                }
+
+                return false;
+            });
+        
+        var result = sut.TestValidate(manifest);
+        result.ShouldNotHaveValidationErrorFor(m => m.PaintedResources);
+    }
+    
+    [Fact]
+    public void CanvasPaintingAndItems_Manifest_ErrorWhenNoChoiceWithCanvasOrder()
+    {
+        var manifest = new PresentationManifest
+        {
+            PaintedResources =
+            [
+                new PaintedResource
+                {
+                    CanvasPainting = new CanvasPainting()
+                    {
+                        CanvasId = "someCanvasId-1",
+                        CanvasOrder = 1,
+                        ChoiceOrder = 1
+                    }
+                },
+
+                new PaintedResource
+                {
+                    CanvasPainting = new CanvasPainting()
+                    {
+                        CanvasId = "someCanvasId-2",
+                        CanvasOrder = 1
+                    }
+                }
+            ],
+        };
+
+        var stuff = manifest.PaintedResources.Where(pr => pr.CanvasPainting.CanvasOrder != 0);
+        
+        var test = manifest.PaintedResources.Where(pr => pr.CanvasPainting.CanvasOrder != 0).GroupBy(pr => pr.CanvasPainting.CanvasOrder)
+            .Count(s => s.Any(g =>
+            {
+                if (g.CanvasPainting.ChoiceOrder != null)
+                    return false;
+                return true;
+            })) == 0;
+        
+        var result = sut.TestValidate(manifest);
+        result.ShouldHaveValidationErrorFor(m => m.PaintedResources)
+            .WithErrorMessage("'choiceOrder' cannot be null within a duplicate 'canvasOrder'");
+    }
+    
+    [Fact]
+    public void CanvasPaintingAndItems_Manifest_NoErrorWhenNoChoiceWithIndividualCanvasOrder()
+    {
+        var manifest = new PresentationManifest
+        {
+            PaintedResources =
+            [
+                new PaintedResource
+                {
+                    CanvasPainting = new CanvasPainting()
+                    {
+                        CanvasId = "someCanvasId-1",
+                        CanvasOrder = 1,
+                        ChoiceOrder = 1
+                    }
+                },
+
+                new PaintedResource
+                {
+                    CanvasPainting = new CanvasPainting()
+                    {
+                        CanvasId = "someCanvasId-2",
+                        CanvasOrder = 2
+                    }
+                }
+            ],
+        };
+        
+        var result = sut.TestValidate(manifest);
+        result.ShouldNotHaveValidationErrorFor(m => m.PaintedResources);
+    }
+    
+    [Fact]
+    public void CanvasPaintingAndItems_Manifest_NoErrorWhenNoChoiceNoCanvasMultiple()
+    {
+        var manifest = new PresentationManifest
+        {
+            PaintedResources =
+            [
+                new PaintedResource
+                {
+                    CanvasPainting = new CanvasPainting()
+                    {
+                        CanvasId = "someCanvasId-1"
+                    }
+                },
+
+                new PaintedResource
+                {
+                    CanvasPainting = new CanvasPainting()
+                    {
+                        CanvasId = "someCanvasId-2",
+                    }
+                }
+            ],
+        };
+        
+        var result = sut.TestValidate(manifest);
+        result.ShouldNotHaveValidationErrorFor(m => m.PaintedResources);
+    }
+    
+    [Fact]
+    public void CanvasPaintingAndItems_Manifest_ErrorWhenNotEveryItemHasCanvasOrder()
+    {
+        var manifest = new PresentationManifest
+        {
+            PaintedResources =
+            [
+                new PaintedResource
+                {
+                    CanvasPainting = new CanvasPainting()
+                    {
+                        CanvasId = "someCanvasId-1",
+                        CanvasOrder = 1
+                    }
+                },
+
+                new PaintedResource
+                {
+                    CanvasPainting = new CanvasPainting()
+                    {
+                        CanvasId = "someCanvasId-2",
+                    }
+                }
+            ],
+        };
+        
+        var result = sut.TestValidate(manifest);
+        result.ShouldHaveValidationErrorFor(m => m.PaintedResources)
+            .WithErrorMessage("'canvasOrder' is required on all resources when used in at least one");
+    }
 }

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
@@ -891,6 +891,11 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
                                                   "canvas testing"
                                               ]
                                           },
+                                          "canvasLabel": {
+                                              "en": [
+                                                  "canvas testing"
+                                              ]
+                                          },
                                         "canvasOrder": 2
                                      },
                                       "asset": {
@@ -997,6 +1002,8 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
          dbManifest.Batches!.First().Id.Should().Be(batchId);
          
          dbManifest.CanvasPaintings[0].CanvasOrder.Should().Be(2);
+         dbManifest.CanvasPaintings[0].CanvasLabel.Should().NotBeNull();
+         dbManifest.CanvasPaintings[0].Label.Should().NotBeNull();
          dbManifest.CanvasPaintings[0].AssetId.ToString().Should()
              .Be($"{Customer}/{NewlyCreatedSpace}/testAssetByPresentation-multipleAssets-0");
          dbManifest.CanvasPaintings[1].CanvasOrder.Should().Be(1);

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
@@ -855,6 +855,316 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
      }
      
      [Fact]
+     public async Task CreateManifest_CorrectlyOrdersAssetRequests_WhenCanvasPaintingSetsOrder()
+     {
+         // Arrange
+         var slug = nameof(CreateManifest_CorrectlyOrdersAssetRequests_WhenCanvasPaintingSetsOrder);
+         var batchId = 5;
+         
+         var manifestWithoutSpace = $$"""
+                          {
+                              "type": "Manifest",
+                              "behavior": [
+                                  "public-iiif"
+                              ],
+                              "label": {
+                                  "en": [
+                                      "post testing"
+                                  ]
+                              },
+                              "slug": "{{slug}}",
+                              "parent": "root",
+                              "thumbnail": [
+                                  {
+                                      "id": "https://example.org/img/thumb.jpg",
+                                      "type": "Image",
+                                      "format": "image/jpeg",
+                                      "width": 300,
+                                      "height": 200
+                                  }
+                              ],
+                              "paintedResources": [
+                                  {
+                                     "canvasPainting":{
+                                         "label": {
+                                              "en": [
+                                                  "canvas testing"
+                                              ]
+                                          },
+                                        "canvasOrder": 2
+                                     },
+                                      "asset": {
+                                          "id": "testAssetByPresentation-multipleAssets-0",
+                                          "batch": "{{batchId}}",
+                                          "mediaType": "image/jpg",
+                                          "string1": "somestring",
+                                          "string2": "somestring2",
+                                          "string3": "somestring3",
+                                          "origin": "some/origin",
+                                          "deliveryChannels": [
+                                              {
+                                                  "channel": "iiif-img",
+                                                  "policy": "default"
+                                              },
+                                              {
+                                                  "channel": "thumbs",
+                                                  "policy": "default"
+                                              }
+                                          ]
+                                      }
+                                  },
+                                  {
+                                     "canvasPainting":{
+                                         "label": {
+                                              "en": [
+                                                  "canvas testing"
+                                              ]
+                                          },
+                                          "canvasOrder": 1
+                                     },
+                                      "asset": {
+                                          "id": "testAssetByPresentation-multipleAssets-1",
+                                          "mediaType": "image/jpg",
+                                          "string1": "somestring",
+                                          "string2": "somestring2",
+                                          "string3": "somestring3",
+                                          "origin": "some/origin",
+                                          "deliveryChannels": [
+                                              {
+                                                  "channel": "iiif-img",
+                                                  "policy": "default"
+                                              },
+                                              {
+                                                  "channel": "thumbs",
+                                                  "policy": "default"
+                                              }
+                                          ]
+                                      }
+                                  },
+                                  {
+                                     "canvasPainting":{
+                                         "label": {
+                                              "en": [
+                                                  "canvas testing"
+                                              ]
+                                          },
+                                          "canvasOrder": 0
+                                     },
+                                      "asset": {
+                                          "id": "testAssetByPresentation-multipleAssets-2",
+                                          "mediaType": "image/jpg",
+                                          "string1": "somestring",
+                                          "string2": "somestring2",
+                                          "string3": "somestring3",
+                                          "origin": "some/origin",
+                                          "deliveryChannels": [
+                                              {
+                                                  "channel": "iiif-img",
+                                                  "policy": "default"
+                                              },
+                                              {
+                                                  "channel": "thumbs",
+                                                  "policy": "default"
+                                              }
+                                          ]
+                                      }
+                                  }
+                              ] 
+                          }
+                          """;
+         
+         var requestMessage =
+             HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Post, $"{Customer}/manifests", manifestWithoutSpace);
+         requestMessage.Headers.Add("Link", "<https://dlcs.io/vocab#Space>;rel=\"DCTERMS.requires\"");
+         
+         // Act
+         var response = await httpClient.AsCustomer().SendAsync(requestMessage);
+
+         // Assert
+         response.StatusCode.Should().Be(HttpStatusCode.Created);
+         var responseManifest = await response.ReadAsPresentationResponseAsync<PresentationManifest>();
+
+         responseManifest!.Id.Should().NotBeNull();
+         
+         var dbManifest = dbContext.Manifests
+             .Include(m => m.CanvasPaintings)
+             .Include(m => m.Batches)
+             .First(x => x.Id == responseManifest.Id!.Split('/', StringSplitOptions.TrimEntries).Last());
+
+         dbManifest.CanvasPaintings!.Count().Should().Be(3);
+         dbManifest.Batches.Should().HaveCount(1);
+         dbManifest.Batches!.First().Status.Should().Be(BatchStatus.Ingesting);
+         dbManifest.Batches!.First().Id.Should().Be(batchId);
+         
+         dbManifest.CanvasPaintings[0].CanvasOrder.Should().Be(2);
+         dbManifest.CanvasPaintings[0].AssetId.ToString().Should()
+             .Be($"{Customer}/{NewlyCreatedSpace}/testAssetByPresentation-multipleAssets-0");
+         dbManifest.CanvasPaintings[1].CanvasOrder.Should().Be(1);
+         dbManifest.CanvasPaintings[1].AssetId.ToString().Should()
+             .Be($"{Customer}/{NewlyCreatedSpace}/testAssetByPresentation-multipleAssets-1");
+         dbManifest.CanvasPaintings[2].CanvasOrder.Should().Be(0);
+         dbManifest.CanvasPaintings[2].AssetId.ToString().Should()
+             .Be($"{Customer}/{NewlyCreatedSpace}/testAssetByPresentation-multipleAssets-2");
+     }
+     
+     [Fact]
+     public async Task CreateManifest_CorrectlySetsChoiceOrder_WhenCanvasPaintingSetsChoice()
+     {
+         // Arrange
+         var slug = nameof(CreateManifest_CorrectlyOrdersAssetRequests_WhenCanvasPaintingSetsOrder);
+         var batchId = 5;
+         
+         var manifestWithoutSpace = $$"""
+                          {
+                              "type": "Manifest",
+                              "behavior": [
+                                  "public-iiif"
+                              ],
+                              "label": {
+                                  "en": [
+                                      "post testing"
+                                  ]
+                              },
+                              "slug": "{{slug}}",
+                              "parent": "root",
+                              "thumbnail": [
+                                  {
+                                      "id": "https://example.org/img/thumb.jpg",
+                                      "type": "Image",
+                                      "format": "image/jpeg",
+                                      "width": 300,
+                                      "height": 200
+                                  }
+                              ],
+                              "paintedResources": [
+                                  {
+                                     "canvasPainting":{
+                                         "label": {
+                                              "en": [
+                                                  "canvas testing"
+                                              ]
+                                          },
+                                        "canvasOrder": 1,
+                                        "choiceOrder": 1
+                                     },
+                                      "asset": {
+                                          "id": "testAssetByPresentation-multipleAssets-0",
+                                          "batch": "{{batchId}}",
+                                          "mediaType": "image/jpg",
+                                          "string1": "somestring",
+                                          "string2": "somestring2",
+                                          "string3": "somestring3",
+                                          "origin": "some/origin",
+                                          "deliveryChannels": [
+                                              {
+                                                  "channel": "iiif-img",
+                                                  "policy": "default"
+                                              },
+                                              {
+                                                  "channel": "thumbs",
+                                                  "policy": "default"
+                                              }
+                                          ]
+                                      }
+                                  },
+                                  {
+                                     "canvasPainting":{
+                                         "label": {
+                                              "en": [
+                                                  "canvas testing"
+                                              ]
+                                          },
+                                          "canvasOrder": 1,
+                                          "choiceOrder": 2
+                                     },
+                                      "asset": {
+                                          "id": "testAssetByPresentation-multipleAssets-1",
+                                          "mediaType": "image/jpg",
+                                          "string1": "somestring",
+                                          "string2": "somestring2",
+                                          "string3": "somestring3",
+                                          "origin": "some/origin",
+                                          "deliveryChannels": [
+                                              {
+                                                  "channel": "iiif-img",
+                                                  "policy": "default"
+                                              },
+                                              {
+                                                  "channel": "thumbs",
+                                                  "policy": "default"
+                                              }
+                                          ]
+                                      }
+                                  },
+                                  {
+                                     "canvasPainting":{
+                                         "label": {
+                                              "en": [
+                                                  "canvas testing"
+                                              ]
+                                          },
+                                          "canvasOrder": 0
+                                     },
+                                      "asset": {
+                                          "id": "testAssetByPresentation-multipleAssets-2",
+                                          "mediaType": "image/jpg",
+                                          "string1": "somestring",
+                                          "string2": "somestring2",
+                                          "string3": "somestring3",
+                                          "origin": "some/origin",
+                                          "deliveryChannels": [
+                                              {
+                                                  "channel": "iiif-img",
+                                                  "policy": "default"
+                                              },
+                                              {
+                                                  "channel": "thumbs",
+                                                  "policy": "default"
+                                              }
+                                          ]
+                                      }
+                                  }
+                              ] 
+                          }
+                          """;
+         
+         var requestMessage =
+             HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Post, $"{Customer}/manifests", manifestWithoutSpace);
+         requestMessage.Headers.Add("Link", "<https://dlcs.io/vocab#Space>;rel=\"DCTERMS.requires\"");
+         
+         // Act
+         var response = await httpClient.AsCustomer().SendAsync(requestMessage);
+
+         // Assert
+         response.StatusCode.Should().Be(HttpStatusCode.Created);
+         var responseManifest = await response.ReadAsPresentationResponseAsync<PresentationManifest>();
+
+         responseManifest!.Id.Should().NotBeNull();
+         
+         var dbManifest = dbContext.Manifests
+             .Include(m => m.CanvasPaintings)
+             .Include(m => m.Batches)
+             .First(x => x.Id == responseManifest.Id!.Split('/', StringSplitOptions.TrimEntries).Last());
+
+         dbManifest.CanvasPaintings!.Count().Should().Be(3);
+         dbManifest.Batches.Should().HaveCount(1);
+         dbManifest.Batches!.First().Status.Should().Be(BatchStatus.Ingesting);
+         dbManifest.Batches!.First().Id.Should().Be(batchId);
+         
+         dbManifest.CanvasPaintings[0].CanvasOrder.Should().Be(1);
+         dbManifest.CanvasPaintings[0].AssetId.ToString().Should()
+             .Be($"{Customer}/{NewlyCreatedSpace}/testAssetByPresentation-multipleAssets-0");
+         dbManifest.CanvasPaintings[0].ChoiceOrder.Should().Be(1);
+         dbManifest.CanvasPaintings[1].CanvasOrder.Should().Be(1);
+         dbManifest.CanvasPaintings[1].AssetId.ToString().Should()
+             .Be($"{Customer}/{NewlyCreatedSpace}/testAssetByPresentation-multipleAssets-1");
+         dbManifest.CanvasPaintings[1].ChoiceOrder.Should().Be(2);
+         dbManifest.CanvasPaintings[2].CanvasOrder.Should().Be(0);
+         dbManifest.CanvasPaintings[2].AssetId.ToString().Should()
+             .Be($"{Customer}/{NewlyCreatedSpace}/testAssetByPresentation-multipleAssets-2");
+     }
+     
+     [Fact]
     public async Task? CreateManifest_ReturnsError_WhenErrorFromDlcs()
     {
         // Arrange

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
@@ -1011,8 +1011,8 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
      public async Task CreateManifest_CorrectlySetsChoiceOrder_WhenCanvasPaintingSetsChoice()
      {
          // Arrange
-         var slug = nameof(CreateManifest_CorrectlyOrdersAssetRequests_WhenCanvasPaintingSetsOrder);
-         var batchId = 5;
+         var slug = nameof(CreateManifest_CorrectlySetsChoiceOrder_WhenCanvasPaintingSetsChoice);
+         var batchId = 6;
          
          var manifestWithoutSpace = $$"""
                           {

--- a/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingResolver.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingResolver.cs
@@ -213,9 +213,9 @@ public class CanvasPaintingResolver(
                 Label = paintedResource.CanvasPainting?.Label,
                 Created = DateTime.UtcNow,
                 CustomerId = customerId,
-                CanvasOrder = count,
+                CanvasOrder = paintedResource.CanvasPainting?.CanvasOrder ?? count,
                 AssetId = AssetId.FromString($"{customerId}/{space}/{id}"),
-                ChoiceOrder = -1,
+                ChoiceOrder = paintedResource.CanvasPainting?.ChoiceOrder ?? -1,
                 Ingesting = true
             };
 

--- a/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingResolver.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingResolver.cs
@@ -211,6 +211,7 @@ public class CanvasPaintingResolver(
             {
                 Id = canvasPaintingIds[count],
                 Label = paintedResource.CanvasPainting?.Label,
+                CanvasLabel = paintedResource.CanvasPainting?.CanvasLabel,
                 Created = DateTime.UtcNow,
                 CustomerId = customerId,
                 CanvasOrder = paintedResource.CanvasPainting?.CanvasOrder ?? count,

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
@@ -184,7 +184,7 @@ public class ManifestWriteService(
                 request.PresentationManifest.SetGeneratedFields(dbManifest!, pathGenerator));
         }
     }
-
+    
     private async Task<(PresUpdateResult? parentErrors, Collection? parentCollection)> TryGetParent(
         WriteManifestRequest request, CancellationToken cancellationToken)
     {

--- a/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionMessageHandlerTests.cs
+++ b/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionMessageHandlerTests.cs
@@ -1,6 +1,8 @@
 ﻿using AWS.Helpers;
+using AWS.Settings;
 using AWS.SQS;
 using BackgroundHandler.BatchCompletion;
+using BackgroundHandler.Settings;
 using BackgroundHandler.Tests.infrastructure;
 using DLCS;
 using DLCS.API;
@@ -34,7 +36,7 @@ public class BatchCompletionMessageHandlerTests
     private readonly BatchCompletionMessageHandler sut;
     private readonly IDlcsOrchestratorClient dlcsClient;
     private readonly IIIIFS3Service iiifS3;
-    private readonly DlcsSettings dlcsSettings;
+    private readonly BackgroundHandlerSettings backgroundHandlerSettings;
     private readonly int customerId = 1;
 
     public BatchCompletionMessageHandlerTests(PresentationContextFixture dbFixture)
@@ -43,13 +45,13 @@ public class BatchCompletionMessageHandlerTests
         dbContext.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.TrackAll;
         dlcsClient = A.Fake<IDlcsOrchestratorClient>();
         iiifS3 = A.Fake<IIIIFS3Service>();
-        dlcsSettings = new DlcsSettings()
+        backgroundHandlerSettings = new BackgroundHandlerSettings()
         {
-            ApiUri = new Uri("https://localhost:5000"),
-            OrchestratorUri = new Uri("https://localhost:5000")
+            PresentationApiUrl = "https://localhost:5000",
+            AWS = new AWSSettings()
         };
         
-        sut = new BatchCompletionMessageHandler(dbFixture.DbContext, dlcsClient, Options.Create(dlcsSettings), iiifS3,
+        sut = new BatchCompletionMessageHandler(dbFixture.DbContext, dlcsClient, Options.Create(backgroundHandlerSettings), iiifS3,
             new NullLogger<BatchCompletionMessageHandler>());
     }
 
@@ -120,7 +122,7 @@ public class BatchCompletionMessageHandlerTests
                 {
                     new ()
                     {
-                        Id = $"{dlcsSettings.OrchestratorUri}/iiif-img/{fullAssetId}/canvas/c/1",
+                        Id = $"{backgroundHandlerSettings.PresentationApiUrl}/iiif-img/{fullAssetId}/canvas/c/1",
                         Width = 100,
                         Height = 100,
                         Annotations = new List<AnnotationPage>

--- a/src/IIIFPresentation/BackgroundHandler.Tests/Helpers/ManifestMergerTests.cs
+++ b/src/IIIFPresentation/BackgroundHandler.Tests/Helpers/ManifestMergerTests.cs
@@ -21,7 +21,7 @@ public class ManifestMergerTests
         var blankManifest = new Manifest();
         var assetId = $"1/2/{nameof(Merge_MergesBlankManifestWithGeneratedManifest)}";
         
-        var namedQueryManifest = GeneratedManifest(assetId);
+        var namedQueryManifest = GenerateManifest(assetId);
         var itemDictionary = namedQueryManifest.Items.ToDictionary(i => AssetId.FromString(i.Id), i => i);
         
         // Act
@@ -44,9 +44,9 @@ public class ManifestMergerTests
     {
         // Arrange
         var blankManifest = new Manifest();
-        var assetId = $"1/2/{nameof(Merge_MergesBlankManifestWithGeneratedManifest)}";
+        var assetId = $"1/2/{nameof(Merge_MergesBlankManifestWithGeneratedManifestWithCanvasLabel)}";
         
-        var namedQueryManifest = GeneratedManifest(assetId);
+        var namedQueryManifest = GenerateManifest(assetId);
         namedQueryManifest.Items[0].Label = null;
         var itemDictionary = namedQueryManifest.Items.ToDictionary(i => AssetId.FromString(i.Id), i => i);
         var canvasPaintings = GenerateCanvasPaintings([assetId]);
@@ -73,10 +73,10 @@ public class ManifestMergerTests
     {
         // Arrange
         var assetId = $"1/2/{nameof(Merge_MergesFullManifestWithGeneratedManifest)}";
-        var blankManifest = GeneratedManifest(assetId);
+        var blankManifest = GenerateManifest(assetId);
         blankManifest.Items[0].Width = 200;
         blankManifest.Items[0].Height = 200;
-        var namedQueryManifest = GeneratedManifest(assetId);
+        var namedQueryManifest = GenerateManifest(assetId);
         var itemDictionary = namedQueryManifest.Items.ToDictionary(i => AssetId.FromString(i.Id), i => i);
         
         // Act
@@ -96,12 +96,12 @@ public class ManifestMergerTests
     {
         // Arrange
         var assetId = $"1/2/{nameof(Merge_ShouldNotUpdateAttachedManifestThumbnail)}";
-        var blankManifest = GeneratedManifest(assetId);
+        var blankManifest = GenerateManifest(assetId);
         blankManifest.Items[0].Width = 200;
         blankManifest.Items[0].Height = 200;
         blankManifest.Thumbnail.Add(GenerateImageService(assetId));
         blankManifest.Thumbnail[0].Service[0].Id = "namedQueryId";
-        var namedQueryManifest = GeneratedManifest(assetId);
+        var namedQueryManifest = GenerateManifest(assetId);
         var itemDictionary = namedQueryManifest.Items.ToDictionary(i => AssetId.FromString(i.Id), i => i);
         
         // Act
@@ -122,7 +122,7 @@ public class ManifestMergerTests
     {
         // Arrange
         var blankManifest = new Manifest();
-        var namedQueryManifest = GeneratedManifest($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1");
+        var namedQueryManifest = GenerateManifest($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1");
         namedQueryManifest.Items.Add(GenerateCanvas($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_2"));
         var itemDictionary = namedQueryManifest.Items.ToDictionary(i => AssetId.FromString(i.Id), i => i);
         
@@ -152,20 +152,27 @@ public class ManifestMergerTests
     {
         // Arrange
         var blankManifest = new Manifest();
-        var namedQueryManifest = GeneratedManifest($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1");
-        namedQueryManifest.Items.Add(GenerateCanvas($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_2"));
-        namedQueryManifest.Items.Add(GenerateCanvas($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_3"));
-        namedQueryManifest.Items.Add(GenerateCanvas($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_4"));
-        namedQueryManifest.Items.Add(GenerateCanvas($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_5"));
+        
+        var canvas0Choice0 = $"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1";
+        var canvas1Choice2 = $"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_2";
+        var canvas0Choice1 = $"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_3";
+        var canvas1Choice0 = $"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_4";
+        var canvas2NoChoice = $"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_5";
+        
+        var namedQueryManifest = GenerateManifest(canvas0Choice0);
+        namedQueryManifest.Items.Add(GenerateCanvas(canvas1Choice2));
+        namedQueryManifest.Items.Add(GenerateCanvas(canvas0Choice1));
+        namedQueryManifest.Items.Add(GenerateCanvas(canvas1Choice0));
+        namedQueryManifest.Items.Add(GenerateCanvas(canvas2NoChoice));
         
         var itemDictionary = namedQueryManifest.Items.ToDictionary(i => AssetId.FromString(i.Id), i => i);
         
         var canvasPaintings = GenerateCanvasPaintings([
-            $"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1",
-            $"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_2",
-            $"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_3",
-            $"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_4",
-            $"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_5"
+            canvas0Choice0,
+            canvas1Choice2,
+            canvas0Choice1,
+            canvas1Choice0,
+            canvas2NoChoice
         ]);
 
         canvasPaintings[0].CanvasOrder = 0;
@@ -181,8 +188,15 @@ public class ManifestMergerTests
         
         canvasPaintings[0].CanvasLabel =
             new LanguageMap("canvasPaintingCanvasLabel", "generated canvas painting label");
+        
+        // make sure canvas label isn't used and label isn't set for canvas1Choice0
         canvasPaintings[1].CanvasLabel =
             new LanguageMap("canvasPaintingCanvasLabel", "generated canvas painting label");
+        canvasPaintings[1].Label = null;
+        
+        // remove labels from canvas2NoChoice
+        canvasPaintings[4].CanvasLabel = null;
+        canvasPaintings[4].Label = null;
         
         // Act
         var mergedManifest =
@@ -190,57 +204,60 @@ public class ManifestMergerTests
         
         // Assert
         mergedManifest.Items.Count.Should().Be(3);
-        mergedManifest.Thumbnail[0].Service[0].Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1");
+        mergedManifest.Thumbnail[0].Service[0].Id.Should().Be(canvas0Choice0);
         mergedManifest.Thumbnail.Count.Should().Be(1);
         // should be 1 + 3 then 4 + 2 then 5
-        mergedManifest.Items[0].Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1");
+        mergedManifest.Items[0].Id.Should().Be(canvas0Choice0);
         mergedManifest.Items[0].Label.Keys.Should().Contain("canvasPaintingCanvasLabel");
-        mergedManifest.Items[1].Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_4");
+        mergedManifest.Items[1].Id.Should().Be(canvas1Choice0);
         mergedManifest.Items[1].Label.Keys.Should().Contain("canvasPaintingLabel");
         mergedManifest.Items[1].Label.Keys.Should().NotContain("canvasPaintingCanvasLabel");
-        mergedManifest.Items[2].Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_5");
+        mergedManifest.Items[2].Id.Should().Be(canvas2NoChoice);
+        mergedManifest.Items[2].Label.Should().BeNull("label cannot be carried over from the named query");
         
-        var currentCanvasAnnotation = mergedManifest.GetCurrentCanvasAnnotation(0);
+        var currentCanvasAnnotation = mergedManifest.GetCurrentCanvasAnnotationPage(0);
         
-        currentCanvasAnnotation.Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1_AnnotationPage");
-        currentCanvasAnnotation.Items[0].As<PaintingAnnotation>().Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1_PaintingAnnotation");
+        currentCanvasAnnotation.Id.Should().Be($"{canvas0Choice0}_AnnotationPage");
+        currentCanvasAnnotation.Items[0].As<PaintingAnnotation>().Id.Should().Be($"{canvas0Choice0}_PaintingAnnotation");
 
         var target = currentCanvasAnnotation.Items[0].As<PaintingAnnotation>().Target as Canvas;
-        target.Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1");
+        target.Id.Should().Be(canvas0Choice0);
 
         var firstAnnotationBody = currentCanvasAnnotation.Items[0].As<PaintingAnnotation>().Body.As<PaintingChoice>();
-        firstAnnotationBody.Items[0].As<Image>().Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1");
-        firstAnnotationBody.Items[1].As<Image>().Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_3");
+        firstAnnotationBody.Items[0].As<Image>().Id.Should().Be(canvas0Choice0);
+        firstAnnotationBody.Items[1].As<Image>().Id.Should().Be(canvas0Choice1);
         firstAnnotationBody.Items[0].As<Image>().Label.Keys.Should().Contain("canvasPaintingLabel");
         
-        var secondAnnotationBody =  mergedManifest.GetCurrentCanvasAnnotation(1).Items[0].As<PaintingAnnotation>().Body.As<PaintingChoice>();
-        secondAnnotationBody.Items[0].As<Image>().Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_4");
-        secondAnnotationBody.Items[1].As<Image>().Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_2");
-        secondAnnotationBody.Items[0].As<Image>().Label.Keys.Should().Contain("canvasPaintingLabel");
+        var secondAnnotationBody =  mergedManifest.GetCurrentCanvasAnnotationPage(1).Items[0].As<PaintingAnnotation>().Body.As<PaintingChoice>();
+        secondAnnotationBody.Items[0].As<Image>().Id.Should().Be(canvas1Choice0);
+        secondAnnotationBody.Items[1].As<Image>().Id.Should().Be(canvas1Choice2);
+        secondAnnotationBody.Items[1].As<Image>().Label.Should()
+            .BeNull("label cannot be carried over from named query");
     }
     
     [Fact]
     public void Merge_CorrectlyMergesChoiceOrder_WhenUpdatingChoiceOrder()
     {
         // Arrange
-        var blankManifest = GeneratedManifest($"1/2/{nameof(Merge_CorrectlyMergesChoiceOrder_WhenUpdatingChoiceOrder)}_1", true);
-
-        blankManifest.Items[0].Items[0].Items[0].As<PaintingAnnotation>().Body.As<PaintingChoice>().Items[0].As<Image>().Label =
-            new LanguageMap("before_update", "before update");
+        var existingItemBecomingCanvas0Choice0 = $"1/2/{nameof(Merge_CorrectlyMergesChoiceOrder_WhenUpdatingChoiceOrder)}_1";
+        var canvas0Choice1 = $"1/2/{nameof(Merge_CorrectlyMergesChoiceOrder_WhenUpdatingChoiceOrder)}_2";
+        var canvas1NoChoice = $"1/2/{nameof(Merge_CorrectlyMergesChoiceOrder_WhenUpdatingChoiceOrder)}_3";
         
-        var namedQueryManifest = GeneratedManifest($"1/2/{nameof(Merge_CorrectlyMergesChoiceOrder_WhenUpdatingChoiceOrder)}_1");
-        namedQueryManifest.Items.Add(GenerateCanvas($"1/2/{nameof(Merge_CorrectlyMergesChoiceOrder_WhenUpdatingChoiceOrder)}_2"));
-        namedQueryManifest.Items.Add(GenerateCanvas($"1/2/{nameof(Merge_CorrectlyMergesChoiceOrder_WhenUpdatingChoiceOrder)}_3"));
+        var minimalManifest = GenerateManifest(existingItemBecomingCanvas0Choice0, true);
+        
+        var namedQueryManifest = GenerateManifest(existingItemBecomingCanvas0Choice0);
+        namedQueryManifest.Items.Add(GenerateCanvas(canvas0Choice1));
+        namedQueryManifest.Items.Add(GenerateCanvas(canvas1NoChoice));
         
         namedQueryManifest.Items[0].Items[0].Items[0].As<PaintingAnnotation>().Body.As<Image>().Label =
-            new LanguageMap("after_update", "after update");
+            new LanguageMap("after_update", "making sure label is filled out");
         
         var itemDictionary = namedQueryManifest.Items.ToDictionary(i => AssetId.FromString(i.Id), i => i);
         
         var canvasPaintings = GenerateCanvasPaintings([
-            $"1/2/{nameof(Merge_CorrectlyMergesChoiceOrder_WhenUpdatingChoiceOrder)}_1",
-            $"1/2/{nameof(Merge_CorrectlyMergesChoiceOrder_WhenUpdatingChoiceOrder)}_2",
-            $"1/2/{nameof(Merge_CorrectlyMergesChoiceOrder_WhenUpdatingChoiceOrder)}_3"
+            existingItemBecomingCanvas0Choice0,
+            canvas0Choice1,
+            canvas1NoChoice
         ]);
 
         canvasPaintings[0].CanvasOrder = 0;
@@ -253,56 +270,56 @@ public class ManifestMergerTests
         
         // Act
         var mergedManifest =
-            ManifestMerger.Merge(blankManifest, canvasPaintings, itemDictionary, namedQueryManifest.Thumbnail);
+            ManifestMerger.Merge(minimalManifest, canvasPaintings, itemDictionary, namedQueryManifest.Thumbnail);
         
         // Assert
         mergedManifest.Items.Count.Should().Be(2);
         mergedManifest.Thumbnail[0].Service[0].Id.Should()
-            .Be($"1/2/{nameof(Merge_CorrectlyMergesChoiceOrder_WhenUpdatingChoiceOrder)}_1");
+            .Be(existingItemBecomingCanvas0Choice0);
         mergedManifest.Thumbnail.Count.Should().Be(1);
 
-        mergedManifest.Items[0].Id.Should()
-            .Be($"1/2/{nameof(Merge_CorrectlyMergesChoiceOrder_WhenUpdatingChoiceOrder)}_1");
-        mergedManifest.Items[1].Id.Should()
-            .Be($"1/2/{nameof(Merge_CorrectlyMergesChoiceOrder_WhenUpdatingChoiceOrder)}_3");
+        mergedManifest.Items[0].Id.Should().Be(existingItemBecomingCanvas0Choice0);
+        mergedManifest.Items[1].Id.Should().Be(canvas1NoChoice);
         
-        var currentCanvasAnnotation = mergedManifest.GetCurrentCanvasAnnotation(0);
+        var currentCanvasAnnotation = mergedManifest.GetCurrentCanvasAnnotationPage(0);
 
         currentCanvasAnnotation.Id.Should()
-            .Be($"1/2/{nameof(Merge_CorrectlyMergesChoiceOrder_WhenUpdatingChoiceOrder)}_1_AnnotationPage");
-        currentCanvasAnnotation.Items[0].As<PaintingAnnotation>().Id.Should().Be(
-            $"1/2/{nameof(Merge_CorrectlyMergesChoiceOrder_WhenUpdatingChoiceOrder)}_1_PaintingAnnotation");
+            .Be($"{existingItemBecomingCanvas0Choice0}_AnnotationPage");
+        currentCanvasAnnotation.Items[0].As<PaintingAnnotation>().Id.Should()
+            .Be($"{existingItemBecomingCanvas0Choice0}_PaintingAnnotation");
         
         var target = currentCanvasAnnotation.Items[0].As<PaintingAnnotation>().Target as Canvas;
-        target.Id.Should().Be($"1/2/{nameof(Merge_CorrectlyMergesChoiceOrder_WhenUpdatingChoiceOrder)}_1");
+        target.Id.Should().Be(existingItemBecomingCanvas0Choice0);
 
         var firstAnnotationBody = currentCanvasAnnotation.Items[0].As<PaintingAnnotation>().Body.As<PaintingChoice>();
-        firstAnnotationBody.Items[0].As<Image>().Id.Should()
-            .Be($"1/2/{nameof(Merge_CorrectlyMergesChoiceOrder_WhenUpdatingChoiceOrder)}_1");
-        firstAnnotationBody.Items[0].As<Image>().Label.Keys.Should().Contain("after_update");
-        firstAnnotationBody.Items[1].As<Image>().Id.Should()
-            .Be($"1/2/{nameof(Merge_CorrectlyMergesChoiceOrder_WhenUpdatingChoiceOrder)}_2");
+        firstAnnotationBody.Items[0].As<Image>().Id.Should().Be(existingItemBecomingCanvas0Choice0);
+        firstAnnotationBody.Items[0].As<Image>().Label.Should().BeNull("label cannot be carried over from named query");
+        firstAnnotationBody.Items[1].As<Image>().Id.Should().Be(canvas0Choice1);
     }
     
     [Fact]
     public void Merge_CorrectlyMergesImageIntoChoiceOrder_WhenUpdatingChoiceOrder()
     {
         // Arrange
-        var blankManifest = GeneratedManifest($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1");
+        var existingCanvas0Choice0 = $"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1";
+        var canvas0Choice1 = $"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_2";
+        var canvas1NoChoice = $"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_3";
         
-        var namedQueryManifest = GeneratedManifest($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1");
-        namedQueryManifest.Items.Add(GenerateCanvas($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_2"));
-        namedQueryManifest.Items.Add(GenerateCanvas($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_3"));
+        var existingManifest = GenerateManifest(existingCanvas0Choice0);
+        
+        var namedQueryManifest = GenerateManifest(existingCanvas0Choice0);
+        namedQueryManifest.Items.Add(GenerateCanvas(canvas0Choice1));
+        namedQueryManifest.Items.Add(GenerateCanvas(canvas1NoChoice));
         
         namedQueryManifest.Items[0].Items[0].Items[0].As<PaintingAnnotation>().Body.As<Image>().Label =
-            new LanguageMap("after_update", "after update");
+            new LanguageMap("after_update", "making sure label is filled out");
         
         var itemDictionary = namedQueryManifest.Items.ToDictionary(i => AssetId.FromString(i.Id), i => i);
         
         var canvasPaintings = GenerateCanvasPaintings([
-            $"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1",
-            $"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_2",
-            $"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_3"
+            existingCanvas0Choice0,
+            canvas0Choice1,
+            canvas1NoChoice
         ]);
 
         canvasPaintings[0].CanvasOrder = 0;
@@ -315,28 +332,28 @@ public class ManifestMergerTests
         
         // Act
         var mergedManifest =
-            ManifestMerger.Merge(blankManifest, canvasPaintings, itemDictionary, namedQueryManifest.Thumbnail);
+            ManifestMerger.Merge(existingManifest, canvasPaintings, itemDictionary, namedQueryManifest.Thumbnail);
         
         // Assert
         mergedManifest.Items.Count.Should().Be(2);
-        mergedManifest.Thumbnail[0].Service[0].Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1");
+        mergedManifest.Thumbnail[0].Service[0].Id.Should().Be(existingCanvas0Choice0);
         mergedManifest.Thumbnail.Count.Should().Be(1);
-        // should be 1 + 3 then 4 + 2 then 5
-        mergedManifest.Items[0].Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1");
-        mergedManifest.Items[1].Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_3");
+        mergedManifest.Items[0].Id.Should().Be(existingCanvas0Choice0);
+        mergedManifest.Items[1].Id.Should().Be(canvas1NoChoice);
 
-        var currentCanvasAnnotation = mergedManifest.GetCurrentCanvasAnnotation(0);
+        var currentCanvasAnnotation = mergedManifest.GetCurrentCanvasAnnotationPage(0);
 
-        currentCanvasAnnotation.Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1_AnnotationPage");
-        currentCanvasAnnotation.Items[0].As<PaintingAnnotation>().Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1_PaintingAnnotation");
+        currentCanvasAnnotation.Id.Should().Be($"{existingCanvas0Choice0}_AnnotationPage");
+        currentCanvasAnnotation.Items[0].As<PaintingAnnotation>().Id.Should().Be($"{existingCanvas0Choice0}_PaintingAnnotation");
         
         var target = currentCanvasAnnotation.Items[0].As<PaintingAnnotation>().Target as Canvas;
-        target.Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1");
+        target.Id.Should().Be(existingCanvas0Choice0);
         
         var firstAnnotationBody = currentCanvasAnnotation.Items[0].As<PaintingAnnotation>().Body.As<PaintingChoice>();
-        firstAnnotationBody.Items[0].As<Image>().Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1");
-        firstAnnotationBody.Items[0].As<Image>().Label.Keys.Should().Contain("after_update");
-        firstAnnotationBody.Items[1].As<Image>().Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_2");
+        firstAnnotationBody.Items[0].As<Image>().Id.Should().Be(existingCanvas0Choice0);
+        firstAnnotationBody.Items[0].As<Image>().Label.Should()
+            .BeNull("label cannot be carried over from named query");
+        firstAnnotationBody.Items[1].As<Image>().Id.Should().Be(canvas0Choice1);
     }
 
     private List<CanvasPainting> GenerateCanvasPaintings(List<string> idList)
@@ -349,7 +366,7 @@ public class ManifestMergerTests
         }).ToList();
     }
 
-    private Manifest GeneratedManifest(string id, bool paintingChoice = false)
+    private Manifest GenerateManifest(string id, bool paintingChoice = false)
     {
         return new Manifest
         {
@@ -438,7 +455,8 @@ public class ManifestMergerTests
                     Id = id,
                     Sizes = [new(100, 100)]
                 }
-            ]
+            ],
+            Label = new LanguageMap("en", $"{id}_Image")
         };
     }
 }

--- a/src/IIIFPresentation/BackgroundHandler.Tests/Helpers/ManifestMergerTests.cs
+++ b/src/IIIFPresentation/BackgroundHandler.Tests/Helpers/ManifestMergerTests.cs
@@ -31,8 +31,8 @@ public class ManifestMergerTests
         
         // Assert
         mergedManifest.Items.Count.Should().Be(1);
-        mergedManifest.Items[0].Width.Should().Be(100);
-        mergedManifest.Items[0].Height.Should().Be(100);
+        mergedManifest.Items[0].Width.Should().Be(110);
+        mergedManifest.Items[0].Height.Should().Be(110);
         mergedManifest.Thumbnail.Count.Should().Be(1);
         mergedManifest.Metadata.Should().BeNull();
         mergedManifest.Label.Should().BeNull();
@@ -58,8 +58,8 @@ public class ManifestMergerTests
         // Assert
         mergedManifest.Items.Count.Should().Be(1);
         mergedManifest.Thumbnail.Count.Should().Be(1);
-        mergedManifest.Items[0].Width.Should().Be(100);
-        mergedManifest.Items[0].Height.Should().Be(100);
+        mergedManifest.Items[0].Width.Should().Be(110);
+        mergedManifest.Items[0].Height.Should().Be(110);
     }
     
     [Fact]
@@ -84,8 +84,8 @@ public class ManifestMergerTests
         mergedManifest.Items.Count.Should().Be(1);
         mergedManifest.Thumbnail[0].Service[0].Id.Should().Be("namedQueryId");
         mergedManifest.Thumbnail.Count.Should().Be(2);
-        mergedManifest.Items[0].Width.Should().Be(100);
-        mergedManifest.Items[0].Height.Should().Be(100);
+        mergedManifest.Items[0].Width.Should().Be(110);
+        mergedManifest.Items[0].Height.Should().Be(110);
     }
     
     [Fact]
@@ -317,8 +317,8 @@ public class ManifestMergerTests
         {
             Id = $"{id}",
             Label = new LanguageMap("en", $"{id}"),
-            Width = 100,
-            Height = 100,
+            Width = 110,
+            Height = 110,
             Metadata = GenerateMetadata(),
             Items =
             [

--- a/src/IIIFPresentation/BackgroundHandler.Tests/Helpers/ManifestMergerTests.cs
+++ b/src/IIIFPresentation/BackgroundHandler.Tests/Helpers/ManifestMergerTests.cs
@@ -21,13 +21,13 @@ public class ManifestMergerTests
         var blankManifest = new Manifest();
         var assetId = $"1/2/{nameof(Merge_MergesBlankManifestWithGeneratedManifest)}";
         
-        var generatedManifest = GeneratedManifest(assetId);
-        var itemDictionary = generatedManifest.Items.ToDictionary(i => AssetId.FromString(i.Id), i => i);
+        var namedQueryManifest = GeneratedManifest(assetId);
+        var itemDictionary = namedQueryManifest.Items.ToDictionary(i => AssetId.FromString(i.Id), i => i);
         
         // Act
         var mergedManifest = ManifestMerger.Merge(blankManifest,
             GenerateCanvasPaintings([assetId]), itemDictionary,
-            generatedManifest.Thumbnail);
+            namedQueryManifest.Thumbnail);
         
         // Assert
         mergedManifest.Items.Count.Should().Be(1);
@@ -47,13 +47,13 @@ public class ManifestMergerTests
         var blankManifest = GeneratedManifest(assetId);
         blankManifest.Items[0].Width = 200;
         blankManifest.Items[0].Height = 200;
-        var generatedManifest = GeneratedManifest(assetId);
-        var itemDictionary = generatedManifest.Items.ToDictionary(i => AssetId.FromString(i.Id), i => i);
+        var namedQueryManifest = GeneratedManifest(assetId);
+        var itemDictionary = namedQueryManifest.Items.ToDictionary(i => AssetId.FromString(i.Id), i => i);
         
         // Act
         var mergedManifest = ManifestMerger.Merge(blankManifest,
             GenerateCanvasPaintings([assetId]), itemDictionary,
-            generatedManifest.Thumbnail);
+            namedQueryManifest.Thumbnail);
         
         // Assert
         mergedManifest.Items.Count.Should().Be(1);
@@ -70,19 +70,19 @@ public class ManifestMergerTests
         var blankManifest = GeneratedManifest(assetId);
         blankManifest.Items[0].Width = 200;
         blankManifest.Items[0].Height = 200;
-        blankManifest.Thumbnail.Add(GenerateImage());
-        blankManifest.Thumbnail[0].Service[0].Id = "generatedId";
-        var generatedManifest = GeneratedManifest(assetId);
-        var itemDictionary = generatedManifest.Items.ToDictionary(i => AssetId.FromString(i.Id), i => i);
+        blankManifest.Thumbnail.Add(GenerateImageService(assetId));
+        blankManifest.Thumbnail[0].Service[0].Id = "namedQueryId";
+        var namedQueryManifest = GeneratedManifest(assetId);
+        var itemDictionary = namedQueryManifest.Items.ToDictionary(i => AssetId.FromString(i.Id), i => i);
         
         // Act
         var mergedManifest = ManifestMerger.Merge(blankManifest,
             GenerateCanvasPaintings([assetId]), itemDictionary,
-            generatedManifest.Thumbnail);
+            namedQueryManifest.Thumbnail);
         
         // Assert
         mergedManifest.Items.Count.Should().Be(1);
-        mergedManifest.Thumbnail[0].Service[0].Id.Should().Be("generatedId");
+        mergedManifest.Thumbnail[0].Service[0].Id.Should().Be("namedQueryId");
         mergedManifest.Thumbnail.Count.Should().Be(2);
         mergedManifest.Items[0].Width.Should().Be(100);
         mergedManifest.Items[0].Height.Should().Be(100);
@@ -93,9 +93,9 @@ public class ManifestMergerTests
     {
         // Arrange
         var blankManifest = new Manifest();
-        var generatedManifest = GeneratedManifest($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1");
-        generatedManifest.Items.Add(GenerateCanvas($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_2"));
-        var itemDictionary = generatedManifest.Items.ToDictionary(i => AssetId.FromString(i.Id), i => i);
+        var namedQueryManifest = GeneratedManifest($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1");
+        namedQueryManifest.Items.Add(GenerateCanvas($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_2"));
+        var itemDictionary = namedQueryManifest.Items.ToDictionary(i => AssetId.FromString(i.Id), i => i);
         
         var canvasPaintings = GenerateCanvasPaintings([
             $"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1",
@@ -107,15 +107,167 @@ public class ManifestMergerTests
         
         // Act
         var mergedManifest =
-            ManifestMerger.Merge(blankManifest, canvasPaintings, itemDictionary, generatedManifest.Thumbnail);
+            ManifestMerger.Merge(blankManifest, canvasPaintings, itemDictionary, namedQueryManifest.Thumbnail);
         
         // Assert
         mergedManifest.Items.Count.Should().Be(2);
-        mergedManifest.Thumbnail[0].Service[0].Id.Should().Be("imageId");
+        mergedManifest.Thumbnail[0].Service[0].Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1");
         mergedManifest.Thumbnail.Count.Should().Be(1);
         // order flipped due to canvas order
         mergedManifest.Items[0].Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_2");
         mergedManifest.Items[1].Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1");
+    }
+    
+    [Fact]
+    public void Merge_CorrectlyOrdersItemsWithChoiceOrder()
+    {
+        // Arrange
+        var blankManifest = new Manifest();
+        var namedQueryManifest = GeneratedManifest($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1");
+        namedQueryManifest.Items.Add(GenerateCanvas($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_2"));
+        namedQueryManifest.Items.Add(GenerateCanvas($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_3"));
+        namedQueryManifest.Items.Add(GenerateCanvas($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_4"));
+        namedQueryManifest.Items.Add(GenerateCanvas($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_5"));
+        var itemDictionary = namedQueryManifest.Items.ToDictionary(i => AssetId.FromString(i.Id), i => i);
+        
+        var canvasPaintings = GenerateCanvasPaintings([
+            $"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1",
+            $"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_2",
+            $"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_3",
+            $"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_4",
+            $"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_5"
+        ]);
+
+        canvasPaintings[0].CanvasOrder = 0;
+        canvasPaintings[1].CanvasOrder = 1;
+        canvasPaintings[2].CanvasOrder = 0;
+        canvasPaintings[3].CanvasOrder = 1;
+        canvasPaintings[4].CanvasOrder = 2;
+        canvasPaintings[0].ChoiceOrder = 0;
+        canvasPaintings[1].ChoiceOrder = 1;
+        canvasPaintings[2].ChoiceOrder = 1;
+        canvasPaintings[3].ChoiceOrder = 0;
+        canvasPaintings[4].ChoiceOrder = 0;
+        
+        // Act
+        var mergedManifest =
+            ManifestMerger.Merge(blankManifest, canvasPaintings, itemDictionary, namedQueryManifest.Thumbnail);
+        
+        // Assert
+        mergedManifest.Items.Count.Should().Be(3);
+        mergedManifest.Thumbnail[0].Service[0].Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1");
+        mergedManifest.Thumbnail.Count.Should().Be(1);
+        // should be 1 + 3 then 4 + 2 then 5
+        mergedManifest.Items[0].Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1");
+        mergedManifest.Items[1].Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_4");
+        mergedManifest.Items[2].Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_5");
+        mergedManifest.Items[0].Items[0].Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1_AnnotationPage");
+        mergedManifest.Items[0].Items[0].Items[0].As<PaintingAnnotation>().Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1_PaintingAnnotation");
+
+        var firstAnnotationBody = mergedManifest.Items[0].Items[0].Items[0].As<PaintingAnnotation>().Body.As<PaintingChoice>();
+        firstAnnotationBody.Items[0].As<Image>().Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1");
+        firstAnnotationBody.Items[1].As<Image>().Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_3");
+        
+        var secondAnnotationBody = mergedManifest.Items[1].Items[0].Items[0].As<PaintingAnnotation>().Body.As<PaintingChoice>();
+        secondAnnotationBody.Items[0].As<Image>().Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_4");
+        secondAnnotationBody.Items[1].As<Image>().Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_2");
+    }
+    
+    [Fact]
+    public void Merge_CorrectlyMergesChoiceOrder_WhenUpdatingChoiceOrder()
+    {
+        // Arrange
+        var blankManifest = GeneratedManifest($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1", true);
+
+        blankManifest.Items[0].Items[0].Items[0].As<PaintingAnnotation>().Body.As<PaintingChoice>().Items[0].As<Image>().Label =
+            new LanguageMap("before_update", "before update");
+        
+        var namedQueryManifest = GeneratedManifest($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1");
+        namedQueryManifest.Items.Add(GenerateCanvas($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_2"));
+        namedQueryManifest.Items.Add(GenerateCanvas($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_3"));
+        
+        namedQueryManifest.Items[0].Items[0].Items[0].As<PaintingAnnotation>().Body.As<Image>().Label =
+            new LanguageMap("after_update", "after update");
+        
+        var itemDictionary = namedQueryManifest.Items.ToDictionary(i => AssetId.FromString(i.Id), i => i);
+        
+        var canvasPaintings = GenerateCanvasPaintings([
+            $"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1",
+            $"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_2",
+            $"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_3"
+        ]);
+
+        canvasPaintings[0].CanvasOrder = 0;
+        canvasPaintings[1].CanvasOrder = 0;
+        canvasPaintings[2].CanvasOrder = 1;
+        canvasPaintings[0].ChoiceOrder = 0;
+        canvasPaintings[1].ChoiceOrder = 1;
+        
+        // Act
+        var mergedManifest =
+            ManifestMerger.Merge(blankManifest, canvasPaintings, itemDictionary, namedQueryManifest.Thumbnail);
+        
+        // Assert
+        mergedManifest.Items.Count.Should().Be(2);
+        mergedManifest.Thumbnail[0].Service[0].Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1");
+        mergedManifest.Thumbnail.Count.Should().Be(1);
+        // should be 1 + 3 then 4 + 2 then 5
+        mergedManifest.Items[0].Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1");
+        mergedManifest.Items[1].Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_3");
+        mergedManifest.Items[0].Items[0].Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1_AnnotationPage");
+        mergedManifest.Items[0].Items[0].Items[0].As<PaintingAnnotation>().Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1_PaintingAnnotation");
+
+        var firstAnnotationBody = mergedManifest.Items[0].Items[0].Items[0].As<PaintingAnnotation>().Body.As<PaintingChoice>();
+        firstAnnotationBody.Items[0].As<Image>().Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1");
+        firstAnnotationBody.Items[0].As<Image>().Label.Keys.Should().Contain("after_update");
+        firstAnnotationBody.Items[1].As<Image>().Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_2");
+    }
+    
+    [Fact]
+    public void Merge_CorrectlyMergesImageIntoChoiceOrder_WhenUpdatingChoiceOrder()
+    {
+        // Arrange
+        var blankManifest = GeneratedManifest($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1");
+        
+        var namedQueryManifest = GeneratedManifest($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1");
+        namedQueryManifest.Items.Add(GenerateCanvas($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_2"));
+        namedQueryManifest.Items.Add(GenerateCanvas($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_3"));
+        
+        namedQueryManifest.Items[0].Items[0].Items[0].As<PaintingAnnotation>().Body.As<Image>().Label =
+            new LanguageMap("after_update", "after update");
+        
+        var itemDictionary = namedQueryManifest.Items.ToDictionary(i => AssetId.FromString(i.Id), i => i);
+        
+        var canvasPaintings = GenerateCanvasPaintings([
+            $"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1",
+            $"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_2",
+            $"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_3"
+        ]);
+
+        canvasPaintings[0].CanvasOrder = 0;
+        canvasPaintings[1].CanvasOrder = 0;
+        canvasPaintings[2].CanvasOrder = 1;
+        canvasPaintings[0].ChoiceOrder = 0;
+        canvasPaintings[1].ChoiceOrder = 1;
+        
+        // Act
+        var mergedManifest =
+            ManifestMerger.Merge(blankManifest, canvasPaintings, itemDictionary, namedQueryManifest.Thumbnail);
+        
+        // Assert
+        mergedManifest.Items.Count.Should().Be(2);
+        mergedManifest.Thumbnail[0].Service[0].Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1");
+        mergedManifest.Thumbnail.Count.Should().Be(1);
+        // should be 1 + 3 then 4 + 2 then 5
+        mergedManifest.Items[0].Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1");
+        mergedManifest.Items[1].Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_3");
+
+        mergedManifest.Items[0].Items[0].Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1_AnnotationPage");
+        mergedManifest.Items[0].Items[0].Items[0].As<PaintingAnnotation>().Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1_PaintingAnnotation");
+        var firstAnnotationBody = mergedManifest.Items[0].Items[0].Items[0].As<PaintingAnnotation>().Body.As<PaintingChoice>();
+        firstAnnotationBody.Items[0].As<Image>().Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1");
+        firstAnnotationBody.Items[0].As<Image>().Label.Keys.Should().Contain("after_update");
+        firstAnnotationBody.Items[1].As<Image>().Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_2");
     }
 
     private List<CanvasPainting> GenerateCanvasPaintings(List<string> idList)
@@ -124,48 +276,51 @@ public class ManifestMergerTests
         return idList.Select(id => new CanvasPainting{Id = id, AssetId = AssetId.FromString(id), CanvasOrder = canvasOrder++}).ToList();
     }
 
-    private Manifest GeneratedManifest(string id)
+    private Manifest GeneratedManifest(string id, bool paintingChoice = false)
     {
         return new Manifest
         {
             Thumbnail =
             [
-                GenerateImage()
+                GenerateImageService(id)
             ],
             Label = new LanguageMap("en", "someLabel"),
             Items =
             [
-                GenerateCanvas(id)
+                GenerateCanvas(id, paintingChoice)
             ],
             Metadata = GenerateMetadata()
         };
     }
 
-    private static Canvas GenerateCanvas(string id)
+    private static Canvas GenerateCanvas(string id, bool paintingChoice = false)
     {
         return new Canvas
         {
-            Id = id,
+            Id = $"{id}",
+            Label = new LanguageMap("en", $"{id}"),
             Width = 100,
             Height = 100,
             Metadata = GenerateMetadata(),
-            Annotations =
+            Items =
             [
                 new AnnotationPage
                 {
+                    Id = $"{id}_AnnotationPage",
+                    Label = new LanguageMap("en", $"{id}_AnnotationPage"),
                     Items =
                     [
                         new PaintingAnnotation
                         {
-                            Body = new Image
-                            {
-                                Width = 100,
-                                Height = 100,
-                            },
+                            Id = $"{id}_PaintingAnnotation",
+                            Label = new LanguageMap("en", $"PaintingAnnotation_{id}_PaintingAnnotation"),
+                            Body = paintingChoice ? GeneratePaintingChoice(id) : GenerateImage(id),
                             Service = new List<IService>
                             {
                                 new ImageService3
                                 {
+                                    Id = $"{id}_ImageService3",
+                                    Label = new LanguageMap("en", $"{id}_ImageService3"),
                                     Profile = "level2"
                                 }
                             }
@@ -176,15 +331,30 @@ public class ManifestMergerTests
         };
     }
 
-    private static List<LabelValuePair> GenerateMetadata()
+    private static PaintingChoice GeneratePaintingChoice(string id)
     {
-        return new List<LabelValuePair>()
+        return new PaintingChoice()
         {
-            new(new LanguageMap("en", "label1"), new LanguageMap("en", "value1"))
+            Items = [GenerateImage(id)]
         };
     }
 
-    private static Image GenerateImage()
+    private static Image GenerateImage(string id)
+    {
+        return new Image
+        {
+            Id = id,
+            Width = 100,
+            Height = 100,
+        };
+    }
+
+    private static List<LabelValuePair> GenerateMetadata()
+    {
+        return [new(new LanguageMap("en", "label1"), new LanguageMap("en", "value1"))];
+    }
+
+    private static Image GenerateImageService(string id)
     {
         return new Image
         {
@@ -192,7 +362,7 @@ public class ManifestMergerTests
             [
                 new ImageService3
                 {
-                    Id = "imageId",
+                    Id = id,
                     Sizes = [new(100, 100)]
                 }
             ]

--- a/src/IIIFPresentation/BackgroundHandler.Tests/Helpers/ManifestMergerTests.cs
+++ b/src/IIIFPresentation/BackgroundHandler.Tests/Helpers/ManifestMergerTests.cs
@@ -35,7 +35,36 @@ public class ManifestMergerTests
         mergedManifest.Items[0].Height.Should().Be(110);
         mergedManifest.Thumbnail.Count.Should().Be(1);
         mergedManifest.Metadata.Should().BeNull();
-        mergedManifest.Label.Should().BeNull();
+        mergedManifest.Items[0].Label.Keys.Should().Contain("canvasPaintingLabel");;
+        mergedManifest.Items[0].Metadata.Should().BeNull();
+    }
+    
+    [Fact]
+    public void Merge_MergesBlankManifestWithGeneratedManifestWithCanvasLabel()
+    {
+        // Arrange
+        var blankManifest = new Manifest();
+        var assetId = $"1/2/{nameof(Merge_MergesBlankManifestWithGeneratedManifest)}";
+        
+        var namedQueryManifest = GeneratedManifest(assetId);
+        namedQueryManifest.Items[0].Label = null;
+        var itemDictionary = namedQueryManifest.Items.ToDictionary(i => AssetId.FromString(i.Id), i => i);
+        var canvasPaintings = GenerateCanvasPaintings([assetId]);
+        canvasPaintings[0].CanvasLabel =
+            new LanguageMap("canvasPaintingCanvasLabel", "generated canvas painting label");
+        
+        // Act
+        var mergedManifest = ManifestMerger.Merge(blankManifest,
+            canvasPaintings, itemDictionary,
+            namedQueryManifest.Thumbnail);
+        
+        // Assert
+        mergedManifest.Items.Count.Should().Be(1);
+        mergedManifest.Items[0].Width.Should().Be(110);
+        mergedManifest.Items[0].Height.Should().Be(110);
+        mergedManifest.Thumbnail.Count.Should().Be(1);
+        mergedManifest.Metadata.Should().BeNull();
+        mergedManifest.Items[0].Label.Keys.Should().Contain("canvasPaintingCanvasLabel");;
         mergedManifest.Items[0].Metadata.Should().BeNull();
     }
     
@@ -128,6 +157,7 @@ public class ManifestMergerTests
         namedQueryManifest.Items.Add(GenerateCanvas($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_3"));
         namedQueryManifest.Items.Add(GenerateCanvas($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_4"));
         namedQueryManifest.Items.Add(GenerateCanvas($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_5"));
+        
         var itemDictionary = namedQueryManifest.Items.ToDictionary(i => AssetId.FromString(i.Id), i => i);
         
         var canvasPaintings = GenerateCanvasPaintings([
@@ -149,6 +179,11 @@ public class ManifestMergerTests
         canvasPaintings[3].ChoiceOrder = 0;
         canvasPaintings[4].ChoiceOrder = 0;
         
+        canvasPaintings[0].CanvasLabel =
+            new LanguageMap("canvasPaintingCanvasLabel", "generated canvas painting label");
+        canvasPaintings[1].CanvasLabel =
+            new LanguageMap("canvasPaintingCanvasLabel", "generated canvas painting label");
+        
         // Act
         var mergedManifest =
             ManifestMerger.Merge(blankManifest, canvasPaintings, itemDictionary, namedQueryManifest.Thumbnail);
@@ -159,7 +194,10 @@ public class ManifestMergerTests
         mergedManifest.Thumbnail.Count.Should().Be(1);
         // should be 1 + 3 then 4 + 2 then 5
         mergedManifest.Items[0].Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1");
+        mergedManifest.Items[0].Label.Keys.Should().Contain("canvasPaintingCanvasLabel");
         mergedManifest.Items[1].Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_4");
+        mergedManifest.Items[1].Label.Keys.Should().Contain("canvasPaintingLabel");
+        mergedManifest.Items[1].Label.Keys.Should().NotContain("canvasPaintingCanvasLabel");
         mergedManifest.Items[2].Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_5");
         
         var currentCanvasAnnotation = mergedManifest.GetCurrentCanvasAnnotation(0);
@@ -173,24 +211,26 @@ public class ManifestMergerTests
         var firstAnnotationBody = currentCanvasAnnotation.Items[0].As<PaintingAnnotation>().Body.As<PaintingChoice>();
         firstAnnotationBody.Items[0].As<Image>().Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1");
         firstAnnotationBody.Items[1].As<Image>().Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_3");
+        firstAnnotationBody.Items[0].As<Image>().Label.Keys.Should().Contain("canvasPaintingLabel");
         
         var secondAnnotationBody =  mergedManifest.GetCurrentCanvasAnnotation(1).Items[0].As<PaintingAnnotation>().Body.As<PaintingChoice>();
         secondAnnotationBody.Items[0].As<Image>().Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_4");
         secondAnnotationBody.Items[1].As<Image>().Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_2");
+        secondAnnotationBody.Items[0].As<Image>().Label.Keys.Should().Contain("canvasPaintingLabel");
     }
     
     [Fact]
     public void Merge_CorrectlyMergesChoiceOrder_WhenUpdatingChoiceOrder()
     {
         // Arrange
-        var blankManifest = GeneratedManifest($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1", true);
+        var blankManifest = GeneratedManifest($"1/2/{nameof(Merge_CorrectlyMergesChoiceOrder_WhenUpdatingChoiceOrder)}_1", true);
 
         blankManifest.Items[0].Items[0].Items[0].As<PaintingAnnotation>().Body.As<PaintingChoice>().Items[0].As<Image>().Label =
             new LanguageMap("before_update", "before update");
         
-        var namedQueryManifest = GeneratedManifest($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1");
-        namedQueryManifest.Items.Add(GenerateCanvas($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_2"));
-        namedQueryManifest.Items.Add(GenerateCanvas($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_3"));
+        var namedQueryManifest = GeneratedManifest($"1/2/{nameof(Merge_CorrectlyMergesChoiceOrder_WhenUpdatingChoiceOrder)}_1");
+        namedQueryManifest.Items.Add(GenerateCanvas($"1/2/{nameof(Merge_CorrectlyMergesChoiceOrder_WhenUpdatingChoiceOrder)}_2"));
+        namedQueryManifest.Items.Add(GenerateCanvas($"1/2/{nameof(Merge_CorrectlyMergesChoiceOrder_WhenUpdatingChoiceOrder)}_3"));
         
         namedQueryManifest.Items[0].Items[0].Items[0].As<PaintingAnnotation>().Body.As<Image>().Label =
             new LanguageMap("after_update", "after update");
@@ -198,9 +238,9 @@ public class ManifestMergerTests
         var itemDictionary = namedQueryManifest.Items.ToDictionary(i => AssetId.FromString(i.Id), i => i);
         
         var canvasPaintings = GenerateCanvasPaintings([
-            $"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1",
-            $"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_2",
-            $"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_3"
+            $"1/2/{nameof(Merge_CorrectlyMergesChoiceOrder_WhenUpdatingChoiceOrder)}_1",
+            $"1/2/{nameof(Merge_CorrectlyMergesChoiceOrder_WhenUpdatingChoiceOrder)}_2",
+            $"1/2/{nameof(Merge_CorrectlyMergesChoiceOrder_WhenUpdatingChoiceOrder)}_3"
         ]);
 
         canvasPaintings[0].CanvasOrder = 0;
@@ -209,30 +249,39 @@ public class ManifestMergerTests
         canvasPaintings[0].ChoiceOrder = 0;
         canvasPaintings[1].ChoiceOrder = 1;
         
+        canvasPaintings[0].Label = null;
+        
         // Act
         var mergedManifest =
             ManifestMerger.Merge(blankManifest, canvasPaintings, itemDictionary, namedQueryManifest.Thumbnail);
         
         // Assert
         mergedManifest.Items.Count.Should().Be(2);
-        mergedManifest.Thumbnail[0].Service[0].Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1");
+        mergedManifest.Thumbnail[0].Service[0].Id.Should()
+            .Be($"1/2/{nameof(Merge_CorrectlyMergesChoiceOrder_WhenUpdatingChoiceOrder)}_1");
         mergedManifest.Thumbnail.Count.Should().Be(1);
-        // should be 1 + 3 then 4 + 2 then 5
-        mergedManifest.Items[0].Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1");
-        mergedManifest.Items[1].Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_3");
+
+        mergedManifest.Items[0].Id.Should()
+            .Be($"1/2/{nameof(Merge_CorrectlyMergesChoiceOrder_WhenUpdatingChoiceOrder)}_1");
+        mergedManifest.Items[1].Id.Should()
+            .Be($"1/2/{nameof(Merge_CorrectlyMergesChoiceOrder_WhenUpdatingChoiceOrder)}_3");
         
         var currentCanvasAnnotation = mergedManifest.GetCurrentCanvasAnnotation(0);
-        
-        currentCanvasAnnotation.Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1_AnnotationPage");
-        currentCanvasAnnotation.Items[0].As<PaintingAnnotation>().Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1_PaintingAnnotation");
+
+        currentCanvasAnnotation.Id.Should()
+            .Be($"1/2/{nameof(Merge_CorrectlyMergesChoiceOrder_WhenUpdatingChoiceOrder)}_1_AnnotationPage");
+        currentCanvasAnnotation.Items[0].As<PaintingAnnotation>().Id.Should().Be(
+            $"1/2/{nameof(Merge_CorrectlyMergesChoiceOrder_WhenUpdatingChoiceOrder)}_1_PaintingAnnotation");
         
         var target = currentCanvasAnnotation.Items[0].As<PaintingAnnotation>().Target as Canvas;
-        target.Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1");
+        target.Id.Should().Be($"1/2/{nameof(Merge_CorrectlyMergesChoiceOrder_WhenUpdatingChoiceOrder)}_1");
 
         var firstAnnotationBody = currentCanvasAnnotation.Items[0].As<PaintingAnnotation>().Body.As<PaintingChoice>();
-        firstAnnotationBody.Items[0].As<Image>().Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1");
+        firstAnnotationBody.Items[0].As<Image>().Id.Should()
+            .Be($"1/2/{nameof(Merge_CorrectlyMergesChoiceOrder_WhenUpdatingChoiceOrder)}_1");
         firstAnnotationBody.Items[0].As<Image>().Label.Keys.Should().Contain("after_update");
-        firstAnnotationBody.Items[1].As<Image>().Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_2");
+        firstAnnotationBody.Items[1].As<Image>().Id.Should()
+            .Be($"1/2/{nameof(Merge_CorrectlyMergesChoiceOrder_WhenUpdatingChoiceOrder)}_2");
     }
     
     [Fact]
@@ -261,6 +310,8 @@ public class ManifestMergerTests
         canvasPaintings[2].CanvasOrder = 1;
         canvasPaintings[0].ChoiceOrder = 0;
         canvasPaintings[1].ChoiceOrder = 1;
+        
+        canvasPaintings[0].Label = null;
         
         // Act
         var mergedManifest =
@@ -291,7 +342,11 @@ public class ManifestMergerTests
     private List<CanvasPainting> GenerateCanvasPaintings(List<string> idList)
     {
         var canvasOrder = 0;
-        return idList.Select(id => new CanvasPainting{Id = id, AssetId = AssetId.FromString(id), CanvasOrder = canvasOrder++}).ToList();
+        return idList.Select(id => new CanvasPainting
+        {
+            Id = id, AssetId = AssetId.FromString(id), CanvasOrder = canvasOrder++,
+            Label = new LanguageMap("canvasPaintingLabel", "generated canvas painting label")
+        }).ToList();
     }
 
     private Manifest GeneratedManifest(string id, bool paintingChoice = false)
@@ -351,7 +406,7 @@ public class ManifestMergerTests
 
     private static PaintingChoice GeneratePaintingChoice(string id)
     {
-        return new PaintingChoice()
+        return new PaintingChoice
         {
             Items = [GenerateImage(id)]
         };

--- a/src/IIIFPresentation/BackgroundHandler.Tests/Helpers/ManifestMergerTests.cs
+++ b/src/IIIFPresentation/BackgroundHandler.Tests/Helpers/ManifestMergerTests.cs
@@ -161,14 +161,20 @@ public class ManifestMergerTests
         mergedManifest.Items[0].Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1");
         mergedManifest.Items[1].Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_4");
         mergedManifest.Items[2].Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_5");
-        mergedManifest.Items[0].Items[0].Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1_AnnotationPage");
-        mergedManifest.Items[0].Items[0].Items[0].As<PaintingAnnotation>().Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1_PaintingAnnotation");
+        
+        var currentCanvasAnnotation = mergedManifest.GetCurrentCanvasAnnotation(0);
+        
+        currentCanvasAnnotation.Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1_AnnotationPage");
+        currentCanvasAnnotation.Items[0].As<PaintingAnnotation>().Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1_PaintingAnnotation");
 
-        var firstAnnotationBody = mergedManifest.Items[0].Items[0].Items[0].As<PaintingAnnotation>().Body.As<PaintingChoice>();
+        var target = currentCanvasAnnotation.Items[0].As<PaintingAnnotation>().Target as Canvas;
+        target.Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1");
+
+        var firstAnnotationBody = currentCanvasAnnotation.Items[0].As<PaintingAnnotation>().Body.As<PaintingChoice>();
         firstAnnotationBody.Items[0].As<Image>().Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1");
         firstAnnotationBody.Items[1].As<Image>().Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_3");
         
-        var secondAnnotationBody = mergedManifest.Items[1].Items[0].Items[0].As<PaintingAnnotation>().Body.As<PaintingChoice>();
+        var secondAnnotationBody =  mergedManifest.GetCurrentCanvasAnnotation(1).Items[0].As<PaintingAnnotation>().Body.As<PaintingChoice>();
         secondAnnotationBody.Items[0].As<Image>().Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_4");
         secondAnnotationBody.Items[1].As<Image>().Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_2");
     }
@@ -214,10 +220,16 @@ public class ManifestMergerTests
         // should be 1 + 3 then 4 + 2 then 5
         mergedManifest.Items[0].Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1");
         mergedManifest.Items[1].Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_3");
-        mergedManifest.Items[0].Items[0].Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1_AnnotationPage");
-        mergedManifest.Items[0].Items[0].Items[0].As<PaintingAnnotation>().Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1_PaintingAnnotation");
+        
+        var currentCanvasAnnotation = mergedManifest.GetCurrentCanvasAnnotation(0);
+        
+        currentCanvasAnnotation.Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1_AnnotationPage");
+        currentCanvasAnnotation.Items[0].As<PaintingAnnotation>().Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1_PaintingAnnotation");
+        
+        var target = currentCanvasAnnotation.Items[0].As<PaintingAnnotation>().Target as Canvas;
+        target.Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1");
 
-        var firstAnnotationBody = mergedManifest.Items[0].Items[0].Items[0].As<PaintingAnnotation>().Body.As<PaintingChoice>();
+        var firstAnnotationBody = currentCanvasAnnotation.Items[0].As<PaintingAnnotation>().Body.As<PaintingChoice>();
         firstAnnotationBody.Items[0].As<Image>().Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1");
         firstAnnotationBody.Items[0].As<Image>().Label.Keys.Should().Contain("after_update");
         firstAnnotationBody.Items[1].As<Image>().Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_2");
@@ -262,9 +274,15 @@ public class ManifestMergerTests
         mergedManifest.Items[0].Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1");
         mergedManifest.Items[1].Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_3");
 
-        mergedManifest.Items[0].Items[0].Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1_AnnotationPage");
-        mergedManifest.Items[0].Items[0].Items[0].As<PaintingAnnotation>().Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1_PaintingAnnotation");
-        var firstAnnotationBody = mergedManifest.Items[0].Items[0].Items[0].As<PaintingAnnotation>().Body.As<PaintingChoice>();
+        var currentCanvasAnnotation = mergedManifest.GetCurrentCanvasAnnotation(0);
+
+        currentCanvasAnnotation.Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1_AnnotationPage");
+        currentCanvasAnnotation.Items[0].As<PaintingAnnotation>().Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1_PaintingAnnotation");
+        
+        var target = currentCanvasAnnotation.Items[0].As<PaintingAnnotation>().Target as Canvas;
+        target.Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1");
+        
+        var firstAnnotationBody = currentCanvasAnnotation.Items[0].As<PaintingAnnotation>().Body.As<PaintingChoice>();
         firstAnnotationBody.Items[0].As<Image>().Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_1");
         firstAnnotationBody.Items[0].As<Image>().Label.Keys.Should().Contain("after_update");
         firstAnnotationBody.Items[1].As<Image>().Id.Should().Be($"1/2/{nameof(Merge_CorrectlyOrdersMultipleItems)}_2");

--- a/src/IIIFPresentation/BackgroundHandler/Helpers/ManifestMerger.cs
+++ b/src/IIIFPresentation/BackgroundHandler/Helpers/ManifestMerger.cs
@@ -1,5 +1,6 @@
 ﻿using Core.Helpers;
 using IIIF.Presentation.V3;
+using IIIF.Presentation.V3.Annotation;
 using IIIF.Presentation.V3.Content;
 using Models.DLCS;
 using CanvasPainting = Models.Database.CanvasPainting;
@@ -16,26 +17,38 @@ public static class ManifestMerger
     {
         if (baseManifest.Items == null) baseManifest.Items = [];
 
-        var indexedBaseManifest = baseManifest.Items.Select((item, index) => (item, index)).ToList();
-        var orderedCanvasPaintings = canvasPaintings?.OrderBy(cp => cp.CanvasOrder).ToList() ?? [];
+        var indexBasedManifest = baseManifest.Items.Select((item, index) => (item, index)).ToList();
+        // get everything in the right order, then group by so we can tell where one choice ends and the next begins
+        var orderedCanvasPaintings = canvasPaintings?.OrderBy(cp => cp.CanvasOrder).ThenBy(cp => cp.ChoiceOrder).GroupBy(cp => cp.CanvasOrder).ToList() ?? [];
         
         // We want to use the canvas order set when creating assets, rather than the 
-        foreach (var canvasPainting in orderedCanvasPaintings)
+        foreach (var groupedCanvasPaintings in orderedCanvasPaintings.Select((item, index) => (item, index)))
         {
-            if (!itemDictionary.TryGetValue(canvasPainting.AssetId!, out var generatedItem)) continue;
-            
-            var existingItem = indexedBaseManifest.FirstOrDefault(bm => bm.item.Id == generatedItem.Id);
+            groupedCanvasPaintings.item.TryGetNonEnumeratedCount(out var totalGroupedItems);
+            foreach (var canvasPainting in groupedCanvasPaintings.item)
+            {
+                if (!itemDictionary.TryGetValue(canvasPainting.AssetId!, out var namedQueryItem)) continue;
 
-            // remove canvas metadata as it's not required
-            generatedItem.Metadata = null;
-            
-            if (existingItem.item != null)
-            {
-                baseManifest.Items[existingItem.index] = generatedItem;
-            }
-            else
-            {
-                baseManifest.Items.Add(generatedItem);
+                var existingItem = indexBasedManifest.FirstOrDefault(bm => bm.item.Id == namedQueryItem.Id);
+
+                // remove canvas metadata as it's not required
+                namedQueryItem.Metadata = null;
+
+                if (totalGroupedItems == 1)
+                {
+                    AddOrUpdateIndividualCanvas(baseManifest, existingItem, namedQueryItem);
+                }
+                else
+                {
+                    if (existingItem.item?.Id != null)
+                    {
+                        UpdateChoiceOrder(baseManifest, groupedCanvasPaintings.index, namedQueryItem);
+                    }
+                    else
+                    {
+                        AddChoiceOrder(baseManifest, groupedCanvasPaintings.index, namedQueryItem);
+                    }
+                }
             }
         }
 
@@ -45,5 +58,144 @@ public static class ManifestMerger
         }
         
         return baseManifest;
+    }
+
+    private static void UpdateChoiceOrder(Manifest baseManifest, int index, Canvas namedQueryItem)
+    {
+        // grab the body of the selected image and base maniest to update
+        var baseManifestPaintingAnnotations = baseManifest.Items![index].Items!;
+        var paintingAnnotation = baseManifestPaintingAnnotations[0].Items?[0] as PaintingAnnotation;
+        var baseImage = paintingAnnotation!.Body as PaintingChoice; 
+        var namedQueryAnnotation = namedQueryItem.Items?[0].Items?[0] as PaintingAnnotation;
+        var namedQueryImage = (Image)namedQueryAnnotation!.Body!;
+        
+        var baseImageIndex = baseImage?.Items?.OfType<Image>().ToList()
+            .FindIndex(pa => pa.Id == namedQueryItem.Id);
+        
+        // this is moving an image to a choice order
+        if (baseImageIndex is -1 or null)
+        {
+            // this is replacing the existing image in items with a painting choice
+            baseManifest.Items = 
+            [
+                new Canvas
+                {
+                    Items = [new AnnotationPage
+                    {
+                        Id = namedQueryItem.Items?[0].Id,
+                        Label = namedQueryItem.Items?[0].Label,
+                        Items = []
+                    }]
+                }
+            ];
+
+            baseImage = new PaintingChoice
+            {
+                Items =
+                [
+                    namedQueryImage
+                ]
+            };
+            
+            // update the identifier and label of the canvas based on the identifier and label of the first choice
+            baseManifest.Items[index].Id = namedQueryItem.Id;
+            baseManifest.Items[index].Label = namedQueryItem.Label;
+            paintingAnnotation.Target ??= baseManifest.Items[index];
+            
+            paintingAnnotation.Body = baseImage;
+            baseManifest.Items![index].Items![0].Items!.Add(paintingAnnotation);
+        }
+        else
+        {
+            // update the manifest with the updated image
+            baseImage.Items![baseImageIndex.Value] = namedQueryImage;
+            baseImage.Service ??= namedQueryAnnotation.Service;
+            paintingAnnotation.Body = baseImage;
+            baseManifest.Items![index].Items![0].Items![0] = paintingAnnotation;
+        }
+    }
+
+    private static void AddChoiceOrder(Manifest baseManifest, int index,
+        Canvas namedQueryItem)
+    {
+        List<AnnotationPage> baseManifestPaintingAnnotations;
+        var namedQueryAnnotationPage = namedQueryItem.Items?[0];
+        
+        // is this the first item in a new choice order?
+        if (baseManifest.Items?.Count == index)
+        {
+            // if it is, set up the first annotation page with objects and then populate, so errors aren't thrown
+            baseManifest.Items ??= [];
+            baseManifestPaintingAnnotations = CreateEmptyPaintingAnnotations(namedQueryAnnotationPage);
+            
+            baseManifest.Items.Add(new Canvas
+            {
+                Items = baseManifestPaintingAnnotations
+            });
+            
+            // set the identifier and label of the canvas based on the identifier and label of the first choice
+            baseManifest.Items[index].Id ??= namedQueryItem.Id;
+            baseManifest.Items[index].Label ??= namedQueryItem.Label;
+        }
+        else
+        {
+            // otherwise, just use the already created choice order
+           baseManifestPaintingAnnotations = baseManifest.Items![index].Items!;
+        }
+        
+        // grab the painting annotations from both items
+        var paintingAnnotation = baseManifestPaintingAnnotations[0].Items?[0] as PaintingAnnotation;
+        var namedQueryAnnotation = namedQueryAnnotationPage?.Items?[0] as PaintingAnnotation;
+        
+        // convert the namedQuery manifest image into a painting choice on the base manifest
+        var baseImage = paintingAnnotation!.Body as PaintingChoice;
+        // use the labels from the first choice as the annotation
+        paintingAnnotation.Id ??= namedQueryAnnotation?.Id;
+        paintingAnnotation.Label ??= namedQueryAnnotation?.Label;
+       // paintingAnnotation.Target ??= baseManifest.Items[index];
+        var namedQueryImage = (Image)namedQueryAnnotation?.Body;
+        
+        // if no defaults are set for the base image, set them (this happens on the first choice order)
+        if (baseImage == null)
+        {
+            baseImage = new PaintingChoice
+            {
+                Items = []
+            };
+        }
+        
+        // add the new image to the base image choice, then update the manifest with the changes
+        baseImage.Items!.Add(namedQueryImage);
+        baseImage.Service ??= namedQueryAnnotation?.Service;
+        paintingAnnotation.Body = baseImage;
+        baseManifest.Items![index].Items![0].Items![0] = paintingAnnotation;
+    }
+
+    private static List<AnnotationPage> CreateEmptyPaintingAnnotations(AnnotationPage? paintingAnnotation)
+    {
+        List<AnnotationPage> baseManifestPaintingAnnotations;
+        baseManifestPaintingAnnotations =
+        [
+            new AnnotationPage
+            {
+                Id = paintingAnnotation?.Id,
+                Label = paintingAnnotation?.Label,
+                Items = [new PaintingAnnotation()]
+            }
+        ];
+        return baseManifestPaintingAnnotations;
+    }
+
+    private static void AddOrUpdateIndividualCanvas(Manifest baseManifest, (Canvas? item, int index) existingItem,
+        Canvas namedQueryItem)
+    {
+        if (existingItem.item != null)
+        {
+            baseManifest.Items![existingItem.index] = namedQueryItem;
+        }
+        else
+        {
+            baseManifest.Items!.Add(namedQueryItem);
+        }
     }
 }

--- a/src/IIIFPresentation/BackgroundHandler/Helpers/ManifestMerger.cs
+++ b/src/IIIFPresentation/BackgroundHandler/Helpers/ManifestMerger.cs
@@ -64,9 +64,9 @@ public static class ManifestMerger
     {
         // grab the body of the selected image and base maniest to update
         var baseManifestPaintingAnnotations = baseManifest.Items![index].Items!;
-        var paintingAnnotation = baseManifestPaintingAnnotations[0].Items?[0] as PaintingAnnotation;
+        var paintingAnnotation = baseManifestPaintingAnnotations.GetFirstPaintingAnnotation();
         var baseImage = paintingAnnotation!.Body as PaintingChoice; 
-        var namedQueryAnnotation = namedQueryItem.Items?[0].Items?[0] as PaintingAnnotation;
+        var namedQueryAnnotation = namedQueryItem.GetFirstPaintingAnnotation();
         var namedQueryImage = (Image)namedQueryAnnotation!.Body!;
         
         var baseImageIndex = baseImage?.Items?.OfType<Image>().ToList()
@@ -82,8 +82,8 @@ public static class ManifestMerger
                 {
                     Items = [new AnnotationPage
                     {
-                        Id = namedQueryItem.Items?[0].Id,
-                        Label = namedQueryItem.Items?[0].Label,
+                        Id = namedQueryItem.GetFirstAnnotationPage()?.Id,
+                        Label = namedQueryItem.GetFirstAnnotationPage()?.Label,
                         Items = []
                     }]
                 }
@@ -119,7 +119,7 @@ public static class ManifestMerger
         Canvas namedQueryItem)
     {
         List<AnnotationPage> baseManifestPaintingAnnotations;
-        var namedQueryAnnotationPage = namedQueryItem.Items?[0];
+        var namedQueryAnnotationPage = namedQueryItem.GetFirstAnnotationPage();
         
         // is this the first item in a new choice order?
         if (baseManifest.Items?.Count == index)
@@ -144,15 +144,15 @@ public static class ManifestMerger
         }
         
         // grab the painting annotations from both items
-        var paintingAnnotation = baseManifestPaintingAnnotations[0].Items?[0] as PaintingAnnotation;
-        var namedQueryAnnotation = namedQueryAnnotationPage?.Items?[0] as PaintingAnnotation;
+        var paintingAnnotation = baseManifestPaintingAnnotations.GetFirstPaintingAnnotation();
+        var namedQueryAnnotation = namedQueryAnnotationPage?.GetFirstPaintingAnnotation();
         
         // convert the namedQuery manifest image into a painting choice on the base manifest
         var baseImage = paintingAnnotation!.Body as PaintingChoice;
         // use the labels from the first choice as the annotation
         paintingAnnotation.Id ??= namedQueryAnnotation?.Id;
         paintingAnnotation.Label ??= namedQueryAnnotation?.Label;
-       // paintingAnnotation.Target ??= baseManifest.Items[index];
+        paintingAnnotation.Target ??= baseManifest.Items[index];
         var namedQueryImage = (Image)namedQueryAnnotation?.Body;
         
         // if no defaults are set for the base image, set them (this happens on the first choice order)

--- a/src/IIIFPresentation/BackgroundHandler/Helpers/ManifestMerger.cs
+++ b/src/IIIFPresentation/BackgroundHandler/Helpers/ManifestMerger.cs
@@ -137,8 +137,8 @@ public static class ManifestMerger
             baseManifest.Items.Add(new Canvas
             {
                 Items = baseManifestPaintingAnnotations,
-                Height = namedQueryImage?.Height,
-                Width = namedQueryImage?.Width,
+                Height = namedQueryItem.Height,
+                Width = namedQueryItem.Width,
             });
             
             // set the identifier and label of the canvas based on the identifier and label of the first choice

--- a/src/IIIFPresentation/BackgroundHandler/Helpers/ManifestX.cs
+++ b/src/IIIFPresentation/BackgroundHandler/Helpers/ManifestX.cs
@@ -24,4 +24,9 @@ public static class ManifestX
     {
         return canvas.Items?[0];
     }
+    
+    public static AnnotationPage GetCurrentCanvasAnnotation(this Manifest manifest, int index)
+    {
+        return manifest.Items![index].Items![0];
+    }
 }

--- a/src/IIIFPresentation/BackgroundHandler/Helpers/ManifestX.cs
+++ b/src/IIIFPresentation/BackgroundHandler/Helpers/ManifestX.cs
@@ -25,7 +25,7 @@ public static class ManifestX
         return canvas.Items?[0];
     }
     
-    public static AnnotationPage GetCurrentCanvasAnnotation(this Manifest manifest, int index)
+    public static AnnotationPage GetCurrentCanvasAnnotationPage(this Manifest manifest, int index)
     {
         return manifest.Items![index].Items![0];
     }

--- a/src/IIIFPresentation/BackgroundHandler/Helpers/ManifestX.cs
+++ b/src/IIIFPresentation/BackgroundHandler/Helpers/ManifestX.cs
@@ -1,0 +1,27 @@
+﻿using IIIF.Presentation.V3;
+using IIIF.Presentation.V3.Annotation;
+
+namespace BackgroundHandler.Helpers;
+
+public static class ManifestX
+{
+    public static PaintingAnnotation? GetFirstPaintingAnnotation(this Canvas canvas)
+    {
+        return canvas.Items?[0].Items?[0] as PaintingAnnotation;
+    }
+    
+    public static PaintingAnnotation? GetFirstPaintingAnnotation(this List<AnnotationPage> annotationPages)
+    {
+        return annotationPages[0].Items?[0] as PaintingAnnotation;
+    }
+    
+    public static PaintingAnnotation? GetFirstPaintingAnnotation(this AnnotationPage annotationPages)
+    {
+        return annotationPages.Items?[0] as PaintingAnnotation;
+    }
+    
+    public static AnnotationPage? GetFirstAnnotationPage(this Canvas canvas)
+    {
+        return canvas.Items?[0];
+    }
+}

--- a/src/IIIFPresentation/BackgroundHandler/Settings/BackgroundHandlerSettings.cs
+++ b/src/IIIFPresentation/BackgroundHandler/Settings/BackgroundHandlerSettings.cs
@@ -5,4 +5,6 @@ namespace BackgroundHandler.Settings;
 public class BackgroundHandlerSettings
 {
     public required AWSSettings AWS { get; set; }
+    
+    public string PresentationApiUrl { get; set; } = string.Empty;
 }

--- a/src/IIIFPresentation/Models/API/Manifest/PresentationManifest.cs
+++ b/src/IIIFPresentation/Models/API/Manifest/PresentationManifest.cs
@@ -46,7 +46,7 @@ public class CanvasPainting
 {
     public required string CanvasId { get; set; }
     public string? CanvasOriginalId { get; set; }
-    public int CanvasOrder { get; set; }
+    public int? CanvasOrder { get; set; }
     public int? ChoiceOrder { get; set; }
     public string? Thumbnail { get; set; }
     public LanguageMap? Label { get; set; }

--- a/src/IIIFPresentation/Models/Models.csproj
+++ b/src/IIIFPresentation/Models/Models.csproj
@@ -15,5 +15,9 @@
     <ItemGroup>
       <None Remove="Properties\launchSettings.json" />
     </ItemGroup>
+
+    <ItemGroup>
+      <Folder Include="Helpers\" />
+    </ItemGroup>
     
 </Project>


### PR DESCRIPTION
Resolves #204

This PR essentially enables manifests with choiceOrder to be created

It has 2 parts:

- Updates to the API to reject invalid `canvasOrder` and `choiceOrder` combinations
  - If there are duplicate `canvasOrder` values these must all have a `choiceOrder` value and each `choiceOrder` must be unique.
  - If any `paintedResource` has a `canvas_order` then _all_ items must have a canvas_order.
  - allowing canvasOrder to be set directly on a `canvasPainting`, rather than inferred by the order of the assets
- Updates to the background handler to be able to handle valid `canvasOrder` and `choiceOrder` combinations
  - labels translated from canvas painting to item in `choiceOrder` - choosing the label of the first item as overall labels
  - using the size of the first asset as the size of the canvas
  - sets the thumbnail of a manifest based on the first asset in a `choice`, if it's the first item in a `canvasOrder`
  - sets the canvas label based on the `canvasPainting` `canvasLabel` value, with fallback to the `label` value
  - sets the choice label based on the `canvasPainting` `label` value

The response for a choice order has been tested as working through the IIIF presentation validator, Project Theseus and Universal Viewer

`choiceOrder` example:

<details>
manifest request:

```json
{
    "type": "Manifest",
    "behavior": [
        "public-iiif"
    ],
    "label": {
        "en": [
            "post testing"
        ]
    },
    "slug": "trial-multiple-asset-8",
    "parent": "root",
    "paintedResources": [
        {
            "canvasPainting":{
                "canvasOrder": 1,
                "choiceOrder": 1
            },
            "asset": {
                "id": "testAssetByPresentation-multiple-1",
                "mediaType": "image/jpg",
                "space": 1,
                "origin": "https://dlcsstage-public-test-objects.s3.eu-west-1.amazonaws.com/nasa-images/610213main_S73-22871_full.jpg",
                "deliveryChannels": [
                    {
                        "channel": "iiif-img",
                        "policy": "default"
                    },
                    {
                        "channel": "thumbs",
                        "policy": "default"
                    }
                ]
            }
        },
        {
            "canvasPainting":{
                "canvasOrder": 1,
                "choiceOrder": 2
            },
            "asset": {
                "id": "testAssetByPresentation-multiple-2",
                "mediaType": "image/jpg",
                "space": 1,
                "origin": "https://dlcsstage-public-test-objects.s3.eu-west-1.amazonaws.com/nasa-images/610213main_S73-22871_full.jpg",
                "deliveryChannels": [
                    {
                        "channel": "iiif-img",
                        "policy": "default"
                    },
                    {
                        "channel": "thumbs",
                        "policy": "default"
                    }
                ]
            }
        }
    ] 
}
```

DLCS batch response:

```json
{
  "@context": "http://iiif.io/api/presentation/3/context.json",
  "id": "https://dlcs.digirati.io/iiif-resource/v3/26/batch-query/573012",
  "type": "Manifest",
  "label": {
    "en": [
      "Generated from 'batch-query' named query"
    ]
  },
  "thumbnail": [
    {
      "id": "https://dlcs.digirati.io/thumbs/26/1/testAssetByPresentation-multiple-1/full/200,115/0/default.jpg",
      "type": "Image",
      "format": "image/jpeg",
      "service": [
        {
          "@context": "http://iiif.io/api/image/2/context.json",
          "@id": "https://dlcs.digirati.io/thumbs/v2/26/1/testAssetByPresentation-multiple-1",
          "@type": "ImageService2",
          "profile": "http://iiif.io/api/image/2/level0.json",
          "sizes": [
            {
              "width": 1024,
              "height": 589
            },
            {
              "width": 400,
              "height": 230
            },
            {
              "width": 200,
              "height": 115
            },
            {
              "width": 100,
              "height": 57
            }
          ]
        },
        {
          "@context": "http://iiif.io/api/image/3/context.json",
          "id": "https://dlcs.digirati.io/thumbs/26/1/testAssetByPresentation-multiple-1",
          "type": "ImageService3",
          "profile": "level0",
          "sizes": [
            {
              "width": 1024,
              "height": 589
            },
            {
              "width": 400,
              "height": 230
            },
            {
              "width": 200,
              "height": 115
            },
            {
              "width": 100,
              "height": 57
            }
          ]
        }
      ]
    }
  ],
  "metadata": [
    {
      "label": {
        "en": [
          "Title"
        ]
      },
      "value": {
        "en": [
          "Created by DLCS"
        ]
      }
    },
    {
      "label": {
        "en": [
          "Generated On"
        ]
      },
      "value": {
        "en": [
          "2025-01-23 17:19:16Z"
        ]
      }
    }
  ],
  "items": [
    {
      "id": "https://dlcs.digirati.io/iiif-img/26/1/testAssetByPresentation-multiple-1/canvas/c/1",
      "type": "Canvas",
      "label": {
        "en": [
          "Canvas 1"
        ]
      },
      "width": 6932,
      "height": 3982,
      "thumbnail": [
        {
          "id": "https://dlcs.digirati.io/thumbs/26/1/testAssetByPresentation-multiple-1/full/200,115/0/default.jpg",
          "type": "Image",
          "format": "image/jpeg",
          "service": [
            {
              "@context": "http://iiif.io/api/image/2/context.json",
              "@id": "https://dlcs.digirati.io/thumbs/v2/26/1/testAssetByPresentation-multiple-1",
              "@type": "ImageService2",
              "profile": "http://iiif.io/api/image/2/level0.json",
              "sizes": [
                {
                  "width": 1024,
                  "height": 589
                },
                {
                  "width": 400,
                  "height": 230
                },
                {
                  "width": 200,
                  "height": 115
                },
                {
                  "width": 100,
                  "height": 57
                }
              ]
            },
            {
              "@context": "http://iiif.io/api/image/3/context.json",
              "id": "https://dlcs.digirati.io/thumbs/26/1/testAssetByPresentation-multiple-1",
              "type": "ImageService3",
              "profile": "level0",
              "sizes": [
                {
                  "width": 1024,
                  "height": 589
                },
                {
                  "width": 400,
                  "height": 230
                },
                {
                  "width": 200,
                  "height": 115
                },
                {
                  "width": 100,
                  "height": 57
                }
              ]
            }
          ]
        }
      ],
      "items": [
        {
          "id": "https://dlcs.digirati.io/iiif-img/26/1/testAssetByPresentation-multiple-1/canvas/c/1/page",
          "type": "AnnotationPage",
          "items": [
            {
              "id": "https://dlcs.digirati.io/iiif-img/26/1/testAssetByPresentation-multiple-1/canvas/c/1/page/image",
              "type": "Annotation",
              "motivation": "painting",
              "body": {
                "id": "https://dlcs.digirati.io/iiif-img/26/1/testAssetByPresentation-multiple-1/full/1024,589/0/default.jpg",
                "type": "Image",
                "width": 1024,
                "height": 589,
                "format": "image/jpeg",
                "service": [
                  {
                    "@context": "http://iiif.io/api/image/2/context.json",
                    "@id": "https://dlcs.digirati.io/iiif-img/v2/26/1/testAssetByPresentation-multiple-1",
                    "@type": "ImageService2",
                    "profile": "http://iiif.io/api/image/2/level2.json",
                    "width": 6932,
                    "height": 3982
                  },
                  {
                    "@context": "http://iiif.io/api/image/3/context.json",
                    "id": "https://dlcs.digirati.io/iiif-img/26/1/testAssetByPresentation-multiple-1",
                    "type": "ImageService3",
                    "profile": "level2",
                    "width": 6932,
                    "height": 3982
                  }
                ]
              },
              "target": "https://dlcs.digirati.io/iiif-img/26/1/testAssetByPresentation-multiple-1/canvas/c/1"
            }
          ]
        }
      ]
    },
    {
      "id": "https://dlcs.digirati.io/iiif-img/26/1/testAssetByPresentation-multiple-2/canvas/c/2",
      "type": "Canvas",
      "label": {
        "en": [
          "Canvas 2"
        ]
      },
      "width": 6932,
      "height": 3982,
      "thumbnail": [
        {
          "id": "https://dlcs.digirati.io/thumbs/26/1/testAssetByPresentation-multiple-2/full/200,115/0/default.jpg",
          "type": "Image",
          "format": "image/jpeg",
          "service": [
            {
              "@context": "http://iiif.io/api/image/2/context.json",
              "@id": "https://dlcs.digirati.io/thumbs/v2/26/1/testAssetByPresentation-multiple-2",
              "@type": "ImageService2",
              "profile": "http://iiif.io/api/image/2/level0.json",
              "sizes": [
                {
                  "width": 1024,
                  "height": 589
                },
                {
                  "width": 400,
                  "height": 230
                },
                {
                  "width": 200,
                  "height": 115
                },
                {
                  "width": 100,
                  "height": 57
                }
              ]
            },
            {
              "@context": "http://iiif.io/api/image/3/context.json",
              "id": "https://dlcs.digirati.io/thumbs/26/1/testAssetByPresentation-multiple-2",
              "type": "ImageService3",
              "profile": "level0",
              "sizes": [
                {
                  "width": 1024,
                  "height": 589
                },
                {
                  "width": 400,
                  "height": 230
                },
                {
                  "width": 200,
                  "height": 115
                },
                {
                  "width": 100,
                  "height": 57
                }
              ]
            }
          ]
        }
      ],
      "items": [
        {
          "id": "https://dlcs.digirati.io/iiif-img/26/1/testAssetByPresentation-multiple-2/canvas/c/2/page",
          "type": "AnnotationPage",
          "items": [
            {
              "id": "https://dlcs.digirati.io/iiif-img/26/1/testAssetByPresentation-multiple-2/canvas/c/2/page/image",
              "type": "Annotation",
              "motivation": "painting",
              "body": {
                "id": "https://dlcs.digirati.io/iiif-img/26/1/testAssetByPresentation-multiple-2/full/1024,589/0/default.jpg",
                "type": "Image",
                "width": 1024,
                "height": 589,
                "format": "image/jpeg",
                "service": [
                  {
                    "@context": "http://iiif.io/api/image/2/context.json",
                    "@id": "https://dlcs.digirati.io/iiif-img/v2/26/1/testAssetByPresentation-multiple-2",
                    "@type": "ImageService2",
                    "profile": "http://iiif.io/api/image/2/level2.json",
                    "width": 6932,
                    "height": 3982
                  },
                  {
                    "@context": "http://iiif.io/api/image/3/context.json",
                    "id": "https://dlcs.digirati.io/iiif-img/26/1/testAssetByPresentation-multiple-2",
                    "type": "ImageService3",
                    "profile": "level2",
                    "width": 6932,
                    "height": 3982
                  }
                ]
              },
              "target": "https://dlcs.digirati.io/iiif-img/26/1/testAssetByPresentation-multiple-2/canvas/c/2"
            }
          ]
        }
      ]
    }
  ]
}
```

generated IIIF manifest:

```json
{
  "@context": "http://iiif.io/api/presentation/3/context.json",
  "id": "https://localhost:7230/26/trial-multiple-asset-8",
  "type": "Manifest",
  "label": {
    "en": [
      "post testing"
    ]
  },
  "thumbnail": [
    {
      "id": "https://dlcs.digirati.io/thumbs/26/1/testAssetByPresentation-multiple-1/full/200,115/0/default.jpg",
      "type": "Image",
      "format": "image/jpeg",
      "service": [
        {
          "@context": "http://iiif.io/api/image/2/context.json",
          "@id": "https://dlcs.digirati.io/thumbs/v2/26/1/testAssetByPresentation-multiple-1",
          "@type": "ImageService2",
          "profile": "http://iiif.io/api/image/2/level0.json",
          "sizes": [
            {
              "width": 1024,
              "height": 589
            },
            {
              "width": 400,
              "height": 230
            },
            {
              "width": 200,
              "height": 115
            },
            {
              "width": 100,
              "height": 57
            }
          ]
        },
        {
          "@context": "http://iiif.io/api/image/3/context.json",
          "id": "https://dlcs.digirati.io/thumbs/26/1/testAssetByPresentation-multiple-1",
          "type": "ImageService3",
          "profile": "level0",
          "sizes": [
            {
              "width": 1024,
              "height": 589
            },
            {
              "width": 400,
              "height": 230
            },
            {
              "width": 200,
              "height": 115
            },
            {
              "width": 100,
              "height": 57
            }
          ]
        }
      ]
    }
  ],
  "items": [
    {
      "id": "https://dlcs.digirati.io/iiif-img/26/1/testAssetByPresentation-multiple-1/canvas/c/1",
      "type": "Canvas",
      "label": {
        "en": [
          "Canvas 1"
        ]
      },
      "width": 1024,
      "height": 589,
      "items": [
        {
          "id": "https://dlcs.digirati.io/iiif-img/26/1/testAssetByPresentation-multiple-1/canvas/c/1/page",
          "type": "AnnotationPage",
          "items": [
            {
              "id": "https://dlcs.digirati.io/iiif-img/26/1/testAssetByPresentation-multiple-1/canvas/c/1/page/image",
              "type": "Annotation",
              "motivation": "painting",
              "body": {
                "type": "Choice",
                "items": [
                  {
                    "id": "https://dlcs.digirati.io/iiif-img/26/1/testAssetByPresentation-multiple-1/full/1024,589/0/default.jpg",
                    "type": "Image",
                    "width": 1024,
                    "height": 589,
                    "format": "image/jpeg",
                    "service": [
                      {
                        "@context": "http://iiif.io/api/image/2/context.json",
                        "@id": "https://dlcs.digirati.io/iiif-img/v2/26/1/testAssetByPresentation-multiple-1",
                        "@type": "ImageService2",
                        "profile": "http://iiif.io/api/image/2/level2.json",
                        "width": 6932,
                        "height": 3982
                      },
                      {
                        "@context": "http://iiif.io/api/image/3/context.json",
                        "id": "https://dlcs.digirati.io/iiif-img/26/1/testAssetByPresentation-multiple-1",
                        "type": "ImageService3",
                        "profile": "level2",
                        "width": 6932,
                        "height": 3982
                      }
                    ]
                  },
                  {
                    "id": "https://dlcs.digirati.io/iiif-img/26/1/testAssetByPresentation-multiple-2/full/1024,589/0/default.jpg",
                    "type": "Image",
                    "width": 1024,
                    "height": 589,
                    "format": "image/jpeg",
                    "service": [
                      {
                        "@context": "http://iiif.io/api/image/2/context.json",
                        "@id": "https://dlcs.digirati.io/iiif-img/v2/26/1/testAssetByPresentation-multiple-2",
                        "@type": "ImageService2",
                        "profile": "http://iiif.io/api/image/2/level2.json",
                        "width": 6932,
                        "height": 3982
                      },
                      {
                        "@context": "http://iiif.io/api/image/3/context.json",
                        "id": "https://dlcs.digirati.io/iiif-img/26/1/testAssetByPresentation-multiple-2",
                        "type": "ImageService3",
                        "profile": "level2",
                        "width": 6932,
                        "height": 3982
                      }
                    ]
                  }
                ]
              },
              "target": "https://dlcs.digirati.io/iiif-img/26/1/testAssetByPresentation-multiple-1/canvas/c/1"
            }
          ]
        }
      ]
    }
  ]
}
```

</details>