### PR TITLE
Order paintedResources in manifests

### DIFF
--- a/src/IIIFPresentation/API.Tests/Converters/ManifestConverterTests.cs
+++ b/src/IIIFPresentation/API.Tests/Converters/ManifestConverterTests.cs
@@ -189,6 +189,60 @@ public class ManifestConverterTests
     }
     
     [Fact]
+    public void SetGeneratedFields_SetsCanvasPaintings_InCanvasThenChoiceOrder()
+    {
+        // Arrange
+        var iiifManifest = new PresentationManifest();
+        var dbManifest = new DBManifest
+        {
+            CustomerId = 123,
+            Created = DateTime.UtcNow,
+            Modified = DateTime.UtcNow.AddDays(1),
+            CreatedBy = "creator",
+            ModifiedBy = "modifier",
+            Id = "id",
+            Hierarchy = [new Hierarchy { Slug = "slug" }],
+            CanvasPaintings =
+            [
+                new CanvasPainting
+                {
+                    CanvasOriginalId = new Uri("http://example.test/canvas1"),
+                    CustomerId = 123,
+                    Id = "the-canvas",
+                    ChoiceOrder = 1,
+                    CanvasOrder = 2,
+                    AssetId = new AssetId(1, 2, "assetId1")
+                },
+                new CanvasPainting
+                {
+                    CanvasOriginalId = new Uri("http://example.test/canvas1"),
+                    CustomerId = 123,
+                    Id = "the-canvas",
+                    ChoiceOrder = 2,
+                    CanvasOrder = 2,
+                    AssetId = new AssetId(1, 2, "assetId2")
+                },
+                new CanvasPainting
+                {
+                    CanvasOriginalId = new Uri("http://example.test/canvas1"),
+                    CustomerId = 123,
+                    Id = "the-canvas",
+                    CanvasOrder = 1,
+                    AssetId = new AssetId(1, 2, "assetId3")
+                }
+            ]
+        };
+        
+        // Act
+        var result = iiifManifest.SetGeneratedFields(dbManifest, pathGenerator);
+
+        // Assert
+        result.PaintedResources.Should()
+            .BeInAscendingOrder(pr => pr.CanvasPainting.CanvasOrder)
+            .And.ThenBeInAscendingOrder(pr => pr.CanvasPainting.ChoiceOrder);
+    }
+    
+    [Fact]
     public void SetGeneratedFields_SetsCanvasPainting_WithoutAssetId()
     {
         // Arrange

--- a/src/IIIFPresentation/API.Tests/Converters/ManifestConverterTests.cs
+++ b/src/IIIFPresentation/API.Tests/Converters/ManifestConverterTests.cs
@@ -206,27 +206,18 @@ public class ManifestConverterTests
             [
                 new CanvasPainting
                 {
-                    CanvasOriginalId = new Uri("http://example.test/canvas1"),
-                    CustomerId = 123,
-                    Id = "the-canvas",
                     ChoiceOrder = 1,
                     CanvasOrder = 2,
                     AssetId = new AssetId(1, 2, "assetId1")
                 },
                 new CanvasPainting
                 {
-                    CanvasOriginalId = new Uri("http://example.test/canvas1"),
-                    CustomerId = 123,
-                    Id = "the-canvas",
                     ChoiceOrder = 2,
                     CanvasOrder = 2,
                     AssetId = new AssetId(1, 2, "assetId2")
                 },
                 new CanvasPainting
                 {
-                    CanvasOriginalId = new Uri("http://example.test/canvas1"),
-                    CustomerId = 123,
-                    Id = "the-canvas",
                     CanvasOrder = 1,
                     AssetId = new AssetId(1, 2, "assetId3")
                 }

--- a/src/IIIFPresentation/API/Converters/ManifestConverter.cs
+++ b/src/IIIFPresentation/API/Converters/ManifestConverter.cs
@@ -53,7 +53,10 @@ public static class ManifestConverter
     {
         if (dbManifest.CanvasPaintings.IsNullOrEmpty()) return null;
 
-        return dbManifest.CanvasPaintings.Select(cp => new PaintedResource
+        return dbManifest.CanvasPaintings
+            .OrderBy(cp => cp.CanvasOrder)
+            .ThenBy(cp => cp.ChoiceOrder)
+            .Select(cp => new PaintedResource
         {
             CanvasPainting = new Models.API.Manifest.CanvasPainting
             {


### PR DESCRIPTION
Fixes #207 

Orders `paintedResources` by canvas then choice order.