### PR TITLE
Set the full path correctly for a hierarchical IIIF request

### DIFF
--- a/src/IIIFPresentation/API.Tests/Converters/CollectionConverterTests.cs
+++ b/src/IIIFPresentation/API.Tests/Converters/CollectionConverterTests.cs
@@ -15,6 +15,7 @@ namespace API.Tests.Converters;
 public class CollectionConverterTests
 {
     private const int PageSize = 100;
+    private const int CustomerId = 1;
     
     private readonly IPathGenerator pathGenerator = TestPathGenerator.CreatePathGenerator("base", Uri.UriSchemeHttp);
 
@@ -25,7 +26,7 @@ public class CollectionConverterTests
         var storageRoot = new Collection
         {
             Id = "some-id",
-            CustomerId = 1,
+            CustomerId = CustomerId,
             Label = new LanguageMap
             {
                 { "en", new List<string> { "repository root" } }
@@ -36,7 +37,8 @@ public class CollectionConverterTests
             Hierarchy = [
                 new Hierarchy
                 {
-                    Slug = "root"
+                    Slug = "root",
+                    CustomerId = CustomerId
                 }
             ]
         };
@@ -108,7 +110,7 @@ public class CollectionConverterTests
         var collection = new Collection
         {
             Id = "some-id",
-            CustomerId = 1,
+            CustomerId = CustomerId,
             Label = new LanguageMap
             {
                 { "en", new List<string> { "repository root" } }
@@ -121,7 +123,7 @@ public class CollectionConverterTests
                 {
                     CollectionId = "some-id",
                     Slug = "root",
-                    CustomerId = 1,
+                    CustomerId = CustomerId,
                     Type = ResourceType.StorageCollection,
                     Canonical = true
                 }
@@ -267,7 +269,7 @@ public class CollectionConverterTests
         var collection = new Collection
         {
             Id = "some-id",
-            CustomerId = 1,
+            CustomerId = CustomerId,
             Created = DateTime.MinValue,
             Modified = DateTime.MinValue,
             IsStorageCollection = true,
@@ -276,7 +278,7 @@ public class CollectionConverterTests
                 {
                     CollectionId = "some-id",
                     Slug = "root",
-                    CustomerId = 1,
+                    CustomerId = CustomerId,
                     Type = ResourceType.StorageCollection,
                     Canonical = true
                 }
@@ -299,7 +301,7 @@ public class CollectionConverterTests
         var collection = new Collection
         {
             Id = "some-id",
-            CustomerId = 1,
+            CustomerId = CustomerId,
             Created = DateTime.MinValue,
             Modified = DateTime.MinValue,
             IsStorageCollection = false,
@@ -308,7 +310,7 @@ public class CollectionConverterTests
                 {
                     CollectionId = "some-id",
                     Slug = "root",
-                    CustomerId = 1,
+                    CustomerId = CustomerId,
                     Type = ResourceType.StorageCollection,
                     Canonical = true
                 }
@@ -401,7 +403,7 @@ public class CollectionConverterTests
         presentationCollectionWithFields.TotalItems.Should().BeNull();
         presentationCollectionWithFields.Totals.Should().BeNull();
         presentationCollectionWithFields.SeeAlso.Should().BeNull();
-        presentationCollectionWithFields.PartOf.Should().BeNull();
+        presentationCollectionWithFields.PartOf![0].Id.Should().Be("http://base/0/collections/theparent");
         presentationCollectionWithFields.Behavior.IsPublic().Should().BeTrue();
     }
 
@@ -455,7 +457,7 @@ public class CollectionConverterTests
             new()
             {
                 CollectionId = "some-child",
-                CustomerId = 1,
+                CustomerId = CustomerId,
                 Slug = "root",
                 Type = ResourceType.StorageCollection,
                 Collection = new Collection
@@ -474,14 +476,13 @@ public class CollectionConverterTests
         var collection = new Collection
         {
             Id = "some-id",
-            CustomerId = 1,
+            CustomerId = CustomerId,
             Label = new LanguageMap
             {
                 { "en", new List<string> { "repository root" } }
             },
             Created = DateTime.MinValue,
             Modified = DateTime.MinValue,
-            FullPath = "top/some-id",
             IsStorageCollection = isStorageCollection,
             IsPublic = isPublic,
             Hierarchy =
@@ -491,9 +492,10 @@ public class CollectionConverterTests
                     CollectionId = "some-id",
                     Slug = "root",
                     Parent = "top",
-                    CustomerId = 1,
+                    CustomerId = CustomerId,
                     Type = isStorageCollection ? ResourceType.StorageCollection : ResourceType.IIIFCollection,
-                    Canonical = true
+                    Canonical = true,
+                    FullPath = "top/some-id"
                 }
             ]
         };
@@ -506,15 +508,22 @@ public class CollectionConverterTests
         var collection = new Collection
         {
             Id = "some-id",
-            CustomerId = 1,
+            CustomerId = CustomerId,
             Label = new LanguageMap
             {
                 { "en", new List<string> { "repository root" } }
             },
             Created = DateTime.MinValue,
             Modified = DateTime.MinValue,
-            FullPath = "top/some-id",
             IsStorageCollection = true,
+            Hierarchy = [
+                new Hierarchy
+                {
+                    Slug = "some-slug",
+                    CustomerId = CustomerId,
+                    FullPath = "top/some-id",
+                }
+            ]
         };
         
         return collection;

--- a/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
@@ -642,6 +642,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         response.Headers.Vary.Should().HaveCount(2);
         collection!.Items.Should().BeNull();
+        collection.Id.Should().Be("http://localhost/1/iiif-collection");
         collection.Behavior![0].Should().Be("public-iiif");
         collection.Type.Should().Be("Collection");
     }

--- a/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
@@ -121,8 +121,8 @@ public class CreateCollectionHandler(
 
         await UploadToS3IfRequiredAsync(collection, iiifCollection?.ConvertedIIIF, isStorageCollection,
             cancellationToken);
-
-        collection.FullPath =
+        
+        collection.Hierarchy.GetCanonical().FullPath =
             await CollectionRetrieval.RetrieveFullPathForCollection(collection, dbContext, cancellationToken);
 
         var enrichedPresentationCollection = request.Collection.EnrichPresentationCollection(collection,

--- a/src/IIIFPresentation/API/Features/Storage/Requests/GetCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/GetCollection.cs
@@ -54,7 +54,7 @@ public class GetCollectionHandler(PresentationContext dbContext, IIIFS3Service i
         
         if (hierarchy.Parent != null)
         {
-            collection.Hierarchy!.GetCanonical().FullPath =
+            collection.Hierarchy.GetCanonical().FullPath =
                 await CollectionRetrieval.RetrieveFullPathForCollection(collection, dbContext, cancellationToken);
         }
 

--- a/src/IIIFPresentation/API/Features/Storage/Requests/GetCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/GetCollection.cs
@@ -3,7 +3,6 @@ using API.Features.Storage.Helpers;
 using API.Features.Storage.Models;
 using API.Infrastructure.Requests;
 using AWS.Helpers;
-using IIIF.Presentation.V3;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Models.API.Collection;
@@ -55,7 +54,7 @@ public class GetCollectionHandler(PresentationContext dbContext, IIIFS3Service i
         
         if (hierarchy.Parent != null)
         {
-            collection.FullPath =
+            collection.Hierarchy!.GetCanonical().FullPath =
                 await CollectionRetrieval.RetrieveFullPathForCollection(collection, dbContext, cancellationToken);
         }
 
@@ -72,7 +71,8 @@ public class GetCollectionHandler(PresentationContext dbContext, IIIFS3Service i
                 request.RequestModifiers.Page, cancellationToken);
 
             // We know the fullPath of parent collection so we can use that as the base for child items
-            items.ForEach(item => item.FullPath = pathGenerator.GenerateFullPath(hierarchy, collection));
+            items.ForEach(item =>
+                item.FullPath = pathGenerator.GenerateFullPath(hierarchy, collection.Hierarchy.GetCanonical()));
 
             var presentationCollection = collection.ToPresentationCollection(request.RequestModifiers.PageSize,
                 request.RequestModifiers.Page, total, items, parentCollection, pathGenerator, orderByParameter);

--- a/src/IIIFPresentation/API/Features/Storage/Requests/GetCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/GetCollection.cs
@@ -44,7 +44,7 @@ public class GetCollectionHandler(PresentationContext dbContext, IIIFS3Service i
         
         if (collection is null) return FetchEntityResult<PresentationCollection>.NotFound();
 
-        var hierarchy = collection.Hierarchy!.Single(h => h.Canonical);
+        var hierarchy = collection.Hierarchy.GetCanonical();
 
         var parentCollection = collection.Hierarchy?.SingleOrDefault()?.ParentCollection;
 
@@ -72,7 +72,7 @@ public class GetCollectionHandler(PresentationContext dbContext, IIIFS3Service i
 
             // We know the fullPath of parent collection so we can use that as the base for child items
             items.ForEach(item =>
-                item.FullPath = pathGenerator.GenerateFullPath(hierarchy, collection.Hierarchy.GetCanonical()));
+                item.FullPath = pathGenerator.GenerateFullPath(item, hierarchy));
 
             var presentationCollection = collection.ToPresentationCollection(request.RequestModifiers.PageSize,
                 request.RequestModifiers.Page, total, items, parentCollection, pathGenerator, orderByParameter);

--- a/src/IIIFPresentation/API/Features/Storage/Requests/GetHierarchicalCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/GetHierarchicalCollection.cs
@@ -37,7 +37,7 @@ public class GetHierarchicalCollectionHandler(
     {
         if (request.Hierarchy.CollectionId == null || request.Hierarchy.Collection == null)
         {
-            logger.LogWarning("Attempt to fetch collection for '{Slug}' but hierarchy has null collection",
+            logger.LogWarning("Attempt to fetch collection for '{FullPath}' but hierarchy has null collection",
                 request.Hierarchy.FullPath);
             return CollectionWithItems.Empty;
         }

--- a/src/IIIFPresentation/API/Features/Storage/Requests/GetHierarchicalCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/GetHierarchicalCollection.cs
@@ -52,6 +52,7 @@ public class GetHierarchicalCollectionHandler(
 
             if (!objectFromS3.Stream.IsNull())
             {
+                request.Hierarchy.FullPath = request.Slug;
                 var collectionFromS3 =
                     objectFromS3.GetDescriptionResourceWithId<Collection>(
                         pathGenerator.GenerateHierarchicalId(request.Hierarchy));

--- a/src/IIIFPresentation/API/Features/Storage/Requests/PostHierarchicalCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/PostHierarchicalCollection.cs
@@ -71,14 +71,16 @@ public class PostHierarchicalCollectionHandler(
         
         await iiifS3.SaveIIIFToS3(collectionFromBody, collection, pathGenerator.GenerateFlatCollectionId(collection),
             cancellationToken);
+
+        var hierarchy = collection.Hierarchy!.GetCanonical();
         
-        if (collection.Hierarchy!.Single(h => h.Canonical).Parent != null)
+        if (hierarchy.Parent != null)
         {
-            collection.FullPath =
+            hierarchy.FullPath =
                 await CollectionRetrieval.RetrieveFullPathForCollection(collection, dbContext, cancellationToken);
         }
 
-        collectionFromBody.Id = pathGenerator.GenerateHierarchicalCollectionId(collection);
+        collectionFromBody.Id = pathGenerator.GenerateHierarchicalId(hierarchy);
         return ModifyEntityResult<Collection, ModifyCollectionType>.Success(collectionFromBody, WriteResult.Created);
     }
 

--- a/src/IIIFPresentation/API/Features/Storage/Requests/PostHierarchicalCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/PostHierarchicalCollection.cs
@@ -72,7 +72,7 @@ public class PostHierarchicalCollectionHandler(
         await iiifS3.SaveIIIFToS3(collectionFromBody, collection, pathGenerator.GenerateFlatCollectionId(collection),
             cancellationToken);
 
-        var hierarchy = collection.Hierarchy!.GetCanonical();
+        var hierarchy = collection.Hierarchy.GetCanonical();
         
         if (hierarchy.Parent != null)
         {

--- a/src/IIIFPresentation/API/Features/Storage/Requests/UpsertCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/UpsertCollection.cs
@@ -1,7 +1,6 @@
 ﻿using API.Converters;
 using API.Features.Storage.Helpers;
 using API.Features.Storage.Models;
-using API.Helpers;
 using API.Infrastructure.Helpers;
 using API.Infrastructure.Requests;
 using API.Infrastructure.Validation;
@@ -179,7 +178,7 @@ public class UpsertCollectionHandler(
         {
             try
             {
-                databaseCollection.FullPath =
+                hierarchy.FullPath =
                     await CollectionRetrieval.RetrieveFullPathForCollection(databaseCollection, dbContext,
                         cancellationToken);
             }
@@ -203,7 +202,7 @@ public class UpsertCollectionHandler(
         foreach (var item in items)
         {
             // We know the fullPath of parent collection so we can use that as the base for child items 
-            item.FullPath = pathGenerator.GenerateFullPath(item, databaseCollection);
+            item.FullPath = pathGenerator.GenerateFullPath(item, hierarchy);
         }
 
         await UploadToS3IfRequiredAsync(databaseCollection, iiifCollection?.ConvertedIIIF, isStorageCollection,

--- a/src/IIIFPresentation/API/Features/Storage/StorageController.cs
+++ b/src/IIIFPresentation/API/Features/Storage/StorageController.cs
@@ -36,8 +36,11 @@ public class StorageController(
     public async Task<IActionResult> GetHierarchical(int customerId, string slug = "")
     {
         var hierarchy = await dbContext.RetrieveHierarchy(customerId, slug);
+        
+        if (hierarchy == null) return this.PresentationNotFound();
+        hierarchy.FullPath = slug;
 
-        switch (hierarchy?.Type)
+        switch (hierarchy.Type)
         {
             case ResourceType.IIIFManifest:
                 if (Request.HasShowExtraHeader() && await authenticator.ValidateRequest(Request) == AuthResult.Success)
@@ -50,7 +53,7 @@ public class StorageController(
 
             case ResourceType.IIIFCollection:
             case ResourceType.StorageCollection:
-                var storageRoot = await Mediator.Send(new GetHierarchicalCollection(hierarchy, slug));
+                var storageRoot = await Mediator.Send(new GetHierarchicalCollection(hierarchy));
 
                 if (storageRoot.Collection == null) return this.PresentationNotFound();
 

--- a/src/IIIFPresentation/API/Features/Storage/StorageController.cs
+++ b/src/IIIFPresentation/API/Features/Storage/StorageController.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using API.Attributes;
 using API.Auth;
 using API.Converters;
@@ -69,7 +70,8 @@ public class StorageController(
                     : this.PresentationContent(storageRoot.StoredCollection);
 
             default:
-                return this.PresentationNotFound();
+                return this.PresentationProblem("Cannot fulfill this resource type", null,
+                    (int)HttpStatusCode.InternalServerError, "Cannot fulfill this resource type");
         }
     }
 

--- a/src/IIIFPresentation/Models/Database/Collections/Collection.cs
+++ b/src/IIIFPresentation/Models/Database/Collections/Collection.cs
@@ -1,5 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations.Schema;
-using IIIF.Presentation.V3.Strings;
+﻿using IIIF.Presentation.V3.Strings;
 using Models.Database.General;
 
 namespace Models.Database.Collections;
@@ -69,12 +68,6 @@ public class Collection : IHierarchyResource
     public int CustomerId { get; set; }
     
     public List<Hierarchy>? Hierarchy { get; set; }
-
-    /// <summary>
-    /// The full path to this object, based on parent collections
-    /// </summary>
-    [NotMapped]
-    public string? FullPath { get; set; }
 
     /// <summary>
     /// Navigation property for any children, when this Collection is the parent

--- a/src/IIIFPresentation/Repository.Tests/Paths/PathGeneratorTests.cs
+++ b/src/IIIFPresentation/Repository.Tests/Paths/PathGeneratorTests.cs
@@ -9,63 +9,6 @@ namespace Repository.Tests.Paths;
 public class PathGeneratorTests
 {
     private readonly IPathGenerator pathGenerator = new TestPathGenerator();
-
-    [Fact]
-    public void GenerateHierarchicalCollectionId_CreatesIdWhenNoFullPath()
-    {
-        // Arrange
-        var collection = new Collection
-        {
-            Id = "test",
-            Hierarchy = GetDefaultHierarchyList()
-        };
-
-        // Act
-        var id = pathGenerator.GenerateHierarchicalCollectionId(collection);
-
-        // Assert
-        id.Should().Be("http://base/0");
-    }
-    
-    [Theory]
-    [InlineData("test/slug", "/test")]
-    [InlineData("test/test/slug", "/test/test")]
-    [InlineData("slug", "")]
-    public void GenerateHierarchicalCollectionParent_Correct_ParentId(string fullPath, string outputUrl)
-    {
-        // Arrange
-        var collection = new Collection
-        {
-            Id = "someId",
-            FullPath = fullPath,
-        };
-        
-        var hierarchy = GetDefaultHierarchyList();
-
-        // Act
-        var parentId = pathGenerator.GenerateHierarchicalCollectionParent(collection, hierarchy.First());
-
-        // Assert
-        parentId.Should().Be($"http://base/0{outputUrl}");
-    }
-    
-    [Fact]
-    public void GenerateHierarchicalCollectionId_CreatesIdWhenFullPath()
-    {
-        // Arrange
-        var collection = new Collection
-        {
-            Id = "test",
-            Hierarchy = GetDefaultHierarchyList(),
-            FullPath = "top/test"
-        };
-
-        // Act
-        var id = pathGenerator.GenerateHierarchicalCollectionId(collection);
-
-        // Assert
-        id.Should().Be("http://base/0/top/test");
-    }
     
     [Fact]
     public void GenerateHierarchicalId_CreatesIdWhenNoFullPath()
@@ -233,12 +176,12 @@ public class PathGeneratorTests
     public void GenerateFullPath_Correct_ParentFullPathNullOrEmpty(string? path)
     {
         // Arrange
-        var parentCollection = new Collection { CustomerId = 99, Id = "javelin", FullPath = path};
+        var parentHierarchy = new Hierarchy { CustomerId = 99, FullPath = path, Slug = "" };
         var hierarchy = new Hierarchy { Slug = "slug" };
         const string expected = "slug";
         
         // Act
-        var actual = pathGenerator.GenerateFullPath(hierarchy, parentCollection);
+        var actual = pathGenerator.GenerateFullPath(hierarchy, parentHierarchy);
         
         // Assert
         actual.Should().Be(expected);
@@ -248,12 +191,12 @@ public class PathGeneratorTests
     public void GenerateFullPath_Correct_ParentFullPathHasValue()
     {
         // Arrange
-        var parentCollection = new Collection { CustomerId = 99, Id = "javelin", FullPath = "have/hold/javelin" };
+        var parentHierarchy = new Hierarchy { CustomerId = 99, Slug = "hold", FullPath = "have/hold/javelin" };
         var hierarchy = new Hierarchy { Slug = "slug" };
         const string expected = "have/hold/javelin/slug";
         
         // Act
-        var actual = pathGenerator.GenerateFullPath(hierarchy, parentCollection);
+        var actual = pathGenerator.GenerateFullPath(hierarchy, parentHierarchy);
         
         // Assert
         actual.Should().Be(expected);
@@ -433,7 +376,8 @@ public class PathGeneratorTests
             .Should().Be(expected, "full path appended to customer");
     }
     
-    private static List<Hierarchy> GetDefaultHierarchyList() =>  [ new() { Slug = "slug" } ];
+    private static List<Hierarchy> GetDefaultHierarchyList(string? fullPath = null) =>  
+        [new() { Slug = "slug", FullPath = fullPath }];
 }
 
 public class TestPathGenerator : PathGeneratorBase

--- a/src/IIIFPresentation/Repository/Helpers/HierarchyHelper.cs
+++ b/src/IIIFPresentation/Repository/Helpers/HierarchyHelper.cs
@@ -1,0 +1,12 @@
+﻿using Models.Database.General;
+
+namespace Repository.Helpers;
+
+public static class HierarchyHelper
+{
+    /// <summary>
+    /// Retrieves the canonical hierarchy from a collection
+    /// </summary>
+    public static Hierarchy GetCanonical(this IEnumerable<Hierarchy>? hierarchy) =>
+        hierarchy?.Single(h => h.Canonical) ?? throw new NullReferenceException("Hierarchy cannot be null");
+}

--- a/src/IIIFPresentation/Repository/Helpers/ManifestRetrieval.cs
+++ b/src/IIIFPresentation/Repository/Helpers/ManifestRetrieval.cs
@@ -1,7 +1,6 @@
 ﻿using Core.Exceptions;
 using Microsoft.EntityFrameworkCore;
 using Models.Database.Collections;
-using Models.Database.General;
 
 namespace Repository.Helpers;
 
@@ -71,10 +70,4 @@ SELECT * FROM parentsearch ps
 
         return fullPath;
     }
-
-    public static Task<string> RetrieveFullPathForManifest(Hierarchy manifestHierarchy, PresentationContext dbContext,
-        CancellationToken cancellationToken = default)
-        => RetrieveFullPathForManifest(manifestHierarchy.ManifestId!, manifestHierarchy.CustomerId, dbContext,
-            cancellationToken);
-    
 }

--- a/src/IIIFPresentation/Repository/Paths/IPathGenerator.cs
+++ b/src/IIIFPresentation/Repository/Paths/IPathGenerator.cs
@@ -7,16 +7,6 @@ namespace Repository.Paths;
 public interface IPathGenerator
 {
     /// <summary>
-    /// Get a hierarchical id for the current collection
-    /// </summary>
-    string GenerateHierarchicalCollectionId(Collection collection);
-
-    /// <summary>
-    /// Get the hierarchical id for the parent of a collection
-    /// </summary>
-    string GenerateHierarchicalCollectionParent(Collection collection, Hierarchy hierarchy);
-
-    /// <summary>
     /// Get the flat id for the current collection
     /// </summary>
     string GenerateFlatCollectionId(Collection collection);
@@ -35,7 +25,7 @@ public interface IPathGenerator
     /// Get flat id for parent of <see cref="Hierarchy"/> 
     /// </summary>
     string GenerateFlatParentId(Hierarchy hierarchy);
-
+    
     /// <summary>
     /// Get the view id for the current collection
     /// </summary>
@@ -68,7 +58,7 @@ public interface IPathGenerator
     /// <summary>
     /// Get the FullPath of an item, using Canonical slug of attached Hierarchy collection and parent FullPath, if set 
     /// </summary>
-    string GenerateFullPath(Hierarchy collection, Collection parent);
+    string GenerateFullPath(Hierarchy collection, Hierarchy parent);
 
     /// <summary>
     /// Get the FullPath of an item, using Canonical slug of attached Hierarchy collection and provided parent 

--- a/src/IIIFPresentation/Repository/Paths/PathGeneratorBase.cs
+++ b/src/IIIFPresentation/Repository/Paths/PathGeneratorBase.cs
@@ -21,20 +21,9 @@ public abstract class PathGeneratorBase : IPathGenerator
     /// Base url for DLCS Protagonist API
     /// </summary>
     protected abstract Uri DlcsApiUrl { get; }
-    
-    public string GenerateHierarchicalCollectionId(Collection collection) =>
-        $"{PresentationUrl}/{collection.CustomerId}{(string.IsNullOrEmpty(collection.FullPath) ? string.Empty : $"/{collection.FullPath}")}";
 
     public string GenerateHierarchicalFromFullPath(int customerId, string? fullPath) =>
         $"{PresentationUrl}/{customerId}{(fullPath is {Length: > 0} ? $"/{fullPath.TrimStart('/')}" : string.Empty)}";
-
-    public string GenerateHierarchicalCollectionParent(Collection collection, Hierarchy hierarchy)
-    {
-        var parentPath = collection.FullPath![..^hierarchy.Slug.Length].TrimEnd('/');
-
-        return
-            $"{PresentationUrl}/{collection.CustomerId}{(string.IsNullOrEmpty(parentPath) ? string.Empty : $"/{parentPath}")}";
-    }
 
     public string GenerateFlatCollectionId(Collection collection) => 
         $"{PresentationUrl}/{collection.CustomerId}/collections/{collection.Id}";
@@ -70,7 +59,7 @@ public abstract class PathGeneratorBase : IPathGenerator
         string orderQueryParam) => new(
         $"{GenerateFlatCollectionId(collection)}?page={lastPage}&pageSize={pageSize}{orderQueryParam}");
     
-    public string GenerateFullPath(Hierarchy collection, Collection parent)
+    public string GenerateFullPath(Hierarchy collection, Hierarchy parent)
         => GenerateFullPath(collection, parent.FullPath);
     
     public string GenerateFullPath(Hierarchy hierarchy, string? parentPath) 


### PR DESCRIPTION
Resolves #281 

This PR fixes an issue where a IIIF collection retrieved hierarchically sets the `id` of the collection to that of the `root`, rather than the correct ID

Additionally, a refactor has taken place to remove `FullPath` from `Collection` due to the duplicate property on `Hierarchy` 