### PR TITLE
Set correct 'id' in manifest saved to s3

### DIFF
--- a/src/IIIFPresentation/API.Tests/Converters/CollectionConverterTests.cs
+++ b/src/IIIFPresentation/API.Tests/Converters/CollectionConverterTests.cs
@@ -1,10 +1,10 @@
 ﻿using API.Converters;
-using API.Helpers;
 using API.Tests.Helpers;
 using IIIF.Presentation.V3.Strings;
 using Models.API.Collection;
 using Models.Database.Collections;
 using Models.Database.General;
+using Repository.Paths;
 
 #nullable disable
 

--- a/src/IIIFPresentation/API.Tests/Converters/ManifestConverterTests.cs
+++ b/src/IIIFPresentation/API.Tests/Converters/ManifestConverterTests.cs
@@ -1,9 +1,9 @@
 ﻿using API.Converters;
-using API.Helpers;
 using API.Tests.Helpers;
 using Models.API.Manifest;
 using Models.Database.General;
 using Models.DLCS;
+using Repository.Paths;
 using CanvasPainting = Models.Database.CanvasPainting;
 using DBManifest = Models.Database.Collections.Manifest;
 

--- a/src/IIIFPresentation/API.Tests/Converters/Streaming/S3StoredJsonProcessorTests.cs
+++ b/src/IIIFPresentation/API.Tests/Converters/Streaming/S3StoredJsonProcessorTests.cs
@@ -1,11 +1,9 @@
 ﻿using System.Text;
-using API.Converters;
 using API.Converters.Streaming;
-using API.Helpers;
 using API.Tests.Helpers;
 using LateApexEarlySpeed.Xunit.Assertion.Json;
-using Microsoft.AspNetCore.Http;
 using Models.Database.General;
+using Repository.Paths;
 
 namespace API.Tests.Converters.Streaming;
 

--- a/src/IIIFPresentation/API.Tests/Helpers/TestPathGenerator.cs
+++ b/src/IIIFPresentation/API.Tests/Helpers/TestPathGenerator.cs
@@ -7,7 +7,7 @@ namespace API.Tests.Helpers;
 
 public static class TestPathGenerator
 {
-    public static PathGenerator CreatePathGenerator(string baseUrl, string scheme)
+    public static HttpRequestBasedPathGenerator CreatePathGenerator(string baseUrl, string scheme)
         => new(new HttpContextAccessor
             {
                 HttpContext = new DefaultHttpContext

--- a/src/IIIFPresentation/API.Tests/Infrastructure/Validation/PresentationValidationTests.cs
+++ b/src/IIIFPresentation/API.Tests/Infrastructure/Validation/PresentationValidationTests.cs
@@ -1,10 +1,8 @@
-﻿using API.Converters;
-using API.Helpers;
-using API.Infrastructure.Validation;
+﻿using API.Infrastructure.Validation;
 using API.Tests.Helpers;
-using Microsoft.AspNetCore.Http;
 using Models.API;
 using Models.Database.Collections;
+using Repository.Paths;
 
 namespace API.Tests.Infrastructure.Validation;
 

--- a/src/IIIFPresentation/API/Converters/CollectionConverter.cs
+++ b/src/IIIFPresentation/API/Converters/CollectionConverter.cs
@@ -1,5 +1,4 @@
-﻿using API.Helpers;
-using Core.Helpers;
+﻿using Core.Helpers;
 using Core.IIIF;
 using IIIF.Presentation;
 using IIIF.Presentation.V3;
@@ -7,6 +6,7 @@ using IIIF.Presentation.V3.Content;
 using Models.API.Collection;
 using Models.Database.General;
 using Models.Infrastructure;
+using Repository.Paths;
 using Collection = IIIF.Presentation.V3.Collection;
 using Manifest = IIIF.Presentation.V3.Manifest;
 using DbCollection = Models.Database.Collections.Collection;

--- a/src/IIIFPresentation/API/Converters/ManifestConverter.cs
+++ b/src/IIIFPresentation/API/Converters/ManifestConverter.cs
@@ -7,6 +7,8 @@ using Models.API.Manifest;
 using Models.Database.Collections;
 using Models.Database.General;
 using Newtonsoft.Json.Linq;
+using Repository;
+using Repository.Paths;
 using CanvasPainting = Models.Database.CanvasPainting;
 
 namespace API.Converters;

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestReadService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestReadService.cs
@@ -1,6 +1,5 @@
 ﻿using API.Converters;
 using API.Features.Storage.Helpers;
-using API.Helpers;
 using API.Infrastructure.Requests;
 using AWS.Helpers;
 using DLCS.API;
@@ -11,6 +10,7 @@ using Models.Database.General;
 using Newtonsoft.Json.Linq;
 using Repository;
 using Repository.Helpers;
+using Repository.Paths;
 using DbManifest = Models.Database.Collections.Manifest;
 
 namespace API.Features.Manifest;

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
@@ -22,6 +22,7 @@ using Models.Database.General;
 using Newtonsoft.Json.Linq;
 using Repository;
 using Repository.Helpers;
+using Repository.Paths;
 using Collection = Models.Database.Collections.Collection;
 using DbManifest = Models.Database.Collections.Manifest;
 using PresUpdateResult = API.Infrastructure.Requests.ModifyEntityResult<Models.API.Manifest.PresentationManifest, Models.API.General.ModifyCollectionType>;

--- a/src/IIIFPresentation/API/Features/Manifest/Requests/GetManifestHierarchical.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/Requests/GetManifestHierarchical.cs
@@ -1,15 +1,14 @@
 ﻿using API.Converters.Streaming;
-using API.Helpers;
 using AWS.Helpers;
 using AWS.S3;
 using AWS.Settings;
 using Core.Streams;
 using MediatR;
 using Microsoft.Extensions.Options;
-using Models.Database.Collections;
 using Models.Database.General;
 using Repository;
 using Repository.Helpers;
+using Repository.Paths;
 
 namespace API.Features.Manifest.Requests;
 

--- a/src/IIIFPresentation/API/Features/Storage/CollectionController.cs
+++ b/src/IIIFPresentation/API/Features/Storage/CollectionController.cs
@@ -6,7 +6,6 @@ using API.Features.Storage.Helpers;
 using API.Features.Storage.Models;
 using API.Features.Storage.Requests;
 using API.Features.Storage.Validators;
-using API.Helpers;
 using API.Infrastructure;
 using API.Infrastructure.Filters;
 using API.Infrastructure.Helpers;
@@ -17,6 +16,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Models.API.Collection;
+using Repository.Paths;
 
 namespace API.Features.Storage;
 

--- a/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
@@ -2,7 +2,6 @@ using System.Data;
 using API.Converters;
 using API.Features.Storage.Helpers;
 using API.Features.Storage.Models;
-using API.Helpers;
 using API.Infrastructure.IdGenerator;
 using API.Infrastructure.Requests;
 using API.Infrastructure.Validation;
@@ -18,6 +17,7 @@ using Models.API.General;
 using Models.Database.General;
 using Repository;
 using Repository.Helpers;
+using Repository.Paths;
 using Collection = Models.Database.Collections.Collection;
 
 namespace API.Features.Storage.Requests;

--- a/src/IIIFPresentation/API/Features/Storage/Requests/GetCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/GetCollection.cs
@@ -1,11 +1,11 @@
 ﻿using API.Features.Storage.Helpers;
 using API.Features.Storage.Models;
-using API.Helpers;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Repository;
 using Repository.Collections;
 using Repository.Helpers;
+using Repository.Paths;
 
 namespace API.Features.Storage.Requests;
 

--- a/src/IIIFPresentation/API/Features/Storage/Requests/GetHierarchicalCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/GetHierarchicalCollection.cs
@@ -1,7 +1,6 @@
 ﻿using API.Converters.Streaming;
 using API.Features.Storage.Helpers;
 using API.Features.Storage.Models;
-using API.Helpers;
 using AWS.Helpers;
 using AWS.S3;
 using AWS.S3.Models;
@@ -12,6 +11,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using Models.Database.General;
 using Repository;
+using Repository.Paths;
 
 namespace API.Features.Storage.Requests;
 

--- a/src/IIIFPresentation/API/Features/Storage/Requests/PostHierarchicalCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/PostHierarchicalCollection.cs
@@ -1,6 +1,5 @@
 ﻿using System.Data;
 using API.Features.Storage.Helpers;
-using API.Helpers;
 using API.Infrastructure.IdGenerator;
 using API.Infrastructure.Requests;
 using AWS.Helpers;
@@ -14,6 +13,7 @@ using Models.API.General;
 using Models.Database.General;
 using Repository;
 using Repository.Helpers;
+using Repository.Paths;
 using DatabaseCollection = Models.Database.Collections;
 
 namespace API.Features.Storage.Requests;

--- a/src/IIIFPresentation/API/Features/Storage/Requests/UpsertCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/UpsertCollection.cs
@@ -20,6 +20,7 @@ using Models.Database.Collections;
 using Models.Database.General;
 using Repository;
 using Repository.Helpers;
+using Repository.Paths;
 
 namespace API.Features.Storage.Requests;
 

--- a/src/IIIFPresentation/API/Features/Storage/StorageController.cs
+++ b/src/IIIFPresentation/API/Features/Storage/StorageController.cs
@@ -3,7 +3,6 @@ using API.Auth;
 using API.Converters;
 using API.Features.Manifest.Requests;
 using API.Features.Storage.Requests;
-using API.Helpers;
 using API.Infrastructure;
 using API.Infrastructure.Filters;
 using API.Infrastructure.Helpers;
@@ -19,6 +18,7 @@ using Microsoft.Extensions.Options;
 using Models.Database.General;
 using Repository;
 using Repository.Helpers;
+using Repository.Paths;
 
 namespace API.Features.Storage;
 

--- a/src/IIIFPresentation/API/Helpers/HttpRequestBasedPathGenerator.cs
+++ b/src/IIIFPresentation/API/Helpers/HttpRequestBasedPathGenerator.cs
@@ -1,0 +1,13 @@
+﻿using API.Infrastructure.Requests;
+using DLCS;
+using Microsoft.Extensions.Options;
+using Repository.Paths;
+
+namespace API.Helpers;
+
+public class HttpRequestBasedPathGenerator(IHttpContextAccessor contextAccessor, IOptions<DlcsSettings> dlcsOptions)
+    : PathGeneratorBase
+{
+    protected override string PresentationUrl { get; } = contextAccessor.HttpContext!.Request.GetBaseUrl();
+    protected override Uri DlcsApiUrl { get; } = dlcsOptions.Value.ApiUri;
+}

--- a/src/IIIFPresentation/API/Infrastructure/Validation/PresentationValidation.cs
+++ b/src/IIIFPresentation/API/Infrastructure/Validation/PresentationValidation.cs
@@ -1,7 +1,6 @@
-﻿using API.Converters;
-using API.Helpers;
-using Models.API;
+﻿using Models.API;
 using Models.Database.Collections;
+using Repository.Paths;
 
 namespace API.Infrastructure.Validation;
 

--- a/src/IIIFPresentation/API/Program.cs
+++ b/src/IIIFPresentation/API/Program.cs
@@ -15,6 +15,7 @@ using Microsoft.AspNetCore.Rewrite;
 using Newtonsoft.Json;
 using Repository;
 using Repository.Manifests;
+using Repository.Paths;
 using Serilog;
 
 const string corsPolicyName = "CorsPolicy";
@@ -63,7 +64,7 @@ builder.Services
     .AddScoped<IManifestRead, ManifestReadService>()
     .AddScoped<CanvasPaintingResolver>()
     .AddSingleton<ManifestItemsParser>()
-    .AddSingleton<IPathGenerator, PathGenerator>()
+    .AddSingleton<IPathGenerator, HttpRequestBasedPathGenerator>()
     .AddHttpContextAccessor()
     .AddOutgoingHeaders();
 builder.Services.ConfigureMediatR();

--- a/src/IIIFPresentation/AWS.Tests/Helpers/BucketHelperTests.cs
+++ b/src/IIIFPresentation/AWS.Tests/Helpers/BucketHelperTests.cs
@@ -1,0 +1,35 @@
+﻿using AWS.Helpers;
+using FluentAssertions;
+
+namespace AWS.Tests.Helpers;
+
+public class BucketHelperTests
+{
+    [Fact]
+    public void GetResourceBucketKey_Collection_Correct()
+    {
+        // Arrange
+        var collection = new Models.Database.Collections.Collection { CustomerId = 99, Id = "parting-ways" };
+        const string expected = "99/collections/parting-ways";
+        
+        // Act
+        var actual = collection.GetResourceBucketKey();
+        
+        // Assert
+        actual.Should().Be(expected);
+    }
+    
+    [Fact]
+    public void GetResourceBucketKey_Manifest_Correct()
+    {
+        // Arrange
+        var collection = new Models.Database.Collections.Manifest { CustomerId = 99, Id = "parting-ways" };
+        const string expected = "99/manifests/parting-ways";
+        
+        // Act
+        var actual = collection.GetResourceBucketKey();
+        
+        // Assert
+        actual.Should().Be(expected);
+    }
+}

--- a/src/IIIFPresentation/BackgroundHandler/Helpers/SettingsBasedPathGenerator.cs
+++ b/src/IIIFPresentation/BackgroundHandler/Helpers/SettingsBasedPathGenerator.cs
@@ -1,0 +1,17 @@
+﻿using BackgroundHandler.Settings;
+using DLCS;
+using Microsoft.Extensions.Options;
+using Repository.Paths;
+
+namespace BackgroundHandler.Helpers;
+
+/// <summary>
+/// Implementation of <see cref="PathGeneratorBase"/> using settings for base urls
+/// </summary>
+public class SettingsBasedPathGenerator(
+    IOptions<DlcsSettings> dlcsOptions,
+    IOptions<BackgroundHandlerSettings> backgroundHandlerOptions) : PathGeneratorBase
+{
+    protected override string PresentationUrl { get; } = backgroundHandlerOptions.Value.PresentationApiUrl;
+    protected override Uri DlcsApiUrl { get; } = dlcsOptions.Value.ApiUri;
+}

--- a/src/IIIFPresentation/BackgroundHandler/Program.cs
+++ b/src/IIIFPresentation/BackgroundHandler/Program.cs
@@ -1,7 +1,9 @@
 ﻿using AWS.Settings;
+using BackgroundHandler.Helpers;
 using BackgroundHandler.Infrastructure;
 using BackgroundHandler.Settings;
 using DLCS;
+using Repository.Paths;
 using Serilog;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -25,9 +27,9 @@ var dlcs = dlcsSettings.Get<DlcsSettings>()!;
     
 builder.Services.AddAws(builder.Configuration, builder.Environment)
     .AddDataAccess(builder.Configuration)
-    .AddHttpContextAccessor()
     .AddDlcsOrchestratorClient(dlcs)
     .AddBackgroundServices(aws)
+    .AddSingleton<IPathGenerator, SettingsBasedPathGenerator>()
     .Configure<DlcsSettings>(dlcsSettings);
 
 var app = builder.Build();

--- a/src/IIIFPresentation/BackgroundHandler/appsettings.Example.json
+++ b/src/IIIFPresentation/BackgroundHandler/appsettings.Example.json
@@ -1,0 +1,19 @@
+{
+  "AWS": {
+    "Profile": "dlcs",
+    "Region": "eu-west-1",
+    "S3": {
+      "StorageBucket": "presentation-bucket"
+    },
+    "SQS": {
+      "BatchCompletionQueueName": "batch-completion"
+    }
+  },
+  "ConnectionStrings": {
+    "PostgreSQLConnection": "Server=127.0.0.1;Port=5452;Database=postgres;User Id=postgres;Password=presentation_password;IncludeErrorDetail=True"
+  },
+  "PresentationApiUrl": "https://localhost:7230",
+  "DLCS": {
+    "ApiUri": "https://api.dlcs.digirati.io"
+  }
+}

--- a/src/IIIFPresentation/Repository.Tests/Paths/PathGeneratorTests.cs
+++ b/src/IIIFPresentation/Repository.Tests/Paths/PathGeneratorTests.cs
@@ -1,15 +1,14 @@
-﻿using API.Helpers;
-using AWS.Helpers;
-using Models.Database;
+﻿using Models.Database;
 using Models.Database.Collections;
 using Models.Database.General;
 using Models.DLCS;
+using Repository.Paths;
 
-namespace API.Tests.Helpers;
+namespace Repository.Tests.Paths;
 
 public class PathGeneratorTests
 {
-    private readonly IPathGenerator pathGenerator = TestPathGenerator.CreatePathGenerator("base", Uri.UriSchemeHttp);
+    private readonly IPathGenerator pathGenerator = new TestPathGenerator();
 
     [Fact]
     public void GenerateHierarchicalCollectionId_CreatesIdWhenNoFullPath()
@@ -228,34 +227,6 @@ public class PathGeneratorTests
         id.Should().Be("http://base/0/collections/test?page=1&pageSize=10&test");
     }
 
-    [Fact]
-    public void GetResourceBucketKey_Collection_Correct()
-    {
-        // Arrange
-        var collection = new Collection { CustomerId = 99, Id = "parting-ways" };
-        const string expected = "99/collections/parting-ways";
-        
-        // Act
-        var actual = collection.GetResourceBucketKey();
-        
-        // Assert
-        actual.Should().Be(expected);
-    }
-    
-    [Fact]
-    public void GetResourceBucketKey_Manifest_Correct()
-    {
-        // Arrange
-        var collection = new Manifest { CustomerId = 99, Id = "parting-ways" };
-        const string expected = "99/manifests/parting-ways";
-        
-        // Act
-        var actual = collection.GetResourceBucketKey();
-        
-        // Assert
-        actual.Should().Be(expected);
-    }
-
     [Theory]
     [InlineData("")]
     [InlineData(null)]
@@ -407,4 +378,10 @@ public class PathGeneratorTests
     }
     
     private static List<Hierarchy> GetDefaultHierarchyList() =>  [ new() { Slug = "slug" } ];
+}
+
+public class TestPathGenerator : PathGeneratorBase
+{
+    protected override string PresentationUrl => "http://base";
+    protected override Uri DlcsApiUrl => new("https://dlcs.test");
 }

--- a/src/IIIFPresentation/Repository/Paths/IPathGenerator.cs
+++ b/src/IIIFPresentation/Repository/Paths/IPathGenerator.cs
@@ -2,7 +2,7 @@
 using Models.Database.Collections;
 using Models.Database.General;
 
-namespace API.Helpers;
+namespace Repository.Paths;
 
 public interface IPathGenerator
 {

--- a/src/IIIFPresentation/Repository/Paths/PathGeneratorBase.cs
+++ b/src/IIIFPresentation/Repository/Paths/PathGeneratorBase.cs
@@ -1,53 +1,50 @@
-﻿using API.Infrastructure.Requests;
-using DLCS;
-using DLCS.Models;
-using Microsoft.Extensions.Options;
+﻿using Models.Database;
 using Models.Database.Collections;
 using Models.Database.General;
-using Models.DLCS;
-using CanvasPainting = Models.Database.CanvasPainting;
 
-namespace API.Helpers;
+namespace Repository.Paths;
 
-public class PathGenerator : IPathGenerator
+public abstract class PathGeneratorBase : IPathGenerator
 {
     private const string ManifestsSlug = "manifests";
     private const string CollectionsSlug = "collections";
     private const string CanvasesSlug = "canvases";
-    private readonly string baseUrl;
-    private readonly DlcsSettings dlcsSettings;
-
-    public PathGenerator(IHttpContextAccessor contextAccessor, IOptions<DlcsSettings> dlcsOptions)
-    {
-         baseUrl = contextAccessor.HttpContext!.Request.GetBaseUrl();
-         dlcsSettings = dlcsOptions.Value;
-    }
+    
+    /// <summary>
+    /// Base url for IIIF Presentation
+    /// </summary>
+    protected abstract string PresentationUrl { get; }
+    
+    /// <summary>
+    /// Base url for DLCS Protagonist API
+    /// </summary>
+    protected abstract Uri DlcsApiUrl { get; }
     
     public string GenerateHierarchicalCollectionId(Collection collection) =>
-        $"{baseUrl}/{collection.CustomerId}{(string.IsNullOrEmpty(collection.FullPath) ? string.Empty : $"/{collection.FullPath}")}";
+        $"{PresentationUrl}/{collection.CustomerId}{(string.IsNullOrEmpty(collection.FullPath) ? string.Empty : $"/{collection.FullPath}")}";
 
     public string GenerateHierarchicalFromFullPath(int customerId, string? fullPath) =>
-        $"{baseUrl}/{customerId}{(fullPath is {Length: > 0} ? $"/{fullPath}" : string.Empty)}";
+        $"{PresentationUrl}/{customerId}{(fullPath is {Length: > 0} ? $"/{fullPath}" : string.Empty)}";
 
     public string GenerateHierarchicalCollectionParent(Collection collection, Hierarchy hierarchy)
     {
         var parentPath = collection.FullPath![..^hierarchy.Slug.Length].TrimEnd('/');
 
         return
-            $"{baseUrl}/{collection.CustomerId}{(string.IsNullOrEmpty(parentPath) ? string.Empty : $"/{parentPath}")}";
+            $"{PresentationUrl}/{collection.CustomerId}{(string.IsNullOrEmpty(parentPath) ? string.Empty : $"/{parentPath}")}";
     }
 
     public string GenerateFlatCollectionId(Collection collection) => 
-        $"{baseUrl}/{collection.CustomerId}/collections/{collection.Id}";
+        $"{PresentationUrl}/{collection.CustomerId}/collections/{collection.Id}";
     
     public string GenerateHierarchicalId(Hierarchy hierarchy) =>
         GenerateHierarchicalFromFullPath(hierarchy.CustomerId, hierarchy.FullPath);
     
     public string GenerateFlatId(Hierarchy hierarchy) =>
-        $"{baseUrl}/{hierarchy.CustomerId}/{GetSlug(hierarchy.Type)}/{hierarchy.ResourceId}";
+        $"{PresentationUrl}/{hierarchy.CustomerId}/{GetSlug(hierarchy.Type)}/{hierarchy.ResourceId}";
     
     public string GenerateFlatParentId(Hierarchy hierarchy) =>
-        $"{baseUrl}/{hierarchy.CustomerId}/{CollectionsSlug}/{hierarchy.Parent}";
+        $"{PresentationUrl}/{hierarchy.CustomerId}/{CollectionsSlug}/{hierarchy.Parent}";
     
     public string GenerateFlatCollectionViewId(Collection collection, int currentPage, int pageSize, 
         string? orderQueryParam) =>
@@ -69,7 +66,7 @@ public class PathGenerator : IPathGenerator
     
     public Uri GenerateFlatCollectionViewLast(Collection collection, int lastPage, int pageSize, 
         string orderQueryParam) => new(
-            $"{GenerateFlatCollectionId(collection)}?page={lastPage}&pageSize={pageSize}{orderQueryParam}");
+        $"{GenerateFlatCollectionId(collection)}?page={lastPage}&pageSize={pageSize}{orderQueryParam}");
     
     public string GenerateFullPath(Hierarchy collection, Collection parent)
         => GenerateFullPath(collection, parent.FullPath);
@@ -78,16 +75,16 @@ public class PathGenerator : IPathGenerator
         => $"{(!string.IsNullOrEmpty(parentPath) ? $"{parentPath}/" : string.Empty)}{hierarchy.Slug}";
     
     public string GenerateFlatManifestId(Manifest manifest) =>
-        $"{baseUrl}/{manifest.CustomerId}/{ManifestsSlug}/{manifest.Id}";
+        $"{PresentationUrl}/{manifest.CustomerId}/{ManifestsSlug}/{manifest.Id}";
 
     public string GenerateCanvasId(CanvasPainting canvasPainting)
-        => $"{baseUrl}/{canvasPainting.CustomerId}/{CanvasesSlug}/{canvasPainting.Id}";
+        => $"{PresentationUrl}/{canvasPainting.CustomerId}/{CanvasesSlug}/{canvasPainting.Id}";
     
     public Uri? GenerateSpaceUri(Manifest manifest)
     {
         if (!manifest.SpaceId.HasValue) return null;
 
-        var uriBuilder = new UriBuilder(dlcsSettings.ApiUri)
+        var uriBuilder = new UriBuilder(DlcsApiUrl)
         {
             Path = $"/customers/{manifest.CustomerId}/spaces/{manifest.SpaceId}",
         };
@@ -98,7 +95,7 @@ public class PathGenerator : IPathGenerator
     {
         if (canvasPainting.AssetId == null) return null;
         
-        var uriBuilder = new UriBuilder(dlcsSettings.ApiUri)
+        var uriBuilder = new UriBuilder(DlcsApiUrl)
         {
             Path = $"/customers/{canvasPainting.AssetId.Customer}/spaces/{canvasPainting.AssetId.Space}/images/{canvasPainting.AssetId.Asset}",
         };


### PR DESCRIPTION
The final Manifest saved to S3 by the `BackgroundHandler` had the incorrect path - it was using the hierarchical path, rather than the flat path. It was also building the path manually, rather than using `IPathGenerator` logic. Noticed when fixing #250 (PR #260).

Fix involved:

* Moving `IPathGenerator` to `Repository` project
* Adding `abstract class PathGeneratorBase : IPathGenerator`. This has the logic for building paths and requires 2 props - `PresentationUrl` and `DlcsApiUrl`
* Adding `HttpRequestBasedPathGenerator : PathGeneratorBase`, which uses current http context as `PresentationUrl` (this replaces the previous `PathGenerator` in `API`
* Adding `SettingsBasedPathGenerator : PathGeneratorBase`, which is new for `BackgroundHandler` and uses appSettings for `PresentationUrl`

Both implementations of `PathGeneratorBase` use appSettings for `DlcsApiUrl`. The `id` value is rewritten on the way out so there won't be any end-user changes but felt like tech debt that was worth resolving.