### PR TITLE
Update iiif-net to the latest version

### DIFF
--- a/src/IIIFPresentation/API/API.csproj
+++ b/src/IIIFPresentation/API/API.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.10.0" />
-        <PackageReference Include="iiif-net" Version="0.3.1" />
+        <PackageReference Include="iiif-net" Version="0.3.2" />
         <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.8" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.7" />

--- a/src/IIIFPresentation/Core/Core.csproj
+++ b/src/IIIFPresentation/Core/Core.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="iiif-net" Version="0.3.1" />
+      <PackageReference Include="iiif-net" Version="0.3.2" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>
 

--- a/src/IIIFPresentation/Models/Models.csproj
+++ b/src/IIIFPresentation/Models/Models.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="iiif-net" Version="0.3.1" />
+      <PackageReference Include="iiif-net" Version="0.3.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/IIIFPresentation/Repository/Repository.csproj
+++ b/src/IIIFPresentation/Repository/Repository.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="EFCore.NamingConventions" Version="8.0.3" />
-        <PackageReference Include="iiif-net" Version="0.3.1" />
+        <PackageReference Include="iiif-net" Version="0.3.2" />
         <PackageReference Include="MediatR" Version="12.4.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.4" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />


### PR DESCRIPTION
Resolves #251
Resolves #253

This PR updates iiif-net to the latest version, which has support for `navPlace` and better handling of  a `TextualBody` within an `Annotation`