### PR TITLE
Return full asset on Manifest get

### DIFF
--- a/src/IIIFPresentation/API/Features/Manifest/ManifestReadService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestReadService.cs
@@ -1,0 +1,101 @@
+﻿using API.Converters;
+using API.Features.Storage.Helpers;
+using API.Helpers;
+using API.Infrastructure.Requests;
+using AWS.Helpers;
+using DLCS.API;
+using DLCS.Exceptions;
+using Models.API.Manifest;
+using Models.Database.General;
+using Newtonsoft.Json.Linq;
+using Repository;
+using Repository.Helpers;
+using DbManifest = Models.Database.Collections.Manifest;
+
+namespace API.Features.Manifest;
+
+public interface IManifestRead
+{
+    /// <summary>
+    /// Get a lookup of full Asset URI : <see cref="JObject"/> for all assets in given manifest
+    /// </summary>
+    /// <returns></returns>
+    Task<Dictionary<string, JObject>?> GetAssets(int customerId, DbManifest? dbManifest,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Attempt to read manifest from storage
+    /// </summary>
+    public Task<FetchEntityResult<PresentationManifest>> GetManifest(int customerId, string manifestId, bool pathOnly,
+        CancellationToken cancellationToken);
+}
+
+public class ManifestReadService(
+    PresentationContext dbContext,
+    IIIFS3Service iiifS3,
+    IDlcsApiClient dlcsApiClient,
+    IPathGenerator pathGenerator,
+    ILogger<ManifestReadService> logger) : IManifestRead
+{
+    public async Task<Dictionary<string, JObject>?> GetAssets(int customerId, Models.Database.Collections.Manifest? dbManifest,
+        CancellationToken cancellationToken)
+    {
+        var assetIds = dbManifest?.CanvasPaintings?.Select(cp => cp.AssetId?.ToString())
+            .OfType<string>().ToArray();
+
+        if (assetIds == null) return null;
+
+        try
+        {
+            var assets = await dlcsApiClient.GetCustomerImages(customerId, assetIds, cancellationToken);
+
+            return assets.Select(a => (asset: a,
+                    id: a.TryGetValue("@id", out var value) && value.Type == JTokenType.String
+                        ? value.Value<string>()
+                        : null))
+                .Where(tuple => tuple.id is { Length: > 0 })
+                .ToDictionary(tuple => tuple.id!, tuple => tuple.asset);
+        }
+        catch (DlcsException dlcsException)
+        {
+            logger.LogError(dlcsException, "Error retrieving selected asset details for Customer {CustomerId}",
+                customerId);
+
+            return null;
+        }
+    }
+
+    public async Task<FetchEntityResult<PresentationManifest>> GetManifest(int customerId, string manifestId, bool pathOnly, CancellationToken cancellationToken)
+    {
+        var dbManifest =
+            await dbContext.RetrieveManifestAsync(customerId, manifestId, cancellationToken: cancellationToken);
+
+        if (dbManifest == null) return FetchEntityResult<PresentationManifest>.NotFound();
+
+        var fetchFullPath = ManifestRetrieval.RetrieveFullPathForManifest(dbManifest.Id, dbManifest.CustomerId,
+            dbContext, cancellationToken);
+
+        if (pathOnly)
+        {
+            return FetchEntityResult<PresentationManifest>.Success(new()
+            {
+                FullPath = pathGenerator.GenerateHierarchicalFromFullPath(customerId, await fetchFullPath)
+            });
+        }
+
+        var getAssets = GetAssets(customerId, dbManifest, cancellationToken);
+        var manifest = await iiifS3.ReadIIIFFromS3<PresentationManifest>(dbManifest, cancellationToken);
+        dbManifest.Hierarchy.Single().FullPath = await fetchFullPath;
+
+        // PK: Will this even happen? Should we log or even throw here?
+        if (manifest == null)
+            return FetchEntityResult<PresentationManifest>.Failure(
+                "Unable to read and deserialize manifest from storage");
+
+        var assets = await getAssets;
+        manifest = manifest.SetGeneratedFields(dbManifest, pathGenerator, assets,
+            m => Enumerable.Single<Hierarchy>(m.Hierarchy!, h => h.Canonical));
+
+        return FetchEntityResult<PresentationManifest>.Success(manifest);
+    }
+}

--- a/src/IIIFPresentation/API/Features/Manifest/Requests/CreateManifest.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/Requests/CreateManifest.cs
@@ -22,7 +22,7 @@ public class CreateManifest(
 }
 
 public class CreateManifestHandler(
-    ManifestService manifestService) : IRequestHandler<CreateManifest,
+    IManifestWrite manifestService) : IRequestHandler<CreateManifest,
     ModifyEntityResult<PresentationManifest, ModifyCollectionType>>
 {
     public Task<ModifyEntityResult<PresentationManifest, ModifyCollectionType>> Handle(CreateManifest request,

--- a/src/IIIFPresentation/API/Features/Manifest/Requests/GetManifest.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/Requests/GetManifest.cs
@@ -1,15 +1,12 @@
-﻿using API.Converters;
-using API.Features.Storage.Helpers;
-using API.Helpers;
-using API.Infrastructure.Requests;
-using AWS.Helpers;
+﻿using API.Infrastructure.Requests;
 using MediatR;
 using Models.API.Manifest;
-using Repository;
-using Repository.Helpers;
 
 namespace API.Features.Manifest.Requests;
 
+/// <summary>
+/// Attempt to read manifest from underlying storage
+/// </summary>
 public class GetManifest(
     int customerId,
     string id,
@@ -21,38 +18,9 @@ public class GetManifest(
 }
 
 public class GetManifestHandler(
-    PresentationContext dbContext,
-    IPathGenerator pathGenerator,
-    IIIFS3Service iiifS3) : IRequestHandler<GetManifest, FetchEntityResult<PresentationManifest>>
+    IManifestRead manifestRead) : IRequestHandler<GetManifest, FetchEntityResult<PresentationManifest>>
 {
-    public async Task<FetchEntityResult<PresentationManifest>> Handle(GetManifest request,
+    public Task<FetchEntityResult<PresentationManifest>> Handle(GetManifest request,
         CancellationToken cancellationToken)
-    {
-        var dbManifest =
-            await dbContext.RetrieveManifestAsync(request.CustomerId, request.Id, cancellationToken: cancellationToken);
-
-        if (dbManifest == null) return FetchEntityResult<PresentationManifest>.NotFound();
-
-        var fetchFullPath = ManifestRetrieval.RetrieveFullPathForManifest(dbManifest.Id, dbManifest.CustomerId,
-            dbContext, cancellationToken);
-
-        if (request.PathOnly)
-            return FetchEntityResult<PresentationManifest>.Success(new()
-            {
-                FullPath = pathGenerator.GenerateHierarchicalFromFullPath(request.CustomerId, await fetchFullPath)
-            });
-
-        var manifest = await iiifS3.ReadIIIFFromS3<PresentationManifest>(dbManifest, cancellationToken);
-        dbManifest.Hierarchy.Single().FullPath = await fetchFullPath;
-
-        // PK: Will this even happen? Should we log or even throw here?
-        if (manifest == null)
-            return FetchEntityResult<PresentationManifest>.Failure(
-                "Unable to read and deserialize manifest from storage");
-
-        manifest = manifest.SetGeneratedFields(dbManifest, pathGenerator, null,
-            m => m.Hierarchy!.Single(h => h.Canonical));
-
-        return FetchEntityResult<PresentationManifest>.Success(manifest);
-    }
+        => manifestRead.GetManifest(request.CustomerId, request.Id, request.PathOnly, cancellationToken);
 }

--- a/src/IIIFPresentation/API/Features/Manifest/Requests/UpsertManifest.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/Requests/UpsertManifest.cs
@@ -1,5 +1,4 @@
-﻿using API.Converters;
-using API.Infrastructure.Requests;
+﻿using API.Infrastructure.Requests;
 using MediatR;
 using Microsoft.Extensions.Primitives;
 using Models.API.General;
@@ -26,7 +25,7 @@ public class UpsertManifest(
     public bool CreateSpace { get; } = createSpace;
 }
 
-public class UpsertManifestHandler(ManifestService manifestService)
+public class UpsertManifestHandler(IManifestWrite manifestService)
     : IRequestHandler<UpsertManifest, ModifyEntityResult<PresentationManifest, ModifyCollectionType>>
 {
     public Task<ModifyEntityResult<PresentationManifest, ModifyCollectionType>> Handle(UpsertManifest request,

--- a/src/IIIFPresentation/API/Program.cs
+++ b/src/IIIFPresentation/API/Program.cs
@@ -59,7 +59,8 @@ builder.Services.AddDataAccess(builder.Configuration);
 builder.Services.AddCaching(cacheSettings);
 builder.Services
     .AddSingleton<IETagManager, ETagManager>()
-    .AddScoped<ManifestService>()
+    .AddScoped<IManifestWrite, ManifestWriteService>()
+    .AddScoped<IManifestRead, ManifestReadService>()
     .AddScoped<CanvasPaintingResolver>()
     .AddSingleton<ManifestItemsParser>()
     .AddSingleton<IPathGenerator, PathGenerator>()

--- a/src/IIIFPresentation/Test.Helpers/Helpers/DatabaseTestDataPopulation.cs
+++ b/src/IIIFPresentation/Test.Helpers/Helpers/DatabaseTestDataPopulation.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Models.Database;
 using Models.Database.Collections;
 using Models.Database.General;
+using Models.DLCS;
 
 namespace Test.Helpers.Helpers;
 
@@ -69,7 +70,7 @@ public static class DatabaseTestDataPopulation
     public static ValueTask<EntityEntry<CanvasPainting>> AddTestCanvasPainting(
         this DbSet<CanvasPainting> canvasPaintings, Manifest manifest, string? id = null, int? canvasOrder = null,
         int? choiceOrder = null, DateTime? createdDate = null, int? width = null, int? height = null,
-        Uri? canvasOriginalId = null, LanguageMap? label = null)
+        Uri? canvasOriginalId = null, LanguageMap? label = null, AssetId? assetId = null)
     {
         createdDate ??= DateTime.UtcNow;
         manifest.CanvasPaintings ??= [];
@@ -88,34 +89,9 @@ public static class DatabaseTestDataPopulation
             CustomerId = manifest.CustomerId,
             ManifestId = manifest.Id,
             Label = label,
+            AssetId = assetId,
         };
         manifest.CanvasPaintings.Add(canvasPainting);
         return canvasPaintings.AddAsync(canvasPainting);
-    }
-
-    public static CanvasPainting WithCanvasPainting(this EntityEntry<Manifest> entry,
-        string? id = null, int? canvasOrder = null, int? choiceOrder = null, DateTime? createdDate = null,
-        int? width = null, int? height = null, Uri? canvasOriginalId = null)
-    {
-        createdDate ??= DateTime.UtcNow;
-        var manifest = entry.Entity;
-        manifest.CanvasPaintings ??= [];
-
-        var canvasPaintingsCount = manifest.CanvasPaintings.Count;
-        var canvasPainting = new CanvasPainting
-        {
-            Id = string.IsNullOrEmpty(id) ? $"{manifest}_{canvasPaintingsCount + 1}" : id,
-            CanvasOrder = canvasOrder ?? canvasPaintingsCount,
-            ChoiceOrder = choiceOrder,
-            Created = createdDate.Value,
-            Modified = createdDate.Value,
-            StaticHeight = height,
-            StaticWidth = width,
-            CanvasOriginalId = canvasOriginalId,
-            CustomerId = manifest.CustomerId,
-            ManifestId = manifest.Id,
-        };
-        manifest.CanvasPaintings.Add(canvasPainting);
-        return canvasPainting;
     }
 }


### PR DESCRIPTION
Reason for change was to populate `"assets"` on manifest GET with full details from DLCS. 

Refactored some classes to accomodate this:
* Renamed `ManifestService` -> `ManifestWriteService` and introduced an interface
* Moves `GetAssets` from `ManifestService` to a new class, `ManifestReadService`, to allow it to be shared
* Refactored code from `GetManifest` handler into `ManifestReadService`, and updated it to call `GetAssets` to read Asset data from DLCS.