### PR TITLE
Include count of child items for storage-collection

### DIFF
--- a/src/IIIFPresentation/API.Tests/Converters/CollectionConverterTests.cs
+++ b/src/IIIFPresentation/API.Tests/Converters/CollectionConverterTests.cs
@@ -97,29 +97,29 @@ public class CollectionConverterTests
         var expectedCounts = new DescendantCounts(1, 0, 0);
 
         // Act
-        var flatCollection =
+        var presentationCollection =
             collection.ToPresentationCollection(PageSize, 1, 1, CreateTestItems(), null, pathGenerator);
 
         // Assert
-        flatCollection.Id.Should().Be("http://base/1/collections/some-id");
-        flatCollection.FlatId.Should().Be("some-id");
-        flatCollection.PublicId.Should().Be("http://base/1");
-        flatCollection.Label!.Count.Should().Be(1);
-        flatCollection.Label["en"].Should().Contain("repository root");
-        flatCollection.Slug.Should().Be("root");
-        flatCollection.SeeAlso.Should().HaveCount(2);
-        flatCollection.SeeAlso![0].Id.Should().Be("http://base/1");
-        flatCollection.SeeAlso![0].Profile.Should().Contain("Public");
-        flatCollection.SeeAlso![1].Id.Should().Be("http://base/1/iiif");
-        flatCollection.SeeAlso[1].Profile.Should().Contain("api-hierarchical");
-        flatCollection.Created.Should().Be(DateTime.MinValue);
-        flatCollection.Parent.Should().BeNull();
-        flatCollection.Items!.Count.Should().Be(1);
-        flatCollection.View!.Id.Should().Be("http://base/1/collections/some-id?page=1&pageSize=100");
-        flatCollection.View.Next.Should().BeNull();
-        flatCollection.View.Last.Should().BeNull();
-        flatCollection.PartOf.Should().BeNull("No parent provided");
-        flatCollection.Totals.Should().BeEquivalentTo(expectedCounts);
+        presentationCollection.Id.Should().Be("http://base/1/collections/some-id");
+        presentationCollection.FlatId.Should().Be("some-id");
+        presentationCollection.PublicId.Should().Be("http://base/1");
+        presentationCollection.Label!.Count.Should().Be(1);
+        presentationCollection.Label["en"].Should().Contain("repository root");
+        presentationCollection.Slug.Should().Be("root");
+        presentationCollection.SeeAlso.Should().HaveCount(2);
+        presentationCollection.SeeAlso![0].Id.Should().Be("http://base/1");
+        presentationCollection.SeeAlso![0].Profile.Should().Contain("Public");
+        presentationCollection.SeeAlso![1].Id.Should().Be("http://base/1/iiif");
+        presentationCollection.SeeAlso[1].Profile.Should().Contain("api-hierarchical");
+        presentationCollection.Created.Should().Be(DateTime.MinValue);
+        presentationCollection.Parent.Should().BeNull();
+        presentationCollection.Items!.Count.Should().Be(1);
+        presentationCollection.View!.Id.Should().Be("http://base/1/collections/some-id?page=1&pageSize=100");
+        presentationCollection.View.Next.Should().BeNull();
+        presentationCollection.View.Last.Should().BeNull();
+        presentationCollection.PartOf.Should().BeNull("No parent provided");
+        presentationCollection.Totals.Should().BeEquivalentTo(expectedCounts);
     }
     
     [Fact]
@@ -130,31 +130,31 @@ public class CollectionConverterTests
         var expectedCounts = new DescendantCounts(1, 0, 0);
 
         // Act
-        var flatCollection =
+        var presentationCollection =
             storageRoot.ToPresentationCollection(PageSize, 1, 0, CreateTestItems(), null, pathGenerator);
 
         // Assert
-        flatCollection.Id.Should().Be("http://base/1/collections/some-id");
-        flatCollection.FlatId.Should().Be("some-id");
-        flatCollection.PublicId.Should().Be("http://base/1/top/some-id");
-        flatCollection.Label!.Count.Should().Be(1);
-        flatCollection.Label["en"].Should().Contain("repository root");
-        flatCollection.Slug.Should().Be("root");
-        flatCollection.SeeAlso.Should().HaveCount(2);
-        flatCollection.SeeAlso![0].Id.Should().Be("http://base/1/top/some-id");
-        flatCollection.SeeAlso![0].Profile.Should().Contain("Public");
-        flatCollection.SeeAlso![1].Id.Should().Be("http://base/1/top/some-id/iiif");
-        flatCollection.SeeAlso[1].Profile.Should().Contain("api-hierarchical");
-        flatCollection.Created.Should().Be(DateTime.MinValue);
-        flatCollection.Parent.Should().Be("http://base/1/collections/top");
-        flatCollection.Items!.Count.Should().Be(1);
-        flatCollection.View!.Id.Should().Be("http://base/1/collections/some-id?page=1&pageSize=100");
-        flatCollection.View.Next.Should().BeNull();
-        flatCollection.View.Last.Should().BeNull();
-        flatCollection.View.First.Should().BeNull();
-        flatCollection.View.Next.Should().BeNull();
-        flatCollection.PartOf.Should().BeNull("No parent provided");
-        flatCollection.Totals.Should().BeEquivalentTo(expectedCounts);
+        presentationCollection.Id.Should().Be("http://base/1/collections/some-id");
+        presentationCollection.FlatId.Should().Be("some-id");
+        presentationCollection.PublicId.Should().Be("http://base/1/top/some-id");
+        presentationCollection.Label!.Count.Should().Be(1);
+        presentationCollection.Label["en"].Should().Contain("repository root");
+        presentationCollection.Slug.Should().Be("root");
+        presentationCollection.SeeAlso.Should().HaveCount(2);
+        presentationCollection.SeeAlso![0].Id.Should().Be("http://base/1/top/some-id");
+        presentationCollection.SeeAlso![0].Profile.Should().Contain("Public");
+        presentationCollection.SeeAlso![1].Id.Should().Be("http://base/1/top/some-id/iiif");
+        presentationCollection.SeeAlso[1].Profile.Should().Contain("api-hierarchical");
+        presentationCollection.Created.Should().Be(DateTime.MinValue);
+        presentationCollection.Parent.Should().Be("http://base/1/collections/top");
+        presentationCollection.Items!.Count.Should().Be(1);
+        presentationCollection.View!.Id.Should().Be("http://base/1/collections/some-id?page=1&pageSize=100");
+        presentationCollection.View.Next.Should().BeNull();
+        presentationCollection.View.Last.Should().BeNull();
+        presentationCollection.View.First.Should().BeNull();
+        presentationCollection.View.Next.Should().BeNull();
+        presentationCollection.PartOf.Should().BeNull("No parent provided");
+        presentationCollection.Totals.Should().BeEquivalentTo(expectedCounts);
     }
 
     [Fact]
@@ -165,32 +165,32 @@ public class CollectionConverterTests
         var expectedCounts = new DescendantCounts(1, 0, 0);
 
         // Act
-        var flatCollection =
+        var presentationCollection =
             storageRoot.ToPresentationCollection(1, 2, 3, CreateTestItems(), null, pathGenerator, "orderBy=created");
 
         // Assert
-        flatCollection.Id.Should().Be("http://base/1/collections/some-id");
-        flatCollection.FlatId.Should().Be("some-id");
-        flatCollection.PublicId.Should().Be("http://base/1/top/some-id");
-        flatCollection.Label!.Count.Should().Be(1);
-        flatCollection.Label["en"].Should().Contain("repository root");
-        flatCollection.Slug.Should().Be("root");
-        flatCollection.SeeAlso.Should().HaveCount(2);
-        flatCollection.SeeAlso![0].Profile.Should().Contain("Public");
-        flatCollection.SeeAlso[1].Profile.Should().Contain("api-hierarchical");
-        flatCollection.Created.Should().Be(DateTime.MinValue);
-        flatCollection.Parent.Should().Be("http://base/1/collections/top");
-        flatCollection.Items!.Count.Should().Be(1);
-        flatCollection.View!.TotalPages.Should().Be(3);
-        flatCollection.View.PageSize.Should().Be(1);
-        flatCollection.View.Id.Should().Be("http://base/1/collections/some-id?page=2&pageSize=1&orderBy=created");
-        flatCollection.View.Next.Should().Be("http://base/1/collections/some-id?page=3&pageSize=1&orderBy=created");
-        flatCollection.View.Previous.Should().Be("http://base/1/collections/some-id?page=1&pageSize=1&orderBy=created");
-        flatCollection.View.First.Should().Be("http://base/1/collections/some-id?page=1&pageSize=1&orderBy=created");
-        flatCollection.View.Last.Should().Be("http://base/1/collections/some-id?page=3&pageSize=1&orderBy=created");
-        flatCollection.TotalItems.Should().Be(3);
-        flatCollection.PartOf.Should().BeNull("No parent provided");
-        flatCollection.Totals.Should().BeEquivalentTo(expectedCounts);
+        presentationCollection.Id.Should().Be("http://base/1/collections/some-id");
+        presentationCollection.FlatId.Should().Be("some-id");
+        presentationCollection.PublicId.Should().Be("http://base/1/top/some-id");
+        presentationCollection.Label!.Count.Should().Be(1);
+        presentationCollection.Label["en"].Should().Contain("repository root");
+        presentationCollection.Slug.Should().Be("root");
+        presentationCollection.SeeAlso.Should().HaveCount(2);
+        presentationCollection.SeeAlso![0].Profile.Should().Contain("Public");
+        presentationCollection.SeeAlso[1].Profile.Should().Contain("api-hierarchical");
+        presentationCollection.Created.Should().Be(DateTime.MinValue);
+        presentationCollection.Parent.Should().Be("http://base/1/collections/top");
+        presentationCollection.Items!.Count.Should().Be(1);
+        presentationCollection.View!.TotalPages.Should().Be(3);
+        presentationCollection.View.PageSize.Should().Be(1);
+        presentationCollection.View.Id.Should().Be("http://base/1/collections/some-id?page=2&pageSize=1&orderBy=created");
+        presentationCollection.View.Next.Should().Be("http://base/1/collections/some-id?page=3&pageSize=1&orderBy=created");
+        presentationCollection.View.Previous.Should().Be("http://base/1/collections/some-id?page=1&pageSize=1&orderBy=created");
+        presentationCollection.View.First.Should().Be("http://base/1/collections/some-id?page=1&pageSize=1&orderBy=created");
+        presentationCollection.View.Last.Should().Be("http://base/1/collections/some-id?page=3&pageSize=1&orderBy=created");
+        presentationCollection.TotalItems.Should().Be(3);
+        presentationCollection.PartOf.Should().BeNull("No parent provided");
+        presentationCollection.Totals.Should().BeEquivalentTo(expectedCounts);
     }
     
     [Fact]
@@ -202,34 +202,34 @@ public class CollectionConverterTests
         var expectedCounts = new DescendantCounts(1, 0, 0);
 
         // Act
-        var flatCollection =
+        var presentationCollection =
             storageRoot.ToPresentationCollection(PageSize, 1, 0, CreateTestItems(), parentCollection, pathGenerator);
 
         // Assert
-        flatCollection.Id.Should().Be("http://base/1/collections/some-id");
-        flatCollection.FlatId.Should().Be("some-id");
-        flatCollection.PublicId.Should().Be("http://base/1/top/some-id");
-        flatCollection.Label!.Count.Should().Be(1);
-        flatCollection.Label["en"].Should().Contain("repository root");
-        flatCollection.Slug.Should().Be("root");
-        flatCollection.SeeAlso.Should().HaveCount(2);
-        flatCollection.SeeAlso![0].Id.Should().Be("http://base/1/top/some-id");
-        flatCollection.SeeAlso![0].Profile.Should().Contain("Public");
-        flatCollection.SeeAlso![1].Id.Should().Be("http://base/1/top/some-id/iiif");
-        flatCollection.SeeAlso[1].Profile.Should().Contain("api-hierarchical");
-        flatCollection.Created.Should().Be(DateTime.MinValue);
-        flatCollection.Parent.Should().Be("http://base/1/collections/top");
-        flatCollection.Items!.Count.Should().Be(1);
-        flatCollection.View!.Id.Should().Be("http://base/1/collections/some-id?page=1&pageSize=100");
-        flatCollection.View.Next.Should().BeNull();
-        flatCollection.View.Last.Should().BeNull();
-        flatCollection.View.First.Should().BeNull();
-        flatCollection.View.Next.Should().BeNull();
-        var partOf = flatCollection.PartOf.Single();
+        presentationCollection.Id.Should().Be("http://base/1/collections/some-id");
+        presentationCollection.FlatId.Should().Be("some-id");
+        presentationCollection.PublicId.Should().Be("http://base/1/top/some-id");
+        presentationCollection.Label!.Count.Should().Be(1);
+        presentationCollection.Label["en"].Should().Contain("repository root");
+        presentationCollection.Slug.Should().Be("root");
+        presentationCollection.SeeAlso.Should().HaveCount(2);
+        presentationCollection.SeeAlso![0].Id.Should().Be("http://base/1/top/some-id");
+        presentationCollection.SeeAlso![0].Profile.Should().Contain("Public");
+        presentationCollection.SeeAlso![1].Id.Should().Be("http://base/1/top/some-id/iiif");
+        presentationCollection.SeeAlso[1].Profile.Should().Contain("api-hierarchical");
+        presentationCollection.Created.Should().Be(DateTime.MinValue);
+        presentationCollection.Parent.Should().Be("http://base/1/collections/top");
+        presentationCollection.Items!.Count.Should().Be(1);
+        presentationCollection.View!.Id.Should().Be("http://base/1/collections/some-id?page=1&pageSize=100");
+        presentationCollection.View.Next.Should().BeNull();
+        presentationCollection.View.Last.Should().BeNull();
+        presentationCollection.View.First.Should().BeNull();
+        presentationCollection.View.Next.Should().BeNull();
+        var partOf = presentationCollection.PartOf.Single();
         partOf.Id.Should().Be("http://base/0/collections/theparent");
         partOf.Label.Should().BeEquivalentTo(parentCollection.Label);
         
-        flatCollection.Totals.Should().BeEquivalentTo(expectedCounts);
+        presentationCollection.Totals.Should().BeEquivalentTo(expectedCounts);
     }
     
     [Theory]
@@ -257,11 +257,11 @@ public class CollectionConverterTests
         };
 
         // Act
-        var flatCollection =
+        var presentationCollection =
             collection.ToPresentationCollection(PageSize, 1, 1, items, null, pathGenerator);
 
         // Assert
-        flatCollection.Totals.Should().BeEquivalentTo(expectedCounts);
+        presentationCollection.Totals.Should().BeEquivalentTo(expectedCounts);
     }
     
     [Theory]
@@ -289,11 +289,11 @@ public class CollectionConverterTests
         };
 
         // Act
-        var flatCollection =
+        var presentationCollection =
             collection.ToPresentationCollection(PageSize, 1, 1, items, null, pathGenerator);
 
         // Assert
-        flatCollection.Totals.Should().BeNull();
+        presentationCollection.Totals.Should().BeNull();
     }
 
     public static IEnumerable<object[]> ItemsForTotals => new List<object[]>

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyCollectionTests.cs
@@ -127,6 +127,7 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
         responseCollection.View.Id.Should().Contain("?page=1&pageSize=20");
         responseCollection.PartOf.Single().Id.Should().Be("http://localhost/1/collections/root");
         responseCollection.PartOf.Single().Label["en"].Single().Should().Be("repository root");
+        responseCollection.Totals.Should().BeEquivalentTo(DescendantCounts.Empty, "Storage collections have empty counts");
         
         var context = (JArray)responseCollection.Context;
         context.First.Value<string>().Should().Be("http://tbc.org/iiif-repository/1/context.json");
@@ -219,6 +220,7 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
         responseCollection.View.Id.Should().Contain("?page=1&pageSize=20");
         responseCollection.PartOf.Single().Id.Should().Be("http://localhost/1/collections/root");
         responseCollection.PartOf.Single().Label["en"].Single().Should().Be("repository root");
+        responseCollection.Totals.Should().BeNull("IIIF collections have no totals");
         
         var context = (JArray)responseCollection.Context;
         context.First.Value<string>().Should().Be("http://tbc.org/iiif-repository/1/context.json");
@@ -273,6 +275,7 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
         responseCollection!.View!.PageSize.Should().Be(20);
         responseCollection.View.Page.Should().Be(1);
         responseCollection.View.Id.Should().Contain("?page=1&pageSize=20");
+        responseCollection.Totals.Should().BeNull("IIIF collections have no totals");
         
         var context = (JArray)responseCollection.Context;
         context.First.Value<string>().Should().Be("http://tbc.org/iiif-repository/1/context.json");
@@ -328,6 +331,7 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
         responseCollection.View.Id.Should().Contain("?page=1&pageSize=20");
         responseCollection.PartOf.Single().Id.Should().Be("http://localhost/1/collections/root");
         responseCollection.PartOf.Single().Label["en"].Single().Should().Be("repository root");
+        responseCollection.Totals.Should().BeEquivalentTo(DescendantCounts.Empty);
     }
 
     [Fact]
@@ -442,6 +446,7 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
         responseCollection.PartOf.Single().Id.Should().Be("http://localhost/1/collections/root");
         responseCollection.PartOf.Single().Label["en"].Single().Should().Be("repository root");
         fromS3.Should().NotBeNull();
+        responseCollection.Totals.Should().BeNull();
     }
     
     [Fact]
@@ -716,6 +721,7 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
         responseCollection.View.Id.Should().Contain("?page=1&pageSize=20");
         responseCollection.PartOf.Single().Id.Should().Be("http://localhost/1/collections/root");
         responseCollection.PartOf.Single().Label["en"].Single().Should().Be("repository root");
+        responseCollection.Totals.Should().BeNull();
         
         var context = (JArray)responseCollection.Context;
         context.First.Value<string>().Should().Be("http://tbc.org/iiif-repository/1/context.json");
@@ -861,6 +867,7 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
         responseCollection.View.Id.Should().Contain("?page=1&pageSize=20");
         responseCollection.PartOf.Single().Id.Should().Be("http://localhost/1/collections/root");
         responseCollection.PartOf.Single().Label["en"].Single().Should().Be("repository root");
+        responseCollection.Totals.Should().BeEquivalentTo(DescendantCounts.Empty);
         
         var context = (JArray)responseCollection.Context;
         context.First.Value<string>().Should().Be("http://tbc.org/iiif-repository/1/context.json");
@@ -947,6 +954,7 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
         responseCollection.View.Id.Should().Contain("?page=1&pageSize=20");
         responseCollection.PartOf.Single().Id.Should().Be("http://localhost/1/collections/root");
         responseCollection.PartOf.Single().Label["en"].Single().Should().Be("repository root");
+        responseCollection.Totals.Should().BeEquivalentTo(DescendantCounts.Empty);
     }
     
     [Fact]
@@ -1058,6 +1066,7 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
         fromDatabase.Label!.Values.First()[0].Should().Be("test collection - updated"); 
         fromDatabase.Thumbnail.Should().Be("https://iiif.io/api/image/3.0/example/reference/someRef");
         fromDatabase.Hierarchy![0].Slug.Should().Be("iiif-programmatic-child");
+        collection.Totals.Should().BeNull();
         
         var context = (JArray)collection.Context;
         context.First.Value<string>().Should().Be("http://tbc.org/iiif-repository/1/context.json");
@@ -1131,7 +1140,7 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
     public async Task UpdateCollection_FailsToUpdateCollection_WhenMovingStorageCollectionToIIIF()
     {
         var id = nameof(UpdateCollection_FailsToUpdateCollection_WhenMovingStorageCollectionToIIIF);
-        var slug =  nameof(UpdateCollection_FailsToUpdateCollection_WhenMovingStorageCollectionToIIIF);
+        var slug = nameof(UpdateCollection_FailsToUpdateCollection_WhenMovingStorageCollectionToIIIF);
         
         // Arrange
         var initialCollection = new Collection()
@@ -1240,6 +1249,7 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
         responseCollection.View.Id.Should().Contain("?page=1&pageSize=20");
         responseCollection.PartOf.Single().Id.Should().Be("http://localhost/1/collections/root");
         responseCollection.PartOf.Single().Label["en"].Single().Should().Be("repository root");
+        responseCollection.Totals.Should().BeEquivalentTo(DescendantCounts.Empty);
         
         var context = (JArray)responseCollection.Context;
         context.First.Value<string>().Should().Be("http://tbc.org/iiif-repository/1/context.json");
@@ -1345,6 +1355,7 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
         fromDatabase.Label.Should().BeNull();
         fromDatabase.IsPublic.Should().BeTrue();
         fromDatabase.IsStorageCollection.Should().BeTrue();
+        responseCollection.Totals.Should().BeEquivalentTo(DescendantCounts.Empty);
     }
 
     [Fact]
@@ -1646,7 +1657,82 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         error!.ErrorTypeUri.Should().Be("http://localhost/errors/ModifyCollectionType/PossibleCircularReference");
     }
+    
+    [Fact]
+    public async Task UpdateCollection_ReturnsCorrectTitles_IfUpdatingStorageCollectionWithDescendants()
+    {
+        // Arrange
+        var parentIdentifier = nameof(UpdateCollection_ReturnsCorrectTitles_IfUpdatingStorageCollectionWithDescendants);
+        var childIdentifier = $"c{parentIdentifier}";
 
+        var expectedCounts = new DescendantCounts(1, 0, 1);
+        
+        // Create a parent with 2 children: 1 storage + 1 manifest 
+        var parentCollection = await dbContext.Collections.AddTestCollection(parentIdentifier);
+        await dbContext.Collections.AddTestCollection(childIdentifier, parent: parentIdentifier);
+        await dbContext.Manifests.AddTestManifest(childIdentifier, parent: parentIdentifier);
+        await dbContext.SaveChangesAsync();
+
+        // doesn't matter what we update - just that we do
+        var updatedCollection = new PresentationCollection
+        {
+            Behavior = [Behavior.IsPublic, Behavior.IsStorageCollection],
+            Label = new LanguageMap("en", ["updated"]),
+            Slug = parentCollection.Entity.Hierarchy!.Single(h => h.Canonical).Slug,
+            Parent = RootCollection.Id,
+        };
+
+        var updateRequestMessage = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Put,
+            $"1/collections/{parentIdentifier}", updatedCollection.AsJson());
+        SetCorrectEtag(updateRequestMessage, parentCollection.Entity);
+
+        // Act
+        var response = await httpClient.AsCustomer().SendAsync(updateRequestMessage);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var returnedCollection = await response.ReadAsPresentationResponseAsync<PresentationCollection>();
+        returnedCollection.Totals.Should().BeEquivalentTo(expectedCounts);
+        returnedCollection.Items.Should().HaveCount(2);
+    }
+    
+    [Fact]
+    public async Task UpdateCollection_RemovesErroneousBehaviors()
+    {
+        // Arrange
+        var parentIdentifier = nameof(UpdateCollection_RemovesErroneousBehaviors);
+        var childIdentifier = $"c{parentIdentifier}";
+
+        // Create a parent with 2 children: 1 storage + 1 manifest 
+        var parentCollection = await dbContext.Collections.AddTestCollection(parentIdentifier);
+        await dbContext.Collections.AddTestCollection(childIdentifier, parent: parentIdentifier);
+        await dbContext.Manifests.AddTestManifest(childIdentifier, parent: parentIdentifier);
+        await dbContext.SaveChangesAsync();
+
+        // doesn't matter what we update - just that we do
+        var updatedCollection = new PresentationCollection
+        {
+            Behavior = [Behavior.IsPublic, Behavior.IsStorageCollection, "I'm fake and will be removed"],
+            Label = new LanguageMap("en", ["updated"]),
+            Slug = parentCollection.Entity.Hierarchy!.Single(h => h.Canonical).Slug,
+            Parent = RootCollection.Id,
+        };
+
+        var updateRequestMessage = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Put,
+            $"1/collections/{parentIdentifier}", updatedCollection.AsJson());
+        SetCorrectEtag(updateRequestMessage, parentCollection.Entity);
+
+        // Act
+        var response = await httpClient.AsCustomer().SendAsync(updateRequestMessage);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var returnedCollection = await response.ReadAsPresentationResponseAsync<PresentationCollection>();
+        returnedCollection.Behavior.Should()
+            .HaveCount(2)
+            .And.ContainInOrder(Behavior.IsPublic, Behavior.IsStorageCollection);
+    }
+    
     [Fact]
     public async Task UpdateCollection_FailsToUpdateCollection_WhenCalledWithoutNeededHeaders()
     {
@@ -1805,6 +1891,7 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
         responseCollection.View.Id.Should().Contain("?page=1&pageSize=20");
         responseCollection.PartOf.Single().Id.Should().Be("http://localhost/1/collections/root");
         responseCollection.PartOf.Single().Label["en"].Single().Should().Be("repository root");
+        responseCollection.Totals.Should().BeNull();
         
         var context = (JArray)responseCollection.Context;
         context.First.Value<string>().Should().Be("http://tbc.org/iiif-repository/1/context.json");

--- a/src/IIIFPresentation/API/Features/Storage/Helpers/PresentationCollectionX.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Helpers/PresentationCollectionX.cs
@@ -1,65 +1,15 @@
-﻿using API.Converters;
-using API.Helpers;
-using Core.Helpers;
-using Core.IIIF;
+﻿using Core.IIIF;
 using IIIF.Presentation.V3.Content;
 using Models.API.Collection;
-using Models.Database.General;
-using Collection = Models.Database.Collections.Collection;
 
 namespace API.Features.Storage.Helpers;
 
 public static class PresentationCollectionX
 {
     /// <summary>
-    /// Enriches a presentation collection with additional fields from the database
+    /// Gets the thumbnail from a <see cref="PresentationCollection"/>
     /// </summary>
-    /// <param name="presentationCollection">The presentation collection to enrich</param>
-    /// <param name="collection">The collection to use for enrichment</param>
-    /// <param name="pageSize">Size of the page</param>
-    /// <param name="currentPage">The current page of items</param>
-    /// <param name="totalItems">The total number of items</param>
-    /// <param name="items">The list of items that use this collection as a </param>
-    /// <param name="parentCollection">The parent collection current collection is part of</param>
-    /// <param name="pathGenerator">A collection path generator</param>
-    /// <param name="orderQueryParam">Used to describe the type of ordering done</param>
-    /// <returns>An enriched presentation collection</returns>
-    public static PresentationCollection EnrichPresentationCollection(this PresentationCollection presentationCollection, 
-    Collection collection, int pageSize, int currentPage, int totalItems, List<Hierarchy>? items, 
-    Collection parentCollection, IPathGenerator pathGenerator, string? orderQueryParam = null)
-    {
-        var totalPages = CollectionConverter.GenerateTotalPages(pageSize, totalItems);
-
-        var orderQueryParamConverted = string.IsNullOrEmpty(orderQueryParam) ? string.Empty : $"&{orderQueryParam}";
-        var hierarchy = collection.Hierarchy!.Single(h => h.Canonical);
-        
-        presentationCollection.Context = CollectionConverter.GenerateContext();
-        presentationCollection.Behavior ??= CollectionConverter.GenerateBehavior(collection);
-        presentationCollection.Slug ??= hierarchy.Slug;
-        presentationCollection.ItemsOrder ??= hierarchy.ItemsOrder;
-        presentationCollection.Items ??= CollectionConverter.GenerateItems(pathGenerator, items);
-        presentationCollection.TotalItems = totalItems;
-
-        presentationCollection.FlatId = collection.Id;
-        presentationCollection.Id = pathGenerator.GenerateFlatCollectionId(collection);
-        presentationCollection.PublicId = pathGenerator.GenerateHierarchicalCollectionId(collection);
-        presentationCollection.Parent = CollectionConverter.GeneratePresentationCollectionParent(pathGenerator, hierarchy);
-        presentationCollection.PartOf = CollectionConverter.GeneratePartOf(parentCollection, pathGenerator);
-        presentationCollection.View = CollectionConverter.GenerateView(collection, pathGenerator, pageSize, currentPage,
-            totalPages, orderQueryParamConverted);
-        presentationCollection.SeeAlso = CollectionConverter.GenerateSeeAlso(collection, pathGenerator);
-        presentationCollection.Created = collection.Created.Floor(DateTimeX.Precision.Second);
-        presentationCollection.Modified = collection.Modified.Floor(DateTimeX.Precision.Second);
-        presentationCollection.CreatedBy = collection.CreatedBy;
-        presentationCollection.ModifiedBy = collection.ModifiedBy;
-        
-        return presentationCollection;
-    }
-    
-    /// <summary>
-    /// Sets the thumbnail for a presentation collection
-    /// </summary>
-    /// <param name="collection">The collection to set a thumbnail for</param>
+    /// <param name="collection">The collection to get a thumbnail from</param>
     /// <returns>
     /// A response showing whether there were errors in the conversion, and a string of the converted collection
     /// </returns>

--- a/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using API.Converters;
 using API.Features.Storage.Helpers;
 using API.Features.Storage.Models;
 using API.Helpers;

--- a/src/IIIFPresentation/API/Features/Storage/Requests/UpsertCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/UpsertCollection.cs
@@ -1,4 +1,5 @@
-﻿using API.Features.Storage.Helpers;
+﻿using API.Converters;
+using API.Features.Storage.Helpers;
 using API.Features.Storage.Models;
 using API.Helpers;
 using API.Infrastructure.Helpers;

--- a/src/IIIFPresentation/Core.Tests/Helpers/CollectionXTests.cs
+++ b/src/IIIFPresentation/Core.Tests/Helpers/CollectionXTests.cs
@@ -1,5 +1,4 @@
 ﻿using Core.Helpers;
-using FluentAssertions;
 
 namespace Core.Tests.Helpers;
 

--- a/src/IIIFPresentation/Models/API/Collection/DescendantCounts.cs
+++ b/src/IIIFPresentation/Models/API/Collection/DescendantCounts.cs
@@ -1,0 +1,12 @@
+namespace Models.API.Collection;
+
+/// <summary>
+/// Represents counts of descendant properties by type
+/// </summary>
+public record DescendantCounts(int ChildStorageCollections, int ChildIIIFCollections, int ChildManifests)
+{
+    /// <summary>
+    /// Empty <see cref="DescendantCounts"/> object
+    /// </summary>
+    public static readonly DescendantCounts Empty = new(0, 0, 0);
+}

--- a/src/IIIFPresentation/Models/API/Collection/PresentationCollection.cs
+++ b/src/IIIFPresentation/Models/API/Collection/PresentationCollection.cs
@@ -30,6 +30,8 @@ public class PresentationCollection : IIIF.Presentation.V3.Collection, IPresenta
     public string? Tags { get; set; }
     
     public string? PresentationThumbnail { get; set; }
+    
+    public DescendantCounts? Totals { get; set; }
 
     public new object? Thumbnail
     {

--- a/src/IIIFPresentation/Models/Database/Collections/Collection.cs
+++ b/src/IIIFPresentation/Models/Database/Collections/Collection.cs
@@ -19,7 +19,7 @@ public class Collection : IHierarchyResource
     public LanguageMap? Label { get; set; }
 
     /// <summary>
-    /// Not the IIIF JSON, just a single path or URI to 100px, for rapid query results
+    /// Not the IIIF JSON, just a single path or URI, for rapid query results
     /// </summary>
     public string? Thumbnail { get; set; }
 
@@ -54,12 +54,12 @@ public class Collection : IHierarchyResource
     public string? Tags { get; set; }
 
     /// <summary>
-    /// Is proper IIIF collection; will have JSON in S3
+    /// Marks whether this is "folder" IIIF collection; there is no JSON stored - everything DB driven
     /// </summary>
     public bool IsStorageCollection { get; set; }
 
     /// <summary>
-    /// Whether the collection is available at Presentation.io/iiif/
+    /// Whether the collection is publicly available
     /// </summary>
     public bool IsPublic { get; set; }
 


### PR DESCRIPTION
Add `"totals"` property to API Storage Collection results which returns the counts of immediate children by type.

Refactored `ToPresentationCollection` (used for GET) and `EnrichPresentationCollection` (used for POST and PUT) with the former now calling the latter. They both contained almost identical code, the difference being that the latter:
* Didn't set `Label` property. It will now always set `Label`
* Used `??=` for a few properties, meaning that the value returned is what was passed in body of request. However, the value saved to the DB could differ, meaning that a subsequent GET request would return different values. In practice I think the only property this could effect is `Behavior` (which I think isn't quite right as it prevents saving custom behaviors). The decision was to always set the value (so `=` rather than `??=`) to be consistent with GET responses.

Resolves #234 