### PR TITLE
setting status code to Accepted when ingesting

### DIFF
--- a/src/IIIFPresentation/API.Tests/Integration/GetManifestTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/GetManifestTests.cs
@@ -203,10 +203,8 @@ public class GetManifestTests : IClassFixture<PresentationAppFactory<Program>>
     [Fact]
     public async Task Get_IiifManifest_Hierarchical_ReturnsNotFoundWhenIngesting()
     {
-        // Arrange and Act
+        // Arrange
         var id = nameof(Get_IiifManifest_Hierarchical_ReturnsNotFoundWhenIngesting);
-        
-        // Arrange and Act
         await dbContext.Manifests.AddAsync(GenerateManifestRecord(id, 2));
         
         await amazonS3.PutObjectAsync(new()
@@ -218,7 +216,9 @@ public class GetManifestTests : IClassFixture<PresentationAppFactory<Program>>
         
         await dbContext.SaveChangesAsync();
         
+        // Act
         var response = await httpClient.GetAsync($"1/{id}");
+        
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
         response.Headers.Vary.Should().HaveCount(2);
@@ -227,10 +227,9 @@ public class GetManifestTests : IClassFixture<PresentationAppFactory<Program>>
     [Fact]
     public async Task Get_IiifManifest_Hierarchical_ReturnsOkWhenIngestingButHasIngestedBefore()
     {
-        // Arrange and Act
+        // Arrange
         var id = nameof(Get_IiifManifest_Hierarchical_ReturnsOkWhenIngestingButHasIngestedBefore);
         
-        // Arrange and Act
         await dbContext.Manifests.AddAsync(GenerateManifestRecord(id, 3, true));
         
         await amazonS3.PutObjectAsync(new()
@@ -242,6 +241,7 @@ public class GetManifestTests : IClassFixture<PresentationAppFactory<Program>>
         
         await dbContext.SaveChangesAsync();
         
+        // Act
         var response = await httpClient.GetAsync($"1/{id}");
         
         var manifest = await response.ReadAsPresentationJsonAsync<PresentationManifest>();

--- a/src/IIIFPresentation/API.Tests/Integration/GetManifestTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/GetManifestTests.cs
@@ -265,7 +265,7 @@ public class GetManifestTests : IClassFixture<PresentationAppFactory<Program>>
             Created = DateTime.UtcNow,
             Modified = DateTime.UtcNow,
             CreatedBy = "admin",
-            Ingested = ingested,
+            LastProcessed = ingested ? DateTime.UtcNow : null,
             Hierarchy =
             [
                 new Hierarchy

--- a/src/IIIFPresentation/API.Tests/Integration/GetManifestTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/GetManifestTests.cs
@@ -16,8 +16,6 @@ using Newtonsoft.Json.Linq;
 using Repository;
 using Test.Helpers.Helpers;
 using Models.Database.General;
-using Repository;
-using Test.Helpers.Helpers;
 using Test.Helpers.Integration;
 
 namespace API.Tests.Integration;
@@ -31,7 +29,6 @@ public class GetManifestTests : IClassFixture<PresentationAppFactory<Program>>
     private readonly PresentationContext dbContext;
     
     private readonly IAmazonS3 amazonS3;
-    private readonly PresentationContext dbContext;
     private readonly IDlcsApiClient dlcsApiClient;
     private readonly IAmazonS3 s3;
     private readonly JObject sampleAsset;
@@ -44,7 +41,6 @@ public class GetManifestTests : IClassFixture<PresentationAppFactory<Program>>
         httpClient = factory.ConfigureBasicIntegrationTestHttpClient(storageFixture.DbFixture,
             appFactory => appFactory.WithLocalStack(storageFixture.LocalStackFixture),
             services => services.AddSingleton(dlcsApiClient));
-            appFactory => appFactory.WithLocalStack(storageFixture.LocalStackFixture));
 
         amazonS3 = storageFixture.LocalStackFixture.AWSS3ClientFactory();
 

--- a/src/IIIFPresentation/API.Tests/Integration/GetManifestTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/GetManifestTests.cs
@@ -15,7 +15,6 @@ using Models.DLCS;
 using Newtonsoft.Json.Linq;
 using Repository;
 using Test.Helpers.Helpers;
-using Models.Database.General;
 using Test.Helpers.Integration;
 
 namespace API.Tests.Integration;

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
@@ -270,6 +270,7 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
         dbManifest.Batches.Should().HaveCount(1);
         dbManifest.Batches!.First().Status.Should().Be(BatchStatus.Ingesting);
         dbManifest.Batches!.First().Id.Should().Be(batchId);
+        dbManifest.LastProcessed.Should().BeNull();
         
         var savedS3 =
             await amazonS3.GetObjectAsync(LocalStackFixture.StorageBucketName,

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
@@ -157,7 +157,7 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
         var response = await httpClient.AsCustomer().SendAsync(requestMessage);
 
         // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
         response.Headers.Location.Should().NotBeNull();
 
         requestMessage =
@@ -247,7 +247,7 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
         var response = await httpClient.AsCustomer().SendAsync(requestMessage);
 
         // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
         var responseManifest = await response.ReadAsPresentationResponseAsync<PresentationManifest>();
 
         responseManifest!.Id.Should().NotBeNull();
@@ -523,7 +523,7 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
         var response = await httpClient.AsCustomer().SendAsync(requestMessage);
 
         // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
         var responseManifest = await response.ReadAsPresentationResponseAsync<PresentationManifest>();
 
         responseManifest!.Id.Should().NotBeNull();
@@ -618,7 +618,7 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
         var response = await httpClient.AsCustomer().SendAsync(requestMessage);
         
         // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
         var responseManifest = await response.ReadAsPresentationResponseAsync<PresentationManifest>();
 
         responseManifest!.Id.Should().NotBeNull();
@@ -829,7 +829,7 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
          var response = await httpClient.AsCustomer().SendAsync(requestMessage);
 
          // Assert
-         response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+         response.StatusCode.Should().Be(HttpStatusCode.Created);
          var responseManifest = await response.ReadAsPresentationResponseAsync<PresentationManifest>();
 
          responseManifest!.Id.Should().NotBeNull();

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
@@ -164,7 +164,7 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
             HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get, response.Headers.Location!.ToString());
         response = await httpClient.AsCustomer().SendAsync(requestMessage);
 
-        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         var responseManifest = await response.ReadAsPresentationResponseAsync<PresentationManifest>();
         responseManifest.Should().NotBeNull();
         responseManifest!.PaintedResources.Should().NotBeNull();

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
@@ -157,14 +157,14 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
         var response = await httpClient.AsCustomer().SendAsync(requestMessage);
 
         // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
         response.Headers.Location.Should().NotBeNull();
 
         requestMessage =
             HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get, response.Headers.Location!.ToString());
         response = await httpClient.AsCustomer().SendAsync(requestMessage);
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
         var responseManifest = await response.ReadAsPresentationResponseAsync<PresentationManifest>();
         responseManifest.Should().NotBeNull();
         responseManifest!.PaintedResources.Should().NotBeNull();
@@ -247,7 +247,7 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
         var response = await httpClient.AsCustomer().SendAsync(requestMessage);
 
         // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
         var responseManifest = await response.ReadAsPresentationResponseAsync<PresentationManifest>();
 
         responseManifest!.Id.Should().NotBeNull();
@@ -523,7 +523,7 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
         var response = await httpClient.AsCustomer().SendAsync(requestMessage);
 
         // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
         var responseManifest = await response.ReadAsPresentationResponseAsync<PresentationManifest>();
 
         responseManifest!.Id.Should().NotBeNull();
@@ -618,7 +618,7 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
         var response = await httpClient.AsCustomer().SendAsync(requestMessage);
         
         // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
         var responseManifest = await response.ReadAsPresentationResponseAsync<PresentationManifest>();
 
         responseManifest!.Id.Should().NotBeNull();
@@ -829,7 +829,7 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
          var response = await httpClient.AsCustomer().SendAsync(requestMessage);
 
          // Assert
-         response.StatusCode.Should().Be(HttpStatusCode.Created);
+         response.StatusCode.Should().Be(HttpStatusCode.Accepted);
          var responseManifest = await response.ReadAsPresentationResponseAsync<PresentationManifest>();
 
          responseManifest!.Id.Should().NotBeNull();

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
@@ -164,7 +164,7 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
             HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get, response.Headers.Location!.ToString());
         response = await httpClient.AsCustomer().SendAsync(requestMessage);
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
         var responseManifest = await response.ReadAsPresentationResponseAsync<PresentationManifest>();
         responseManifest.Should().NotBeNull();
         responseManifest!.PaintedResources.Should().NotBeNull();

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestCreateTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestCreateTests.cs
@@ -467,6 +467,7 @@ public class ModifyManifestCreateTests : IClassFixture<PresentationAppFactory<Pr
 
         fromDatabase.Should().NotBeNull();
         fromDatabase.SpaceId.Should().BeNull("No space was requested");
+        fromDatabase.LastProcessed.Should().NotBeNull();
         hierarchy.Type.Should().Be(ResourceType.IIIFManifest);
         hierarchy.Canonical.Should().BeTrue();
     }

--- a/src/IIIFPresentation/API/Attributes/EtagCachingAttribute.cs
+++ b/src/IIIFPresentation/API/Attributes/EtagCachingAttribute.cs
@@ -37,7 +37,7 @@ public class ETagCachingAttribute : ActionFilterAttribute
         await next();
         memoryStream.Position = 0;
 
-        if (response.StatusCode is StatusCodes.Status200OK or StatusCodes.Status201Created)
+        if (response.StatusCode is StatusCodes.Status200OK or StatusCodes.Status201Created or StatusCodes.Status202Accepted)
         {
             var responseHeaders = response.GetTypedHeaders();
 

--- a/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingResolver.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingResolver.cs
@@ -177,7 +177,7 @@ public class CanvasPaintingResolver(
     }
     
     private async Task<(PresUpdateResult? updateResult, List<CanvasPainting>? canvasPaintings)> CreateCanvasPaintingsFromAssets(
-        int customerId, PresentationManifest presentationManifest, int? manifestSpace, CancellationToken cancellationToken)
+        int customerId, PresentationManifest presentationManifest, int manifestSpace, CancellationToken cancellationToken)
     {
         var paintedResourceCount = presentationManifest.PaintedResources!.Count;
 

--- a/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingResolver.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingResolver.cs
@@ -108,7 +108,6 @@ public class CanvasPaintingResolver(
                 processedCanvasPaintingIds.Add(matching.CanvasPaintingId);
             }
         }
-
         // Delete canvasPaintings from DB that are not in payload
         foreach (var toRemove in existingManifest.CanvasPaintings
                      .Where(cp => !processedCanvasPaintingIds.Contains(cp.CanvasPaintingId)).ToList())
@@ -181,7 +180,7 @@ public class CanvasPaintingResolver(
     }
     
     private async Task<(PresUpdateResult? updateResult, List<CanvasPainting>? canvasPaintings)> CreateCanvasPaintingsFromAssets(
-        int customerId, PresentationManifest presentationManifest, int manifestSpace, CancellationToken cancellationToken)
+        int customerId, PresentationManifest presentationManifest, int? manifestSpace, CancellationToken cancellationToken)
     {
         var paintedResourceCount = presentationManifest.PaintedResources!.Count;
 

--- a/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingResolver.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingResolver.cs
@@ -19,11 +19,8 @@ namespace API.Features.Manifest;
 public class CanvasPaintingResolver(
     IdentityManager identityManager,
     ManifestItemsParser manifestItemsParser,
-    IOptions<DlcsSettings> dlcsOptions,
     ILogger<CanvasPaintingResolver> logger)
 {
-    private DlcsSettings settings = dlcsOptions.Value;
-    
     /// <summary>
     /// Generate new CanvasPainting objects for items in provided <see cref="PresentationManifest"/>
     /// </summary>

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestController.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestController.cs
@@ -4,17 +4,16 @@ using API.Auth;
 using API.Features.Manifest.Requests;
 using API.Features.Manifest.Validators;
 using API.Features.Storage.Helpers;
+using API.Helpers;
 using API.Infrastructure;
 using API.Infrastructure.Filters;
 using API.Infrastructure.Helpers;
 using API.Infrastructure.Requests;
 using API.Settings;
-using Core.IIIF;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
-using Models.API.Collection;
 using Models.API.Manifest;
 
 namespace API.Features.Manifest;
@@ -45,7 +44,10 @@ public class ManifestController(IOptions<ApiSettings> options, IAuthenticator au
                 ? SeeOther(fullPath)
                 : this.PresentationNotFound();
 
-        return Ok(entityResult.Entity);
+        return entityResult.Entity!.PaintedResources.HasAsset()
+            ? this.PresentationWithBodyResponse(Request.GetDisplayUrl(), entityResult.Entity,
+                (int)HttpStatusCode.Accepted)
+            : Ok(entityResult.Entity);
     }
 
     /// <summary>

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestController.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestController.cs
@@ -4,7 +4,6 @@ using API.Auth;
 using API.Features.Manifest.Requests;
 using API.Features.Manifest.Validators;
 using API.Features.Storage.Helpers;
-using API.Helpers;
 using API.Infrastructure;
 using API.Infrastructure.Filters;
 using API.Infrastructure.Helpers;
@@ -44,7 +43,7 @@ public class ManifestController(IOptions<ApiSettings> options, IAuthenticator au
                 ? SeeOther(fullPath)
                 : this.PresentationNotFound();
 
-        return entityResult.Entity!.PaintedResources.HasAsset()
+        return entityResult.Entity!.Ingesting
             ? this.PresentationWithBodyResponse(Request.GetDisplayUrl(), entityResult.Entity,
                 (int)HttpStatusCode.Accepted)
             : Ok(entityResult.Entity);

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
@@ -280,7 +280,8 @@ public class ManifestWriteService(
                 }
             ],
             CanvasPaintings = canvasPaintings,
-            SpaceId = spaceId
+            SpaceId = spaceId,
+            LastProcessed = canvasPaintings?.Any(cp => cp.AssetId != null) ?? false ? null : DateTime.UtcNow
         };
 
         await dbContext.AddAsync(dbManifest, cancellationToken);

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
@@ -281,7 +281,7 @@ public class ManifestWriteService(
             ],
             CanvasPaintings = canvasPaintings,
             SpaceId = spaceId,
-            LastProcessed = canvasPaintings?.Any(cp => cp.AssetId != null) ?? false ? null : DateTime.UtcNow
+            LastProcessed = canvasPaintings?.Any(cp => cp.AssetId != null) ?? false ? null : timeStamp
         };
 
         await dbContext.AddAsync(dbManifest, cancellationToken);

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
@@ -86,7 +86,8 @@ public class ManifestWriteService(
         try
         {
             var existingManifest =
-                await dbContext.RetrieveManifestAsync(request.CustomerId, request.ManifestId, true, true, cancellationToken);
+                await dbContext.RetrieveManifestAsync(request.CustomerId, request.ManifestId, true,
+                    withCanvasPaintings: true, cancellationToken: cancellationToken);
 
             if (existingManifest == null)
             {

--- a/src/IIIFPresentation/API/Features/Manifest/Requests/DeleteManifest.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/Requests/DeleteManifest.cs
@@ -28,7 +28,8 @@ public class DeleteManifestHandler(
             request.CustomerId);
 
         var manifest =
-            await dbContext.RetrieveManifestAsync(request.CustomerId, request.ManifestId, true, false, cancellationToken);
+            await dbContext.RetrieveManifestAsync(request.CustomerId, request.ManifestId, true,
+                withCanvasPaintings: false, cancellationToken: cancellationToken);
         
         if (manifest is null) return new(DeleteResult.NotFound);
 

--- a/src/IIIFPresentation/API/Features/Manifest/Requests/GetManifest.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/Requests/GetManifest.cs
@@ -18,7 +18,9 @@ public class GetManifest(
 }
 
 public class GetManifestHandler(
-    IManifestRead manifestRead) : IRequestHandler<GetManifest, FetchEntityResult<PresentationManifest>>
+    PresentationContext dbContext,
+    IPathGenerator pathGenerator,
+    IIIFS3Service iiifS3) : IRequestHandler<GetManifest, FetchEntityResult<PresentationManifest>>
 {
     public Task<FetchEntityResult<PresentationManifest>> Handle(GetManifest request,
         CancellationToken cancellationToken)

--- a/src/IIIFPresentation/API/Features/Manifest/Requests/GetManifest.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/Requests/GetManifest.cs
@@ -17,12 +17,10 @@ public class GetManifest(
     public bool PathOnly { get; } = pathOnly;
 }
 
-public class GetManifestHandler(
-    PresentationContext dbContext,
-    IPathGenerator pathGenerator,
-    IIIFS3Service iiifS3) : IRequestHandler<GetManifest, FetchEntityResult<PresentationManifest>>
+public class GetManifestHandler(IManifestRead manifestRead) : 
+    IRequestHandler<GetManifest, FetchEntityResult<PresentationManifest>>
 {
     public Task<FetchEntityResult<PresentationManifest>> Handle(GetManifest request,
         CancellationToken cancellationToken)
-        => manifestRead.GetManifest(request.CustomerId, request.Id, request.PathOnly, cancellationToken);
+            => manifestRead.GetManifest(request.CustomerId, request.Id, request.PathOnly, cancellationToken);
 }

--- a/src/IIIFPresentation/API/Features/Manifest/Requests/GetManifestHierarchical.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/Requests/GetManifestHierarchical.cs
@@ -6,6 +6,7 @@ using AWS.Settings;
 using Core.Streams;
 using MediatR;
 using Microsoft.Extensions.Options;
+using Models.Database.Collections;
 using Models.Database.General;
 using Repository;
 using Repository.Helpers;
@@ -41,8 +42,12 @@ public class GetManifestHierarchicalHandler(
             new(settings.S3.StorageBucket, BucketHelperX.GetManifestBucketKey(request.Hierarchy.CustomerId, flatId)),
             cancellationToken);
 
-        if (objectFromS3.Stream.IsNull())
+        if (objectFromS3.Stream.IsNull() ||
+            (request.Hierarchy.Manifest.IsIngesting() &&
+             !request.Hierarchy.Manifest.HasIngestedPreviously()))
+        {
             return null;
+        }
 
         request.Hierarchy.FullPath = await fetchFullPath;
 

--- a/src/IIIFPresentation/API/Features/Manifest/Requests/GetManifestHierarchical.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/Requests/GetManifestHierarchical.cs
@@ -33,6 +33,12 @@ public class GetManifestHierarchicalHandler(
         var flatId = request.Hierarchy.ManifestId ??
                      throw new InvalidOperationException(
                          "The differentiation of requests should prevent this from happening.");
+        
+        if (request.Hierarchy.Manifest.IsIngesting() &&
+         !request.Hierarchy.Manifest.HasIngestedPreviously())
+        {
+            return null;
+        }
 
         // So db can respond while we talk to S3
         var fetchFullPath =
@@ -42,9 +48,7 @@ public class GetManifestHierarchicalHandler(
             new(settings.S3.StorageBucket, BucketHelperX.GetManifestBucketKey(request.Hierarchy.CustomerId, flatId)),
             cancellationToken);
 
-        if (objectFromS3.Stream.IsNull() ||
-            (request.Hierarchy.Manifest.IsIngesting() &&
-             !request.Hierarchy.Manifest.HasIngestedPreviously()))
+        if (objectFromS3.Stream.IsNull())
         {
             return null;
         }

--- a/src/IIIFPresentation/API/Features/Manifest/Requests/GetManifestHierarchical.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/Requests/GetManifestHierarchical.cs
@@ -48,10 +48,7 @@ public class GetManifestHierarchicalHandler(
             new(settings.S3.StorageBucket, BucketHelperX.GetManifestBucketKey(request.Hierarchy.CustomerId, flatId)),
             cancellationToken);
 
-        if (objectFromS3.Stream.IsNull())
-        {
-            return null;
-        }
+        if (objectFromS3.Stream.IsNull()) return null;
 
         request.Hierarchy.FullPath = await fetchFullPath;
 

--- a/src/IIIFPresentation/API/Features/Manifest/Requests/GetManifestHierarchical.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/Requests/GetManifestHierarchical.cs
@@ -34,8 +34,7 @@ public class GetManifestHierarchicalHandler(
                      throw new InvalidOperationException(
                          "The differentiation of requests should prevent this from happening.");
         
-        if (request.Hierarchy.Manifest.IsIngesting() &&
-         !request.Hierarchy.Manifest.HasIngestedPreviously())
+        if (!request.Hierarchy.Manifest!.LastProcessed.HasValue)
         {
             return null;
         }

--- a/src/IIIFPresentation/API/Features/Storage/Helpers/PresentationContextX.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Helpers/PresentationContextX.cs
@@ -58,10 +58,11 @@ public static class PresentationContextX
     /// <param name="manifestId">The manifest to retrieve</param>
     /// <param name="tracked">Whether the resource should be tracked or not</param>
     /// <param name="withCanvasPaintings">Whether the CanvasPaintings records should be included</param>
+    /// <param name="withBatches">Whether the Batches records should be included</param>
     /// <param name="cancellationToken">A cancellation token</param>
     /// <returns>The retrieved collection</returns>
     public static Task<DbManifest?> RetrieveManifestAsync(this PresentationContext dbContext, int customerId,
-        string manifestId, bool tracked = false, bool withCanvasPaintings = true, CancellationToken cancellationToken = default)
+        string manifestId, bool tracked = false, bool withCanvasPaintings = true, bool withBatches = false, CancellationToken cancellationToken = default)
     {
         IQueryable<DbManifest> dbContextManifests = dbContext.Manifests;
 
@@ -70,6 +71,11 @@ public static class PresentationContextX
             dbContextManifests = dbContextManifests.Include(m => m.CanvasPaintings).AsSplitQuery();
         }
 
+        if (withBatches)
+        {
+            dbContextManifests = dbContextManifests.Include(m => m.Batches);
+        }
+        
         return dbContextManifests.Retrieve(customerId, manifestId, tracked, cancellationToken);
     }
     

--- a/src/IIIFPresentation/API/Features/Storage/StorageController.cs
+++ b/src/IIIFPresentation/API/Features/Storage/StorageController.cs
@@ -43,10 +43,12 @@ public class StorageController(
         {
             case ResourceType.IIIFManifest:
                 if (Request.HasShowExtraHeader() && await authenticator.ValidateRequest(Request) == AuthResult.Success)
-                    return hierarchy.ManifestId == null ? NotFound() : SeeOther($"manifests/{hierarchy.ManifestId}");
-
+                    return hierarchy.ManifestId == null
+                        ? this.PresentationNotFound()
+                        : SeeOther($"manifests/{hierarchy.ManifestId}");
+                
                 var storedManifest = await mediator.Send(new GetManifestHierarchical(hierarchy));
-                return storedManifest == null ? NotFound() : Content(storedManifest, ContentTypes.V3);
+                return storedManifest == null ? this.PresentationNotFound() : Content(storedManifest, ContentTypes.V3);
 
             case ResourceType.IIIFCollection:
             case ResourceType.StorageCollection:

--- a/src/IIIFPresentation/API/Infrastructure/ControllerBaseX.cs
+++ b/src/IIIFPresentation/API/Infrastructure/ControllerBaseX.cs
@@ -68,7 +68,8 @@ public static class ControllerBaseX
     entityResult.WriteResult switch
     {
         WriteResult.Updated => controller.Ok(entityResult.Entity),
-        WriteResult.Created => controller.PresentationCreated(controller.Request.GetDisplayUrl(), entityResult.Entity),
+        WriteResult.Accepted => controller.PresentationWithBodyResponse(controller.Request.GetDisplayUrl(), entityResult.Entity, (int)HttpStatusCode.Accepted),
+        WriteResult.Created => controller.PresentationWithBodyResponse(controller.Request.GetDisplayUrl(), entityResult.Entity, (int)HttpStatusCode.Created),
         WriteResult.NotFound => controller.PresentationNotFound(entityResult.Error),
         WriteResult.Error => controller.PresentationProblem(entityResult.Error, instance, 
             (int)HttpStatusCode.InternalServerError, errorTitle, controller.GetErrorType(entityResult.ErrorType)),
@@ -173,7 +174,7 @@ public static class ControllerBaseX
     /// Create a 201 result with standard serialized value or custom serialized IIIF object if value is
     /// <see cref="JsonLdBase"/> 
     /// </summary>
-    public static ActionResult PresentationCreated(this ControllerBase controller, string? uri, object? value)
+    public static ActionResult PresentationWithBodyResponse(this ControllerBase controller, string? uri, object? value, int statusCode)
     {
         if (value is JsonLdBase jsonLdBase)
         {
@@ -186,7 +187,7 @@ public static class ControllerBaseX
             {
                 Content = jsonLdBase.AsJson(),
                 ContentType = ContentTypes.V3,
-                StatusCode = 201,
+                StatusCode = statusCode,
             };
         }
 

--- a/src/IIIFPresentation/API/Infrastructure/ControllerBaseX.cs
+++ b/src/IIIFPresentation/API/Infrastructure/ControllerBaseX.cs
@@ -171,7 +171,8 @@ public static class ControllerBaseX
         => controller.PresentationProblem(statusCode: (int)HttpStatusCode.Forbidden);
     
     /// <summary>
-    /// Create a 201 result with standard serialized value or custom serialized IIIF object if value is
+    /// Creates either a 201 or 202 result with standard serialized value or custom serialized IIIF object if value is
+    /// based on whether the asset is ingesting (202)
     /// <see cref="JsonLdBase"/> 
     /// </summary>
     public static ActionResult PresentationWithBodyResponse(this ControllerBase controller, string? uri, object? value, int statusCode)

--- a/src/IIIFPresentation/API/Infrastructure/ControllerBaseX.cs
+++ b/src/IIIFPresentation/API/Infrastructure/ControllerBaseX.cs
@@ -171,9 +171,8 @@ public static class ControllerBaseX
         => controller.PresentationProblem(statusCode: (int)HttpStatusCode.Forbidden);
     
     /// <summary>
-    /// Creates either a 201 or 202 result with standard serialized value or custom serialized IIIF object if value is
-    /// based on whether the asset is ingesting (202)
-    /// <see cref="JsonLdBase"/> 
+    /// Creates a result with standard serialized value or custom serialized IIIF object, with a specified status code
+    /// <see cref="JsonLdBase"/>
     /// </summary>
     public static ActionResult PresentationWithBodyResponse(this ControllerBase controller, string? uri, object? value, int statusCode)
     {

--- a/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionMessageHandlerTests.cs
+++ b/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionMessageHandlerTests.cs
@@ -164,7 +164,7 @@ public class BatchCompletionMessageHandlerTests
         batch.Status.Should().Be(BatchStatus.Completed);
         batch.Finished.Should().BeCloseTo(finished, TimeSpan.FromSeconds(10));
         batch.Processed.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(10));
-        batch.Manifest!.Ingested.Should().BeTrue();
+        batch.Manifest!.LastProcessed.Should().NotBeNull();
         var canvasPainting = dbContext.CanvasPaintings.Single(c => c.AssetId == fullAssetId);
         canvasPainting.Ingesting.Should().BeFalse();
         canvasPainting.StaticWidth.Should().Be(100);

--- a/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionMessageHandlerTests.cs
+++ b/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionMessageHandlerTests.cs
@@ -160,15 +160,16 @@ public class BatchCompletionMessageHandlerTests
         handleMessage.Should().BeTrue();
         A.CallTo(() => dlcsClient.RetrieveAssetsForManifest(A<int>._, A<List<int>>._, A<CancellationToken>._))
             .MustHaveHappened();
-        var batch = dbContext.Batches.Single(b => b.Id == batchId);
+        var batch = dbContext.Batches.Include(b => b.Manifest).Single(b => b.Id == batchId);
         batch.Status.Should().Be(BatchStatus.Completed);
         batch.Finished.Should().BeCloseTo(finished, TimeSpan.FromSeconds(10));
         batch.Processed.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(10));
+        batch.Manifest!.Ingested.Should().BeTrue();
         var canvasPainting = dbContext.CanvasPaintings.Single(c => c.AssetId == fullAssetId);
         canvasPainting.Ingesting.Should().BeFalse();
         canvasPainting.StaticWidth.Should().Be(100);
         canvasPainting.StaticHeight.Should().Be(100);
-        canvasPainting.AssetId.ToString().Should()
+        canvasPainting.AssetId!.ToString().Should()
             .Be(fullAssetId.ToString());
     }
     

--- a/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionMessageHandlerTests.cs
+++ b/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionMessageHandlerTests.cs
@@ -214,8 +214,9 @@ public class BatchCompletionMessageHandlerTests
         (await sut.HandleMessage(message, CancellationToken.None)).Should().BeTrue();
         A.CallTo(() => dlcsClient.RetrieveAssetsForManifest(A<int>._, A<List<int>>._, A<CancellationToken>._))
             .MustNotHaveHappened();
-        var batch = await dbContext.Batches.SingleOrDefaultAsync(b => b.Id == batchId);
+        var batch = await dbContext.Batches.Include(b => b.Manifest).SingleOrDefaultAsync(b => b.Id == batchId);
         batch.Status.Should().Be(BatchStatus.Completed);
+        batch.Manifest!.LastProcessed.Should().BeNull();
     }
 
     private Manifest CreateManifest(string manifestId, string slug, string assetId, int space, int batchId)

--- a/src/IIIFPresentation/BackgroundHandler/BatchCompletion/BatchCompletionMessageHandler.cs
+++ b/src/IIIFPresentation/BackgroundHandler/BatchCompletion/BatchCompletionMessageHandler.cs
@@ -134,6 +134,7 @@ public class BatchCompletionMessageHandler(
         batch.Processed = DateTime.UtcNow;
         batch.Finished = finished;
         batch.Status = BatchStatus.Completed;
+        batch.Manifest!.Ingested = true;
     }
 
     private void UpdateCanvasPaintings(Manifest generatedManifest, Batch batch, Dictionary<AssetId, Canvas> itemDictionary)

--- a/src/IIIFPresentation/BackgroundHandler/BatchCompletion/BatchCompletionMessageHandler.cs
+++ b/src/IIIFPresentation/BackgroundHandler/BatchCompletion/BatchCompletionMessageHandler.cs
@@ -64,7 +64,7 @@ public class BatchCompletionMessageHandler(
                                                   b.Status != BatchStatus.Completed &&
                                                   b.Id != batch.Id, cancellationToken))
         {
-            CompleteBatch(batch, batchCompletionMessage.Finished);
+            CompleteBatch(batch, batchCompletionMessage.Finished, false);
         }
         else
         {
@@ -93,7 +93,7 @@ public class BatchCompletionMessageHandler(
             try
             {
                 UpdateCanvasPaintings(generatedManifest, batch, itemDictionary);
-                CompleteBatch(batch, batchCompletionMessage.Finished);
+                CompleteBatch(batch, batchCompletionMessage.Finished, true);
                 await UpdateManifestInS3(generatedManifest.Thumbnail, itemDictionary, batch, cancellationToken);
             }
             catch (Exception e)
@@ -129,14 +129,18 @@ public class BatchCompletionMessageHandler(
             cancellationToken);
     }
 
-    private void CompleteBatch(Batch batch, DateTime finished)
+    private void CompleteBatch(Batch batch, DateTime finished, bool finalBatch)
     {
         var processed = DateTime.UtcNow;
         
         batch.Processed = processed;
         batch.Finished = finished;
         batch.Status = BatchStatus.Completed;
-        batch.Manifest!.LastProcessed = processed;
+
+        if (finalBatch)
+        {
+            batch.Manifest!.LastProcessed = processed;
+        }
     }
 
     private void UpdateCanvasPaintings(Manifest generatedManifest, Batch batch, Dictionary<AssetId, Canvas> itemDictionary)

--- a/src/IIIFPresentation/BackgroundHandler/BatchCompletion/BatchCompletionMessageHandler.cs
+++ b/src/IIIFPresentation/BackgroundHandler/BatchCompletion/BatchCompletionMessageHandler.cs
@@ -131,10 +131,12 @@ public class BatchCompletionMessageHandler(
 
     private void CompleteBatch(Batch batch, DateTime finished)
     {
-        batch.Processed = DateTime.UtcNow;
+        var processed = DateTime.UtcNow;
+        
+        batch.Processed = processed;
         batch.Finished = finished;
         batch.Status = BatchStatus.Completed;
-        batch.Manifest!.Ingested = true;
+        batch.Manifest!.LastProcessed = processed;
     }
 
     private void UpdateCanvasPaintings(Manifest generatedManifest, Batch batch, Dictionary<AssetId, Canvas> itemDictionary)

--- a/src/IIIFPresentation/Core/WriteResult.cs
+++ b/src/IIIFPresentation/Core/WriteResult.cs
@@ -29,6 +29,11 @@ public enum WriteResult
     /// Request failed validation
     /// </summary>
     FailedValidation,
+    
+    /// <summary>
+    /// Request has been accepted for processing
+    /// </summary>
+    Accepted,
 
     /// <summary>
     /// Entity was successfully updated

--- a/src/IIIFPresentation/Models/API/Manifest/PresentationManifest.cs
+++ b/src/IIIFPresentation/Models/API/Manifest/PresentationManifest.cs
@@ -25,8 +25,7 @@ public class PresentationManifest : IIIF.Presentation.V3.Manifest, IPresentation
 
     [JsonIgnore] public string? FullPath { get; set; }
     
-    [JsonIgnore] 
-    public bool Ingesting { get; set; }
+    [JsonIgnore] public bool Ingesting { get; set; }
 }
 
 /// <summary>

--- a/src/IIIFPresentation/Models/API/Manifest/PresentationManifest.cs
+++ b/src/IIIFPresentation/Models/API/Manifest/PresentationManifest.cs
@@ -24,6 +24,9 @@ public class PresentationManifest : IIIF.Presentation.V3.Manifest, IPresentation
     [JsonProperty(Order = 13)] public string? Space { get; set; }
 
     [JsonIgnore] public string? FullPath { get; set; }
+    
+    [JsonIgnore] 
+    public bool Ingesting { get; set; }
 }
 
 /// <summary>

--- a/src/IIIFPresentation/Models/Database/Collections/Manifest.cs
+++ b/src/IIIFPresentation/Models/Database/Collections/Manifest.cs
@@ -51,7 +51,7 @@ public class Manifest : IHierarchyResource
     /// <summary>
     /// Whether the manifest has been ingested with assets at some point
     /// </summary>
-    public bool Ingested { get; set; }
+    public DateTime? LastProcessed { get; set; }
 }
 
 public static class ManifestX
@@ -66,5 +66,5 @@ public static class ManifestX
         => manifest?.Batches?.Any(m => m.Status == BatchStatus.Ingesting) ?? false;
     
     public static bool HasIngestedPreviously(this Manifest? manifest)
-        => manifest?.Ingested ?? false;
+        => manifest?.LastProcessed != null;
 }

--- a/src/IIIFPresentation/Models/Database/Collections/Manifest.cs
+++ b/src/IIIFPresentation/Models/Database/Collections/Manifest.cs
@@ -47,6 +47,11 @@ public class Manifest : IHierarchyResource
     public List<CanvasPainting>? CanvasPaintings { get; set; }
     
     public List<Batch>? Batches { get; set; }
+    
+    /// <summary>
+    /// Whether the manifest has been ingested with assets at some point
+    /// </summary>
+    public bool Ingested { get; set; }
 }
 
 public static class ManifestX
@@ -56,4 +61,10 @@ public static class ManifestX
     /// </summary>
     public static string GetDefaultSpaceName(string manifestId)
         => $"For manifest {manifestId} - {DateTime.UtcNow.ToString("s", CultureInfo.InvariantCulture)}";
+    
+    public static bool IsIngesting(this Manifest? manifest)
+        => manifest?.Batches?.Any(m => m.Status == BatchStatus.Ingesting) ?? false;
+    
+    public static bool HasIngestedPreviously(this Manifest? manifest)
+        => manifest?.Ingested ?? false;
 }

--- a/src/IIIFPresentation/Models/Database/Collections/Manifest.cs
+++ b/src/IIIFPresentation/Models/Database/Collections/Manifest.cs
@@ -64,7 +64,4 @@ public static class ManifestX
     
     public static bool IsIngesting(this Manifest? manifest)
         => manifest?.Batches?.Any(m => m.Status == BatchStatus.Ingesting) ?? false;
-    
-    public static bool HasIngestedPreviously(this Manifest? manifest)
-        => manifest?.LastProcessed != null;
 }

--- a/src/IIIFPresentation/Models/Database/Collections/Manifest.cs
+++ b/src/IIIFPresentation/Models/Database/Collections/Manifest.cs
@@ -49,7 +49,7 @@ public class Manifest : IHierarchyResource
     public List<Batch>? Batches { get; set; }
     
     /// <summary>
-    /// Whether the manifest has been ingested with assets at some point
+    /// A timestamp denoting when this batch was last processed into a user viewable format
     /// </summary>
     public DateTime? LastProcessed { get; set; }
 }

--- a/src/IIIFPresentation/Repository/Helpers/CollectionRetrieval.cs
+++ b/src/IIIFPresentation/Repository/Helpers/CollectionRetrieval.cs
@@ -164,6 +164,7 @@ WHERE
             .FromSqlRaw(query)
             .Include(h => h.Collection)
             .Include(h => h.Manifest)
+            .ThenInclude(m => m.Batches)
             .FirstOrDefaultAsync(cancellationToken);
     }
 }

--- a/src/IIIFPresentation/Repository/Helpers/CollectionRetrieval.cs
+++ b/src/IIIFPresentation/Repository/Helpers/CollectionRetrieval.cs
@@ -151,6 +151,7 @@ WHERE
   AND tree_path.slug = slug_array[max_level]
   AND tree_path.customer_id = {customerId}";
 
+        // no need to include the batch as this is only hit for the root collection
         if (slug.Equals(string.Empty))
         {
             return await dbContext.Hierarchy

--- a/src/IIIFPresentation/Repository/Migrations/20250128103132_addIngestedToManifest.Designer.cs
+++ b/src/IIIFPresentation/Repository/Migrations/20250128103132_addIngestedToManifest.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Repository;
@@ -11,9 +12,11 @@ using Repository;
 namespace Repository.Migrations
 {
     [DbContext(typeof(PresentationContext))]
-    partial class PresentationContextModelSnapshot : ModelSnapshot
+    [Migration("20250128103132_addIngestedToManifest")]
+    partial class addIngestedToManifest
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/IIIFPresentation/Repository/Migrations/20250128103132_addIngestedToManifest.cs
+++ b/src/IIIFPresentation/Repository/Migrations/20250128103132_addIngestedToManifest.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Repository.Migrations
+{
+    /// <inheritdoc />
+    public partial class addIngestedToManifest : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "ingested",
+                table: "manifests",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ingested",
+                table: "manifests");
+        }
+    }
+}

--- a/src/IIIFPresentation/Repository/Migrations/20250203165736_changeIngestedToProcessed.Designer.cs
+++ b/src/IIIFPresentation/Repository/Migrations/20250203165736_changeIngestedToProcessed.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Repository;
@@ -11,9 +12,11 @@ using Repository;
 namespace Repository.Migrations
 {
     [DbContext(typeof(PresentationContext))]
-    partial class PresentationContextModelSnapshot : ModelSnapshot
+    [Migration("20250203165736_changeIngestedToProcessed")]
+    partial class changeIngestedToProcessed
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/IIIFPresentation/Repository/Migrations/20250203165736_changeIngestedToProcessed.cs
+++ b/src/IIIFPresentation/Repository/Migrations/20250203165736_changeIngestedToProcessed.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Repository.Migrations
+{
+    /// <inheritdoc />
+    public partial class changeIngestedToProcessed : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ingested",
+                table: "manifests");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "last_processed",
+                table: "manifests",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "last_processed",
+                table: "manifests");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "ingested",
+                table: "manifests",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+    }
+}

--- a/src/IIIFPresentation/Test.Helpers/Helpers/DatabaseTestDataPopulation.cs
+++ b/src/IIIFPresentation/Test.Helpers/Helpers/DatabaseTestDataPopulation.cs
@@ -16,7 +16,7 @@ public static class DatabaseTestDataPopulation
 {
     public static ValueTask<EntityEntry<Manifest>> AddTestManifest(this DbSet<Manifest> manifests,
         [CallerMemberName] string id = "", int customer = 1, DateTime? createdDate = null, string? slug = null,
-        string parent = "root", LanguageMap? label = null)
+        string parent = "root", LanguageMap? label = null, int? batchId = null, bool ingested = false)
     {
         createdDate ??= DateTime.UtcNow;
         return manifests.AddAsync(new Manifest
@@ -27,6 +27,7 @@ public static class DatabaseTestDataPopulation
             Created = createdDate.Value,
             Modified = createdDate.Value,
             Label = label,
+            LastProcessed = ingested ? DateTime.UtcNow : null,
             Hierarchy =
             [
                 new Hierarchy
@@ -36,7 +37,17 @@ public static class DatabaseTestDataPopulation
                     Parent = parent,
                     Type = ResourceType.IIIFManifest
                 }
-            ]
+            ],
+            Batches = batchId != null ?
+            [
+                new Batch
+                {
+                    Id = batchId.Value,
+                    Submitted = DateTime.UtcNow,
+                    Status = BatchStatus.Ingesting,
+                    ManifestId = id
+                }
+            ] : null,
         });
     }
     

--- a/src/IIIFPresentation/Test.Helpers/Integration/PresentationContextFixture.cs
+++ b/src/IIIFPresentation/Test.Helpers/Integration/PresentationContextFixture.cs
@@ -207,7 +207,8 @@ public class PresentationContextFixture : IAsyncLifetime
                     Type = ResourceType.IIIFManifest,
                     Canonical = true
                 }
-            ]
+            ],
+            LastProcessed = DateTime.UtcNow
         });
         
         await DbContext.SaveChangesAsync();


### PR DESCRIPTION
Resolves #230 

This PR does the following

- modifies `GET` manifest to return an `Accepted` status code when assets are ingested
- adds an additional `Ingested` property to the database, denoting that the manifest has been ingested at some point in the past
- Modifies the GET hierarchical call to return `NotFound` if the manifest is ingesting, unless it has previously been ingested
