### PR TITLE
Add helpers for consistent serialisation

### DIFF
--- a/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
@@ -314,7 +314,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         flatCollection!.Id.Should().Be("http://localhost/1/collections/NonPublic");
         flatCollection.FlatId.Should().Be("NonPublic");
         flatCollection.PublicId.Should().Be("http://localhost/1/non-public");
-        flatCollection.Items!.Count.Should().Be(0);
+        flatCollection.Items.Should().BeNull("There are no children");
         flatCollection.CreatedBy.Should().Be("admin");
         flatCollection.Behavior.Should().Contain("storage-collection");
         flatCollection.Behavior.Should().NotContain("public-iiif");

--- a/src/IIIFPresentation/API/Converters/DescriptionResourceConverter.cs
+++ b/src/IIIFPresentation/API/Converters/DescriptionResourceConverter.cs
@@ -1,0 +1,25 @@
+﻿using API.Converters.Streaming;
+using AWS.S3.Models;
+using Core.Helpers;
+using IIIF;
+using IIIF.Serialisation;
+
+namespace API.Converters;
+
+public static class DescriptionResourceConverter
+{
+    /// <summary>
+    /// Deserialized content in <see cref="ObjectFromBucket"/> to provided type and update root "id"
+    /// </summary>
+    public static T GetDescriptionResourceWithId<T>(this ObjectFromBucket objectFromS3, string replacementId)
+        where T : JsonLdBase
+    {
+        using var memoryStream = new MemoryStream();
+        StreamingJsonProcessor.ProcessJson(objectFromS3.Stream.ThrowIfNull(nameof(objectFromS3.Stream)),
+            memoryStream,
+            objectFromS3.Headers.ContentLength,
+            new S3StoredJsonProcessor(replacementId));
+        memoryStream.Seek(0, SeekOrigin.Begin);
+        return memoryStream.FromJsonStream<T>();
+    }
+}

--- a/src/IIIFPresentation/API/Features/Manifest/Helpers/ErrorHelper.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/Helpers/ErrorHelper.cs
@@ -1,5 +1,6 @@
 ﻿using API.Infrastructure.Requests;
 using Core;
+using IIIF;
 using Models.API.General;
 
 namespace API.Features.Manifest.Helpers;
@@ -7,7 +8,7 @@ namespace API.Features.Manifest.Helpers;
 public class ManifestErrorHelper
 {
     public static ModifyEntityResult<TCollection, ModifyCollectionType> ParentMustBeStorageCollection<TCollection>()
-        where TCollection : class
+        where TCollection : JsonLdBase
         => ModifyEntityResult<TCollection, ModifyCollectionType>.Failure("The parent must be a storage collection",
             ModifyCollectionType.ParentMustBeStorageCollection, WriteResult.Conflict);
 }

--- a/src/IIIFPresentation/API/Features/Storage/CollectionController.cs
+++ b/src/IIIFPresentation/API/Features/Storage/CollectionController.cs
@@ -49,7 +49,7 @@ public class CollectionController(
         
         if (Request.HasShowExtraHeader() && await authenticator.ValidateRequest(Request) == AuthResult.Success)
         {
-            return entityResult.EntityNotFound ? this.PresentationNotFound() : Ok(entityResult.Entity);
+            return entityResult.EntityNotFound ? this.PresentationNotFound() : this.PresentationContent(entityResult.Entity);
         }
 
         return entityResult.Entity?.Behavior.IsPublic() ?? false

--- a/src/IIIFPresentation/API/Features/Storage/Helpers/ErrorHelper.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Helpers/ErrorHelper.cs
@@ -1,5 +1,6 @@
 ﻿using API.Infrastructure.Requests;
 using Core;
+using IIIF;
 using Models.API.General;
 
 namespace API.Features.Storage.Helpers;
@@ -7,14 +8,14 @@ namespace API.Features.Storage.Helpers;
 public static class ErrorHelper
 {
     public static ModifyEntityResult<TCollection, ModifyCollectionType> NullParentResponse<TCollection>() 
-        where TCollection : class
+        where TCollection : JsonLdBase
     {
         return ModifyEntityResult<TCollection, ModifyCollectionType>.Failure(
             "The parent collection could not be found", ModifyCollectionType.ParentCollectionNotFound, WriteResult.BadRequest);
     }
     
     public static ModifyEntityResult<TCollection, ModifyCollectionType> CannotGenerateUniqueId<TCollection>() 
-        where TCollection : class
+        where TCollection : JsonLdBase
     {
         return ModifyEntityResult<TCollection, ModifyCollectionType>.Failure(
             "Could not generate a unique identifier.  Please try again",
@@ -22,7 +23,7 @@ public static class ErrorHelper
     }
     
     public static ModifyEntityResult<TCollection, ModifyCollectionType> CannotValidateIIIF<TCollection>() 
-        where TCollection : class
+        where TCollection : JsonLdBase
     {
         return ModifyEntityResult<TCollection, ModifyCollectionType>.Failure(
             "An error occurred while attempting to validate the collection as IIIF",
@@ -30,7 +31,7 @@ public static class ErrorHelper
     }
     
     public static ModifyEntityResult<TCollection, ModifyCollectionType> CannotChangeCollectionType<TCollection>
-        (bool storageCollection) where TCollection : class
+        (bool storageCollection) where TCollection : JsonLdBase
     {
         return ModifyEntityResult<TCollection, ModifyCollectionType>.Failure(
             $"Cannot convert a {CollectionType(storageCollection)} collection to a {CollectionType(!storageCollection)} collection",
@@ -38,7 +39,7 @@ public static class ErrorHelper
     }
 
     public static ModifyEntityResult<T, ModifyCollectionType> EtagNotRequired<T>()
-        where T : class
+        where T : JsonLdBase
     {
         return ModifyEntityResult<T, ModifyCollectionType>.Failure(
             "ETag should not be included in request when inserting via PUT", ModifyCollectionType.ETagNotAllowed,
@@ -46,25 +47,25 @@ public static class ErrorHelper
     }
     
     public static ModifyEntityResult<T, ModifyCollectionType> EtagNonMatching<T>()
-        where T : class
+        where T : JsonLdBase
     {
         return ModifyEntityResult<T, ModifyCollectionType>.Failure(
             "ETag does not match", ModifyCollectionType.ETagNotMatched, WriteResult.PreConditionFailed);
     }
     
     public static ModifyEntityResult<T, ModifyCollectionType> ErrorCreatingSpace<T>()
-        where T : class
+        where T : JsonLdBase
         => ModifyEntityResult<T, ModifyCollectionType>.Failure(
             "Error creating DLCS space", ModifyCollectionType.ErrorCreatingSpace, WriteResult.Error);
 
     public static ModifyEntityResult<T, ModifyCollectionType> SpaceRequired<T>()
-        where T : class
+        where T : JsonLdBase
         => ModifyEntityResult<T, ModifyCollectionType>.Failure(
             "A request with assets requires the space header to be set", ModifyCollectionType.RequiresSpaceHeader,
             WriteResult.BadRequest);
     
     public static ModifyEntityResult<T, ModifyCollectionType> CouldNotRetrieveAssetId<T>()
-        where T : class
+        where T : JsonLdBase
         => ModifyEntityResult<T, ModifyCollectionType>.Failure(
             "Could not retrieve an id from an attached asset", ModifyCollectionType.CouldNotRetrieveAssetId,
             WriteResult.BadRequest);

--- a/src/IIIFPresentation/API/Features/Storage/Helpers/PresentationContextX.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Helpers/PresentationContextX.cs
@@ -1,5 +1,6 @@
 ﻿using API.Infrastructure.Requests;
 using Core;
+using IIIF;
 using Microsoft.EntityFrameworkCore;
 using Models.API.General;
 using Models.Database.Collections;
@@ -17,7 +18,7 @@ public static class PresentationContextX
         int customerId,
         ILogger logger,
         CancellationToken cancellationToken)
-        where T : class
+        where T : JsonLdBase
         => dbContext.TrySave<T>("collection", customerId, logger, cancellationToken);
     
     public static async Task<ModifyEntityResult<T, ModifyCollectionType>?> TrySave<T>(
@@ -26,7 +27,7 @@ public static class PresentationContextX
         int customerId, 
         ILogger logger,
         CancellationToken cancellationToken)
-        where T : class
+        where T : JsonLdBase
     {
         try
         { 

--- a/src/IIIFPresentation/API/Features/Storage/Models/CollectionWithItems.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Models/CollectionWithItems.cs
@@ -1,4 +1,5 @@
-﻿using Models.Database.Collections;
+﻿using IIIF;
+using Models.Database.Collections;
 using Models.Database.General;
 
 namespace API.Features.Storage.Models;
@@ -7,12 +8,12 @@ public class CollectionWithItems(
     Collection? collection,
     List<Hierarchy>? items,
     int totalItems,
-    string? storedCollection = null)
+    JsonLdBase? storedCollection = null)
 {
     public Collection? Collection { get; } = collection;
     public List<Hierarchy>? Items { get; } = items;
     public int TotalItems { get; } = totalItems;
-    public string? StoredCollection { get; } = storedCollection;
+    public JsonLdBase? StoredCollection { get; } = storedCollection;
     public Collection? ParentCollection => Collection?.Hierarchy?.SingleOrDefault()?.ParentCollection;
 
     /// <summary>

--- a/src/IIIFPresentation/API/Features/Storage/Requests/GetHierarchicalCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/GetHierarchicalCollection.cs
@@ -1,4 +1,4 @@
-﻿using API.Converters.Streaming;
+﻿using API.Converters;
 using API.Features.Storage.Helpers;
 using API.Features.Storage.Models;
 using AWS.Helpers;
@@ -6,6 +6,7 @@ using AWS.S3;
 using AWS.S3.Models;
 using AWS.Settings;
 using Core.Streams;
+using IIIF.Presentation.V3;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
@@ -51,13 +52,9 @@ public class GetHierarchicalCollectionHandler(
 
             if (!objectFromS3.Stream.IsNull())
             {
-                using var memoryStream = new MemoryStream();
-                using var reader = new StreamReader(memoryStream);
-                StreamingJsonProcessor.ProcessJson(objectFromS3.Stream, memoryStream,
-                    objectFromS3.Headers.ContentLength,
-                    new S3StoredJsonProcessor(pathGenerator.GenerateHierarchicalId(request.Hierarchy)));
-                memoryStream.Seek(0, SeekOrigin.Begin);
-                var collectionFromS3 = await reader.ReadToEndAsync(cancellationToken);
+                var collectionFromS3 =
+                    objectFromS3.GetDescriptionResourceWithId<Collection>(
+                        pathGenerator.GenerateHierarchicalId(request.Hierarchy));
                 return new(request.Hierarchy.Collection, null, 0, collectionFromS3);
             }
         }

--- a/src/IIIFPresentation/API/Features/Storage/StorageController.cs
+++ b/src/IIIFPresentation/API/Features/Storage/StorageController.cs
@@ -8,8 +8,6 @@ using API.Infrastructure.Filters;
 using API.Infrastructure.Helpers;
 using API.Infrastructure.Requests;
 using API.Settings;
-using IIIF.Presentation;
-using IIIF.Serialisation;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -48,7 +46,7 @@ public class StorageController(
                         : SeeOther($"manifests/{hierarchy.ManifestId}");
                 
                 var storedManifest = await mediator.Send(new GetManifestHierarchical(hierarchy));
-                return storedManifest == null ? this.PresentationNotFound() : Content(storedManifest, ContentTypes.V3);
+                return storedManifest == null ? this.PresentationNotFound() : this.PresentationContent(storedManifest);
 
             case ResourceType.IIIFCollection:
             case ResourceType.StorageCollection:
@@ -64,10 +62,8 @@ public class StorageController(
                 }
 
                 return storageRoot.StoredCollection == null
-                    ? Content(
-                        storageRoot.Collection.ToHierarchicalCollection(pathGenerator, storageRoot.Items).AsJson(),
-                        ContentTypes.V3)
-                    : Content(storageRoot.StoredCollection, ContentTypes.V3);
+                    ? this.PresentationContent(storageRoot.Collection.ToHierarchicalCollection(pathGenerator, storageRoot.Items))
+                    : this.PresentationContent(storageRoot.StoredCollection);
 
             default:
                 return this.PresentationNotFound();

--- a/src/IIIFPresentation/API/Infrastructure/PresentationController.cs
+++ b/src/IIIFPresentation/API/Infrastructure/PresentationController.cs
@@ -3,6 +3,7 @@ using API.Exceptions;
 using API.Infrastructure.Requests;
 using API.Settings;
 using Core;
+using IIIF;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 
@@ -53,7 +54,7 @@ public abstract class PresentationController : Controller
     string? instance = null,
     string? errorTitle = "Operation failed",
     CancellationToken cancellationToken = default)
-    where T : class
+    where T : JsonLdBase
     where TEnum : Enum
     {
         return await HandleRequest(async () =>

--- a/src/IIIFPresentation/API/Infrastructure/Requests/ModifyEntityResult.cs
+++ b/src/IIIFPresentation/API/Infrastructure/Requests/ModifyEntityResult.cs
@@ -18,7 +18,7 @@ public class ModifyEntityResult<T, TEnum> : IModifyRequest
     /// <summary>
     /// Optional representation of entity
     /// </summary>
-    public JsonLdBase? Entity { get; private init; }
+    public T? Entity { get; private init; }
 
     /// <summary>
     /// Optional error message if didn't succeed

--- a/src/IIIFPresentation/API/Infrastructure/Requests/ModifyEntityResult.cs
+++ b/src/IIIFPresentation/API/Infrastructure/Requests/ModifyEntityResult.cs
@@ -1,4 +1,5 @@
 ﻿using Core;
+using IIIF;
 
 namespace API.Infrastructure.Requests;
 
@@ -7,7 +8,7 @@ namespace API.Infrastructure.Requests;
 /// </summary>
 /// <typeparam name="T">Type of entity being modified</typeparam>
 public class ModifyEntityResult<T, TEnum> : IModifyRequest
-    where T : class
+    where T : JsonLdBase
 {
     /// <summary>
     /// Enum representing overall result of operation
@@ -17,7 +18,7 @@ public class ModifyEntityResult<T, TEnum> : IModifyRequest
     /// <summary>
     /// Optional representation of entity
     /// </summary>
-    public T? Entity { get; private init; }
+    public JsonLdBase? Entity { get; private init; }
 
     /// <summary>
     /// Optional error message if didn't succeed

--- a/src/IIIFPresentation/Core/Helpers/GuardX.cs
+++ b/src/IIIFPresentation/Core/Helpers/GuardX.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using Core.Streams;
 
 namespace Core.Helpers;
 
@@ -77,5 +78,15 @@ public static class GuardX
         }
 
         return val;
+    }
+    
+    public static Stream ThrowIfNull(this Stream? argument, string argName)
+    {
+        if (argument.IsNull())
+        {
+            throw new ArgumentNullException(argName);
+        }
+
+        return argument;
     }
 }


### PR DESCRIPTION
Add `ControllerBaseX.PresentationContent()` that takes description resource and uses the `.AsJson()` serialiser helper from iiif-net. This ensures consitent serialisation behaviours and uses the [serialisation helpers](https://github.com/digirati-co-uk/iiif-net?tab=readme-ov-file#serialisation) from that library. 

Everything we return from the API is either a Manifest or Collection, so they will all inherit from `JsonLdBase` so a lot of this PR is updating generic constraints to use `JsonLdBase`, rather than `class`.

Fixes #154 
Fixes #156 