### PR TITLE
Adding ingesting property onto a manifest

### DIFF
--- a/src/IIIFPresentation/API.Tests/Integration/GetManifestTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/GetManifestTests.cs
@@ -31,6 +31,9 @@ public class GetManifestTests : IClassFixture<PresentationAppFactory<Program>>
     private readonly IDlcsApiClient dlcsApiClient;
     private readonly IAmazonS3 s3;
     private readonly JObject sampleAsset;
+    private const string ErrorPaintedResource = "errorPaintedResource";
+    private const string PaintedResource = "foo-paintedResource";
+    private const string IngestingPaintedResource = "ingestingPaintedResource";
 
     public GetManifestTests(StorageFixture storageFixture, PresentationAppFactory<Program> factory)
     {
@@ -52,15 +55,55 @@ public class GetManifestTests : IClassFixture<PresentationAppFactory<Program>>
                    "@id": "https://localhost:7230/customers/1/spaces/2/images/foo-paintedResource",
                    "@type": "vocab:Image",
                    "id": "foo-paintedResource",
+                   "ingesting": false,
                    "space": 1
                  }
             """
         );
+        
+        var errorAsset = JObject.Parse(
+            """
+            {
+                   "@context": "https://localhost/contexts/Image.jsonld",
+                   "@id": "https://localhost:7230/customers/1/spaces/2/images/errorPaintedResource",
+                   "@type": "vocab:Image",
+                   "id": "errorPaintedResource",
+                   "error": "random error",
+                   "space": 1
+                 }
+            """
+        );
+        
+        var ingestingAsset = JObject.Parse(
+            """
+            {
+                   "@context": "https://localhost/contexts/Image.jsonld",
+                   "@id": "https://localhost:7230/customers/1/spaces/2/images/foo-paintedResource",
+                   "@type": "vocab:Image",
+                   "id": "ingestingPaintedResource",
+                   "ingesting": true,
+                   "space": 1
+                 }
+            """
+        );
+        
         A.CallTo(() => dlcsApiClient.GetCustomerImages(PresentationContextFixture.CustomerId,
                 A<IList<string>>.That.Matches(l =>
-                    l.Any(x => "1/2/foo-paintedResource".Equals(x))),
+                    l.Any(x => $"1/2/{PaintedResource}".Equals(x))),
                 A<CancellationToken>._))
             .ReturnsLazily(() => [sampleAsset]);
+        
+        A.CallTo(() => dlcsApiClient.GetCustomerImages(PresentationContextFixture.CustomerId,
+                A<IList<string>>.That.Matches(l =>
+                    l.Any(x => $"1/2/{ErrorPaintedResource}".Equals(x))),
+                A<CancellationToken>._))
+            .ReturnsLazily(() => [errorAsset]);
+        
+        A.CallTo(() => dlcsApiClient.GetCustomerImages(PresentationContextFixture.CustomerId,
+                A<IList<string>>.That.Matches(l =>
+                    l.Any(x => $"1/2/{IngestingPaintedResource}".Equals(x))),
+                A<CancellationToken>._))
+            .ReturnsLazily(() => [ingestingAsset]);
     }
 
     [Fact]
@@ -105,7 +148,7 @@ public class GetManifestTests : IClassFixture<PresentationAppFactory<Program>>
         // Arrange - add manifest with 1 canvasPainting with an asset and corresponding manifest in S3
         var id = nameof(Get_IiifManifest_Flat_ReturnsManifestFromS3_DecoratedWithPaintedResources);
         var dbManifest = await dbContext.Manifests.AddTestManifest(id);
-        var assetId = new AssetId(1, 2, "foo-paintedResource");
+        var assetId = new AssetId(1, 2, PaintedResource);
         await dbContext.CanvasPaintings.AddTestCanvasPainting(dbManifest.Entity, label: new LanguageMap("en", "foo"),
             assetId: assetId);
         await dbContext.SaveChangesAsync();
@@ -129,6 +172,49 @@ public class GetManifestTests : IClassFixture<PresentationAppFactory<Program>>
         var paintedResource = manifest.PaintedResources.Single();
         paintedResource.CanvasPainting.Label.Should().BeEquivalentTo(new LanguageMap("en", "foo"));
         paintedResource.Asset.Should().BeEquivalentTo(sampleAsset);
+        manifest.Ingesting.Should().BeEquivalentTo(new Ingesting
+        {
+            Total = 1,
+            Finished = 1,
+            Errors = 0
+        });
+    }
+    
+    [Fact]
+    public async Task Get_IiifManifest_Flat_ReturnsManifestFromS3_DecoratedWithPaintedResourcesWithErrorIngesting()
+    {
+        // Arrange - add manifest with 1 canvasPainting with an asset and corresponding manifest in S3
+        var id = nameof(Get_IiifManifest_Flat_ReturnsManifestFromS3_DecoratedWithPaintedResourcesWithErrorIngesting);
+        var dbManifest = await dbContext.Manifests.AddTestManifest(id);
+        var assetId = new AssetId(1, 2, ErrorPaintedResource);
+        await dbContext.CanvasPaintings.AddTestCanvasPainting(dbManifest.Entity, label: new LanguageMap("en", "foo"),
+            assetId: assetId);
+        await dbContext.SaveChangesAsync();
+        await s3.PutObjectAsync(new()
+        {
+            BucketName = LocalStackFixture.StorageBucketName,
+            Key = $"1/manifests/{id}",
+            ContentBody = TestContent.ManifestJson,
+        });
+
+        var requestMessage =
+            HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get, $"1/manifests/{id}");
+        var response = await httpClient.AsCustomer().SendAsync(requestMessage);
+
+        // Act
+        var manifest = await response.ReadAsPresentationJsonAsync<PresentationManifest>();
+
+        // Assert
+        manifest.Should().NotBeNull();
+        manifest.PaintedResources.Should().HaveCount(1);
+        var paintedResource = manifest.PaintedResources.Single();
+        paintedResource.CanvasPainting.Label.Should().BeEquivalentTo(new LanguageMap("en", "foo"));
+        manifest.Ingesting.Should().BeEquivalentTo(new Ingesting
+        {
+            Total = 1,
+            Finished = 0,
+            Errors = 1
+        });
     }
 
     [Fact]
@@ -166,7 +252,17 @@ public class GetManifestTests : IClassFixture<PresentationAppFactory<Program>>
         var id = nameof(Get_IiifManifest_Flat_ReturnsAccepted_WhenIngesting);
 
         // Arrange and Act
-        await dbContext.Manifests.AddTestManifest(id, batchId: 1);
+        var dbManifest = await dbContext.Manifests.AddTestManifest(id, batchId: 1);
+        await dbContext.CanvasPaintings.AddTestCanvasPainting(dbManifest.Entity,
+            createdDate: DateTime.UtcNow.AddDays(-1),
+            assetId: new AssetId(1, 2, PaintedResource),
+            height: 1800, width: 1200,
+            canvasOriginalId: new Uri("https://iiif.io/api/eclipse"));
+        await dbContext.CanvasPaintings.AddTestCanvasPainting(dbManifest.Entity,
+            createdDate: DateTime.UtcNow.AddDays(-1),
+            assetId: new AssetId(1, 2, IngestingPaintedResource),
+            height: 1800, width: 1200,
+            canvasOriginalId: new Uri("https://iiif.io/api/eclipse"));
 
         await amazonS3.PutObjectAsync(new()
         {
@@ -193,6 +289,12 @@ public class GetManifestTests : IClassFixture<PresentationAppFactory<Program>>
         manifest.Items.Should().HaveCount(3, "the test content contains 3 children");
         manifest.FlatId.Should().Be(id);
         manifest.PublicId.Should().Be($"http://localhost/1/sm_{id}", "iiif-manifest is slug and under root");
+        manifest.Ingesting.Should().BeEquivalentTo(new Ingesting
+        {
+            Total = 1,
+            Finished = 0,
+            Errors = 0
+        });
     }
 
     [Fact]

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
@@ -446,6 +446,12 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
         responseManifest.CreatedBy.Should().Be("Admin");
         responseManifest.Slug.Should().Be(slug);
         responseManifest.Parent.Should().Be($"http://localhost/1/collections/{RootCollection.Id}");
+        responseManifest.Ingesting.Should().BeEquivalentTo(new Ingesting
+        {
+            Total = 1,
+            Errors = 0,
+            Finished = 0
+        });
 
         responseManifest.PaintedResources.Should().NotBeNull();
         responseManifest.PaintedResources.Should().HaveCount(1);

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
@@ -446,7 +446,7 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
         responseManifest.CreatedBy.Should().Be("Admin");
         responseManifest.Slug.Should().Be(slug);
         responseManifest.Parent.Should().Be($"http://localhost/1/collections/{RootCollection.Id}");
-        responseManifest.Ingesting.Should().BeEquivalentTo(new Ingesting
+        responseManifest.Ingesting.Should().BeEquivalentTo(new IngestingAssets
         {
             Total = 1,
             Errors = 0,

--- a/src/IIIFPresentation/API/Converters/ManifestConverter.cs
+++ b/src/IIIFPresentation/API/Converters/ManifestConverter.cs
@@ -7,6 +7,7 @@ using IIIF.Presentation.V3;
 using IIIF.Presentation.V3.Annotation;
 using IIIF.Presentation.V3.Content;
 using Models.API.Manifest;
+using Models.Database.Collections;
 using Models.Database.General;
 using Models.Infrastructure;
 using Newtonsoft.Json.Linq;
@@ -52,7 +53,10 @@ public static class ManifestConverter
         // Note ??= - this is only if we don't yet have Items set by background process
         iiifManifest.Items ??= GenerateProvisionalItems(iiifManifest.PaintedResources);
 
-        iiifManifest.Ingesting = GenerateIngesting(assets);
+        if (dbManifest.IsIngesting())
+        {
+            iiifManifest.Ingesting = GenerateIngesting(assets);
+        }
         
         iiifManifest.EnsurePresentation3Context();
         iiifManifest.EnsureContext(PresentationJsonLdContext.Context);
@@ -168,11 +172,11 @@ public static class ManifestConverter
             };
     }
     
-    private static Ingesting? GenerateIngesting(Dictionary<string, JObject>? assets)
+    private static IngestingAssets? GenerateIngesting(Dictionary<string, JObject>? assets)
     {
         if (assets == null) return null;
         
-        var ingesting = new Ingesting();
+        var ingesting = new IngestingAssets();
 
         foreach (var asset in assets)
         {

--- a/src/IIIFPresentation/API/Converters/ManifestConverter.cs
+++ b/src/IIIFPresentation/API/Converters/ManifestConverter.cs
@@ -51,6 +51,8 @@ public static class ManifestConverter
 
         // Note ??= - this is only if we don't yet have Items set by background process
         iiifManifest.Items ??= GenerateProvisionalItems(iiifManifest.PaintedResources);
+
+        iiifManifest.Ingesting = GenerateIngesting(assets);
         
         iiifManifest.EnsurePresentation3Context();
         iiifManifest.EnsureContext(PresentationJsonLdContext.Context);
@@ -164,5 +166,28 @@ public static class ManifestConverter
                 ["@id"] = fullAssetId,
                 ["error"] = "Asset not found"
             };
+    }
+    
+    private static Ingesting? GenerateIngesting(Dictionary<string, JObject>? assets)
+    {
+        if (assets == null) return null;
+        
+        var ingesting = new Ingesting();
+
+        foreach (var asset in assets)
+        {
+            ingesting.Total++;
+            
+            if (asset.Value.TryGetValue("finished", out _)) ingesting.Finished++;
+            if (asset.Value.TryGetValue("error", out var error))
+            {
+                if (!string.IsNullOrEmpty(error.Value<string>()))
+                {
+                    ingesting.Errors++;
+                }
+            }
+        }
+        
+        return ingesting;
     }
 }

--- a/src/IIIFPresentation/API/Converters/ManifestConverter.cs
+++ b/src/IIIFPresentation/API/Converters/ManifestConverter.cs
@@ -177,14 +177,19 @@ public static class ManifestConverter
         foreach (var asset in assets)
         {
             ingesting.Total++;
-            
-            if (asset.Value.TryGetValue("finished", out _)) ingesting.Finished++;
-            if (asset.Value.TryGetValue("error", out var error))
+
+            if (asset.Value.TryGetValue("ingesting", out var currentlyIngesting))
             {
-                if (!string.IsNullOrEmpty(error.Value<string>()))
+                if (!currentlyIngesting.Value<bool>())
                 {
-                    ingesting.Errors++;
+                    ingesting.Finished++;
                 }
+            }
+
+            if (!asset.Value.TryGetValue("error", out var error)) continue;
+            if (!string.IsNullOrEmpty(error.Value<string>()))
+            {
+                ingesting.Errors++;
             }
         }
         

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestController.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestController.cs
@@ -43,7 +43,7 @@ public class ManifestController(IOptions<ApiSettings> options, IAuthenticator au
                 ? SeeOther(fullPath)
                 : this.PresentationNotFound();
 
-        return entityResult.Entity!.Ingesting
+        return entityResult.Entity!.CurrentlyIngesting
             ? this.PresentationWithBodyResponse(Request.GetDisplayUrl(), entityResult.Entity,
                 (int)HttpStatusCode.Accepted)
             : Ok(entityResult.Entity);

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestReadService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestReadService.cs
@@ -99,7 +99,7 @@ public class ManifestReadService(
 
         if (dbManifest.IsIngesting())
         {
-            manifest.Ingesting = true;
+            manifest.CurrentlyIngesting = true;
         }
 
         return FetchEntityResult<PresentationManifest>.Success(manifest);

--- a/src/IIIFPresentation/Models/API/Manifest/PresentationManifest.cs
+++ b/src/IIIFPresentation/Models/API/Manifest/PresentationManifest.cs
@@ -23,10 +23,16 @@ public class PresentationManifest : IIIF.Presentation.V3.Manifest, IPresentation
 
     [JsonProperty(Order = 13)] public string? Space { get; set; }
     
-    [JsonProperty(Order = 14)] public Ingesting? Ingesting { get; set; }
+    /// <summary>
+    /// Contains details of the ingestion progress
+    /// </summary>
+    [JsonProperty(Order = 14)] public IngestingAssets? Ingesting { get; set; }
 
     [JsonIgnore] public string? FullPath { get; set; }
     
+    /// <summary>
+    /// Whether this manifest contains items that are currently being ingested
+    /// </summary>
     [JsonIgnore] public bool CurrentlyIngesting { get; set; }
 }
 
@@ -60,7 +66,7 @@ public class CanvasPainting
     public int? StaticHeight { get; set; }
 }
 
-public class Ingesting
+public class IngestingAssets
 {
     public int Total { get; set; }
     public int Finished { get; set; }

--- a/src/IIIFPresentation/Models/API/Manifest/PresentationManifest.cs
+++ b/src/IIIFPresentation/Models/API/Manifest/PresentationManifest.cs
@@ -22,10 +22,12 @@ public class PresentationManifest : IIIF.Presentation.V3.Manifest, IPresentation
     public List<PaintedResource>? PaintedResources { get; set; }
 
     [JsonProperty(Order = 13)] public string? Space { get; set; }
+    
+    [JsonProperty(Order = 14)] public Ingesting? Ingesting { get; set; }
 
     [JsonIgnore] public string? FullPath { get; set; }
     
-    [JsonIgnore] public bool Ingesting { get; set; }
+    [JsonIgnore] public bool CurrentlyIngesting { get; set; }
 }
 
 /// <summary>
@@ -56,4 +58,11 @@ public class CanvasPainting
     public string? Target { get; set; }
     public int? StaticWidth { get; set; }
     public int? StaticHeight { get; set; }
+}
+
+public class Ingesting
+{
+    public int Total { get; set; }
+    public int Finished { get; set; }
+    public int Errors { get; set; }
 }


### PR DESCRIPTION
Resolves #202

This PR adds the `ingesting` property to a manifest, which should look something like this:

```
"ingesting": {
  "total": 10,
  "finished": 7,
  "error": 1
}
```