### PR TITLE
Fix SeeAlso links for api storage collections

### DIFF
--- a/src/IIIFPresentation/API.Tests/Converters/CollectionConverterTests.cs
+++ b/src/IIIFPresentation/API.Tests/Converters/CollectionConverterTests.cs
@@ -44,9 +44,9 @@ public class CollectionConverterTests
             storageRoot.ToHierarchicalCollection(pathGenerator, CreateTestItems());
         // Assert
         hierarchicalCollection.Id.Should().Be("http://base/1");
-        hierarchicalCollection.Label!.Count.Should().Be(1);
+        hierarchicalCollection.Label!.Should().HaveCount(1);
         hierarchicalCollection.Label["en"].Should().Contain("repository root");
-        hierarchicalCollection.Items!.Count.Should().Be(1);
+        hierarchicalCollection.Items!.Should().HaveCount(1);
         hierarchicalCollection.Context!.Should().Be("http://iiif.io/api/presentation/3/context.json");
     }
     
@@ -61,9 +61,9 @@ public class CollectionConverterTests
             storageRoot.ToHierarchicalCollection(pathGenerator, CreateTestItems());
         // Assert
         hierarchicalCollection.Id.Should().Be("http://base/1/top/some-id");
-        hierarchicalCollection.Label!.Count.Should().Be(1);
+        hierarchicalCollection.Label!.Should().HaveCount(1);
         hierarchicalCollection.Label["en"].Should().Contain("repository root");
-        hierarchicalCollection.Items!.Count.Should().Be(1);
+        hierarchicalCollection.Items!.Should().HaveCount(1);
         hierarchicalCollection.Context!.Should().Be("http://iiif.io/api/presentation/3/context.json");
     }
 
@@ -136,7 +136,7 @@ public class CollectionConverterTests
         presentationCollection.Id.Should().Be("http://base/1/collections/some-id");
         presentationCollection.FlatId.Should().Be("some-id");
         presentationCollection.PublicId.Should().Be("http://base/1");
-        presentationCollection.Label!.Count.Should().Be(1);
+        presentationCollection.Label!.Should().HaveCount(1);
         presentationCollection.Label["en"].Should().Contain("repository root");
         presentationCollection.Slug.Should().Be("root");
         presentationCollection.SeeAlso.Should().HaveCount(1);
@@ -144,7 +144,7 @@ public class CollectionConverterTests
         presentationCollection.SeeAlso[0].Profile.Should().Contain("api-hierarchical");
         presentationCollection.Created.Should().Be(DateTime.MinValue);
         presentationCollection.Parent.Should().BeNull();
-        presentationCollection.Items!.Count.Should().Be(1);
+        presentationCollection.Items!.Should().HaveCount(1);
         presentationCollection.View!.Id.Should().Be("http://base/1/collections/some-id?page=1&pageSize=100");
         presentationCollection.View.Next.Should().BeNull();
         presentationCollection.View.Last.Should().BeNull();
@@ -167,7 +167,7 @@ public class CollectionConverterTests
         presentationCollection.Id.Should().Be("http://base/1/collections/some-id");
         presentationCollection.FlatId.Should().Be("some-id");
         presentationCollection.PublicId.Should().Be("http://base/1/top/some-id");
-        presentationCollection.Label!.Count.Should().Be(1);
+        presentationCollection.Label!.Should().HaveCount(1);
         presentationCollection.Label["en"].Should().Contain("repository root");
         presentationCollection.Slug.Should().Be("root");
         presentationCollection.SeeAlso.Should().HaveCount(1);
@@ -175,7 +175,7 @@ public class CollectionConverterTests
         presentationCollection.SeeAlso![0].Profile.Should().Contain("api-hierarchical");
         presentationCollection.Created.Should().Be(DateTime.MinValue);
         presentationCollection.Parent.Should().Be("http://base/1/collections/top");
-        presentationCollection.Items!.Count.Should().Be(1);
+        presentationCollection.Items!.Should().HaveCount(1);
         presentationCollection.View!.Id.Should().Be("http://base/1/collections/some-id?page=1&pageSize=100");
         presentationCollection.View.Next.Should().BeNull();
         presentationCollection.View.Last.Should().BeNull();
@@ -200,14 +200,14 @@ public class CollectionConverterTests
         presentationCollection.Id.Should().Be("http://base/1/collections/some-id");
         presentationCollection.FlatId.Should().Be("some-id");
         presentationCollection.PublicId.Should().Be("http://base/1/top/some-id");
-        presentationCollection.Label!.Count.Should().Be(1);
+        presentationCollection.Label!.Should().HaveCount(1);
         presentationCollection.Label["en"].Should().Contain("repository root");
         presentationCollection.Slug.Should().Be("root");
         presentationCollection.SeeAlso.Should().HaveCount(1);
         presentationCollection.SeeAlso![0].Profile.Should().Contain("api-hierarchical");
         presentationCollection.Created.Should().Be(DateTime.MinValue);
         presentationCollection.Parent.Should().Be("http://base/1/collections/top");
-        presentationCollection.Items!.Count.Should().Be(1);
+        presentationCollection.Items!.Should().HaveCount(1);
         presentationCollection.View!.TotalPages.Should().Be(3);
         presentationCollection.View.PageSize.Should().Be(1);
         presentationCollection.View.Id.Should().Be("http://base/1/collections/some-id?page=2&pageSize=1&orderBy=created");
@@ -236,7 +236,7 @@ public class CollectionConverterTests
         presentationCollection.Id.Should().Be("http://base/1/collections/some-id");
         presentationCollection.FlatId.Should().Be("some-id");
         presentationCollection.PublicId.Should().Be("http://base/1/top/some-id");
-        presentationCollection.Label!.Count.Should().Be(1);
+        presentationCollection.Label!.Should().HaveCount(1);
         presentationCollection.Label["en"].Should().Contain("repository root");
         presentationCollection.Slug.Should().Be("root");
         presentationCollection.SeeAlso.Should().HaveCount(1);
@@ -244,7 +244,7 @@ public class CollectionConverterTests
         presentationCollection.SeeAlso![0].Profile.Should().Contain("api-hierarchical");
         presentationCollection.Created.Should().Be(DateTime.MinValue);
         presentationCollection.Parent.Should().Be("http://base/1/collections/top");
-        presentationCollection.Items!.Count.Should().Be(1);
+        presentationCollection.Items!.Should().HaveCount(1);
         presentationCollection.View!.Id.Should().Be("http://base/1/collections/some-id?page=1&pageSize=100");
         presentationCollection.View.Next.Should().BeNull();
         presentationCollection.View.Last.Should().BeNull();

--- a/src/IIIFPresentation/API.Tests/Features/Storage/Helpers/BehaviourXTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Storage/Helpers/BehaviourXTests.cs
@@ -1,6 +1,6 @@
 ﻿
 using API.Features.Storage.Helpers;
-using Models.Infrastucture;
+using Models.Infrastructure;
 
 namespace API.Tests.Features.Storage.Helpers;
 

--- a/src/IIIFPresentation/API.Tests/Integration/DeleteCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/DeleteCollectionTests.cs
@@ -6,7 +6,7 @@ using Core.Response;
 using IIIF.Serialisation;
 using Models.API.Collection;
 using Models.API.General;
-using Models.Infrastucture;
+using Models.Infrastructure;
 using Repository;
 using Test.Helpers.Helpers;
 using Test.Helpers.Integration;

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyCollectionTests.cs
@@ -16,7 +16,7 @@ using Models.API.Collection;
 using Models.API.General;
 using Models.Database.Collections;
 using Models.Database.General;
-using Models.Infrastucture;
+using Models.Infrastructure;
 using Newtonsoft.Json.Linq;
 using Repository;
 using Test.Helpers.Helpers;

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestCreateTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestCreateTests.cs
@@ -18,7 +18,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Models.API.General;
 using Models.API.Manifest;
 using Models.Database.General;
-using Models.Infrastucture;
+using Models.Infrastructure;
 using Repository;
 using Test.Helpers;
 using Test.Helpers.Helpers;

--- a/src/IIIFPresentation/API/Features/Storage/Helpers/BehaviorX.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Helpers/BehaviorX.cs
@@ -1,4 +1,4 @@
-﻿using Models.Infrastucture;
+﻿using Models.Infrastructure;
 
 namespace API.Features.Storage.Helpers;
 

--- a/src/IIIFPresentation/AWS/Helpers/IIIFS3Service.cs
+++ b/src/IIIFPresentation/AWS/Helpers/IIIFS3Service.cs
@@ -10,7 +10,7 @@ using IIIF.Serialisation;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Models.Database.Collections;
-using Models.Infrastucture;
+using Models.Infrastructure;
 
 namespace AWS.Helpers;
 

--- a/src/IIIFPresentation/Models/Infrastructure/Behavior.cs
+++ b/src/IIIFPresentation/Models/Infrastructure/Behavior.cs
@@ -1,0 +1,10 @@
+﻿namespace Models.Infrastructure;
+
+public static class Behavior
+{
+    public static readonly string IsPublic = "public-iiif";
+
+    public static readonly string IsStorageCollection = "storage-collection";
+    
+    public static readonly string ApiHierarchical = "api-hierarchical";
+}

--- a/src/IIIFPresentation/Models/Infrastucture/Behavior.cs
+++ b/src/IIIFPresentation/Models/Infrastucture/Behavior.cs
@@ -1,8 +1,0 @@
-﻿namespace Models.Infrastucture;
-
-public static class Behavior
-{
-    public static string IsPublic = "public-iiif";
-
-    public static string IsStorageCollection = "storage-collection";
-}


### PR DESCRIPTION
Fixes #168 

Add `"seeAlso"` to storage collections. Which values are shown is dependant on configuration, as noted in docs there is redundancy in these links until canonical paths are implemented.