### PR TITLE
Don't set manifest thumbnail from named query

### DIFF
--- a/src/IIIFPresentation/BackgroundHandler/Helpers/ManifestMerger.cs
+++ b/src/IIIFPresentation/BackgroundHandler/Helpers/ManifestMerger.cs
@@ -1,5 +1,4 @@
-﻿using Core.Helpers;
-using IIIF.Presentation.V3;
+﻿using IIIF.Presentation.V3;
 using IIIF.Presentation.V3.Annotation;
 using IIIF.Presentation.V3.Content;
 using IIIF.Presentation.V3.Strings;
@@ -14,7 +13,7 @@ public static class ManifestMerger
     /// Merges a generated DLCS manifest with the current manifest in S3
     /// </summary>
     public static Manifest Merge(Manifest baseManifest, List<CanvasPainting>? canvasPaintings, 
-        Dictionary<AssetId, Canvas> canvasDictionary, List<ExternalResource>? thumbnail)
+        Dictionary<AssetId, Canvas> canvasDictionary)
     {
         if (baseManifest.Items == null) baseManifest.Items = [];
 
@@ -52,11 +51,6 @@ public static class ManifestMerger
                     }
                 }
             }
-        }
-
-        if (baseManifest.Thumbnail.IsNullOrEmpty())
-        {
-            baseManifest.Thumbnail = thumbnail;
         }
         
         return baseManifest;

--- a/src/IIIFPresentation/Models/DLCS/AssetId.cs
+++ b/src/IIIFPresentation/Models/DLCS/AssetId.cs
@@ -30,7 +30,7 @@ public class AssetId
     /// <summary>
     /// Create a new AssetId from string in format customer/space/image
     /// </summary>
-    public static AssetId? FromString(string assetImageId)
+    public static AssetId FromString(string assetImageId)
     {
         var parts = assetImageId.Split("/", StringSplitOptions.RemoveEmptyEntries);
         if (parts.Length != 3)


### PR DESCRIPTION
Fixes #250

Update background handler logic to never set the manifest-level thumbnail from NamedQuery.