### PR TITLE
Require eTag when updating collection

### DIFF
--- a/src/IIIFPresentation/API/Features/Storage/Requests/UpsertCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/UpsertCollection.cs
@@ -115,7 +115,7 @@ public class UpsertCollectionHandler(
         {
             eTagManager.TryGetETag($"/{request.CustomerId}/collections/{request.CollectionId}", out var eTag);
 
-            if (request.ETag != eTag) return ErrorHelper.EtagNonMatching<PresentationCollection>();
+            if (request.ETag != eTag || string.IsNullOrEmpty(request.ETag)) return ErrorHelper.EtagNonMatching<PresentationCollection>();
             
             if (isStorageCollection != databaseCollection.IsStorageCollection)
             {


### PR DESCRIPTION
Fix bug where POST followed by PUT on collection could result in update not requiring eTag. This was due to how eTags are cached, look up doesn't find anything so checks provided value against found value (`null == null`) which passes.

Fixes #276 