### PR TITLE
Allow status code to be passed in a DLCS exception

### DIFF
--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
@@ -50,7 +50,7 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
 
         A.CallTo(() => dlcsApiClient.IngestAssets(Customer,
             A<List<JObject>>.That.Matches(o => o.First().GetValue("id").ToString() == "returnError"),
-            A<CancellationToken>._)).Throws(new DlcsException("DLCS exception"));
+            A<CancellationToken>._)).Throws(new DlcsException("DLCS exception", HttpStatusCode.BadRequest));
 
         A.CallTo(() => dlcsApiClient.GetCustomerImages(Customer,
                 A<IList<string>>.That.Matches(l => l.Any(x =>
@@ -62,7 +62,7 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
                 A<IList<string>>.That.Matches(l => l.Any(x =>
                     $"{Customer}/{NewlyCreatedSpace}/testAssetByPresentation-assetDetailsFail".Equals(x))),
                 A<CancellationToken>._))
-            .Throws(new DlcsException("DLCS exception"));
+            .Throws(new DlcsException("DLCS exception", HttpStatusCode.BadRequest));
 
         A.CallTo(() => dlcsApiClient.GetCustomerImages(Customer,
                 A<IList<string>>.That.Matches(l =>
@@ -1243,7 +1243,7 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
         var response = await httpClient.AsCustomer().SendAsync(requestMessage);
         
         // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         var errorResponse = await response.ReadAsPresentationResponseAsync<Error>();
         errorResponse!.Detail.Should().Be("DLCS exception");
     }

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestCreateTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestCreateTests.cs
@@ -50,7 +50,7 @@ public class ModifyManifestCreateTests : IClassFixture<PresentationAppFactory<Pr
         A.CallTo(() => dlcsApiClient.CreateSpace(Customer, A<string>._, A<CancellationToken>._))
             .Returns(new Space { Id = NewlyCreatedSpace, Name = "test" });
         A.CallTo(() => dlcsApiClient.CreateSpace(InvalidSpaceCustomer, A<string>._, A<CancellationToken>._))
-            .ThrowsAsync(new DlcsException("err"));
+            .ThrowsAsync(new DlcsException("err", HttpStatusCode.BadRequest));
         httpClient = factory
             .ConfigureBasicIntegrationTestHttpClient(storageFixture.DbFixture,
                 appFactory => appFactory.WithLocalStack(storageFixture.LocalStackFixture),

--- a/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
@@ -103,7 +103,18 @@ public class DlcsManifestCoordinator(
             logger.LogError(exception, "Error creating batch request for customer {CustomerId}, manifest {ManifestId}",
                 customerId, manifestId);
             return EntityResult.Failure(exception.Message, ModifyCollectionType.DlcsException,
-                exception.StatusCode == HttpStatusCode.BadRequest ? WriteResult.BadRequest : WriteResult.Error);
+                ErrorStatusCodeToWriteResult(exception.StatusCode));
         }
+    }
+
+    private WriteResult ErrorStatusCodeToWriteResult(HttpStatusCode statusCode)
+    {
+        return statusCode switch
+        {
+            HttpStatusCode.BadRequest => WriteResult.BadRequest,
+            HttpStatusCode.NotFound => WriteResult.NotFound,
+            HttpStatusCode.Conflict => WriteResult.Conflict,
+            _ => WriteResult.Error
+        };
     }
 }

--- a/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
@@ -1,4 +1,5 @@
-﻿using API.Features.Storage.Helpers;
+﻿using System.Net;
+using API.Features.Storage.Helpers;
 using API.Helpers;
 using Core;
 using DLCS.API;
@@ -102,7 +103,7 @@ public class DlcsManifestCoordinator(
             logger.LogError(exception, "Error creating batch request for customer {CustomerId}, manifest {ManifestId}",
                 customerId, manifestId);
             return EntityResult.Failure(exception.Message, ModifyCollectionType.DlcsException,
-                WriteResult.Error);
+                exception.StatusCode == HttpStatusCode.BadRequest ? WriteResult.BadRequest : WriteResult.Error);
         }
     }
 }

--- a/src/IIIFPresentation/DLCS.Tests/API/DlcsApiClientTests.cs
+++ b/src/IIIFPresentation/DLCS.Tests/API/DlcsApiClientTests.cs
@@ -46,7 +46,8 @@ public class DlcsApiClientTests
         var sut = GetClient(stub);
         
         Func<Task> action = () => sut.CreateSpace(customerId, "hi", CancellationToken.None);
-        await action.Should().ThrowAsync<DlcsException>().WithMessage("Could not find a DlcsError in response");
+        await action.Should().ThrowAsync<DlcsException>()
+            .Where(e => e.Message == "Could not find a DlcsError in response" && e.StatusCode == httpStatusCode);
     }
     
     [Theory]
@@ -63,7 +64,8 @@ public class DlcsApiClientTests
         var sut = GetClient(stub);
         
         Func<Task> action = () => sut.CreateSpace(customerId, "hi", CancellationToken.None);
-        await action.Should().ThrowAsync<DlcsException>().WithMessage("I am broken");
+        await action.Should().ThrowAsync<DlcsException>()
+            .Where(e => e.Message == "I am broken" && e.StatusCode == httpStatusCode);;
     }
     
     [Fact]
@@ -144,7 +146,8 @@ public class DlcsApiClientTests
         var sut = GetClient(stub);
         
         Func<Task> action = () => sut.IngestAssets(customerId, new List<string> {"someString"}, CancellationToken.None);
-        await action.Should().ThrowAsync<DlcsException>().WithMessage("I am broken");
+        await action.Should().ThrowAsync<DlcsException>()
+            .Where(e => e.Message == "I am broken" && e.StatusCode == httpStatusCode);
     }
 
     [Fact]
@@ -208,7 +211,8 @@ public class DlcsApiClientTests
         var sut = GetClient(stub);
 
         Func<Task> action = () => sut.GetBatchAssets(customerId, batchId, CancellationToken.None);
-        await action.Should().ThrowAsync<DlcsException>().WithMessage("I am broken");
+        await action.Should().ThrowAsync<DlcsException>()
+            .Where(e => e.Message == "I am broken" && e.StatusCode == httpStatusCode);
     }
 
     [Fact]
@@ -270,7 +274,8 @@ public class DlcsApiClientTests
         var sut = GetClient(stub);
 
         Func<Task> action = () => sut.GetCustomerImages(customerId, ["someString"], CancellationToken.None);
-        await action.Should().ThrowAsync<DlcsException>().WithMessage("I am broken");
+        await action.Should().ThrowAsync<DlcsException>()
+            .Where(e => e.Message == "I am broken" && e.StatusCode == httpStatusCode);;
     }
 
 

--- a/src/IIIFPresentation/DLCS.Tests/API/DlcsOrchestratorClientTests.cs
+++ b/src/IIIFPresentation/DLCS.Tests/API/DlcsOrchestratorClientTests.cs
@@ -22,7 +22,8 @@ public class DlcsOrchestratorClientTests
         var sut = GetClient(stub);
         
         Func<Task> action = () => sut.RetrieveAssetsForManifest(customerId, [1, 2], CancellationToken.None);
-        await action.Should().ThrowAsync<DlcsException>().WithMessage("Could not find a DlcsError in response");
+        await action.Should().ThrowAsync<DlcsException>()
+            .Where(e => e.Message == "Could not find a DlcsError in response" && e.StatusCode == httpStatusCode);
     }
     
     [Theory]
@@ -38,7 +39,8 @@ public class DlcsOrchestratorClientTests
         var sut = GetClient(stub);
         
         Func<Task> action = () => sut.RetrieveAssetsForManifest(customerId, [1, 2], CancellationToken.None);
-        await action.Should().ThrowAsync<DlcsException>().WithMessage("I am broken");
+        await action.Should().ThrowAsync<DlcsException>()
+            .Where(e => e.Message == "I am broken" && e.StatusCode == httpStatusCode);
     }
     
     [Fact]

--- a/src/IIIFPresentation/DLCS/API/DlcsApiClient.cs
+++ b/src/IIIFPresentation/DLCS/API/DlcsApiClient.cs
@@ -61,7 +61,7 @@ internal class DlcsApiClient(
         var payload = new Space { Name = name };
 
         var space = await CallDlcsApiFor<Space>(HttpMethod.Post, spacePath, payload, cancellationToken);
-        return space ?? throw new DlcsException("Failed to create space");
+        return space ?? throw new DlcsException("Failed to create space", HttpStatusCode.InternalServerError);
     }
     
     public async Task<List<Batch>> IngestAssets<T>(int customerId, List<T> assets, CancellationToken cancellationToken = default)
@@ -81,7 +81,7 @@ internal class DlcsApiClient(
             if (batch == null)
             {
                 logger.LogError("Could not understand the batch response for customer {CustomerId}", customerId);
-                throw new DlcsException("Failed to create batch");
+                throw new DlcsException("Failed to create batch", HttpStatusCode.InternalServerError);
             }
             
             batches.Add(batch);

--- a/src/IIIFPresentation/DLCS/API/DlcsHttpContent.cs
+++ b/src/IIIFPresentation/DLCS/API/DlcsHttpContent.cs
@@ -58,7 +58,7 @@ internal static class DlcsHttpContent
         }
         catch (JsonReaderException jre)
         {
-            throw new DlcsException("Error reading DLCS response", jre);
+            throw new DlcsException("Error reading DLCS response", jre, response.StatusCode);
         }
     }
     
@@ -81,14 +81,14 @@ internal static class DlcsHttpContent
 
             if (error != null)
             {
-                return new DlcsException(error.Description);
+                return new DlcsException(error.Description, response.StatusCode);
             }
 
-            throw new DlcsException("Unable to process error condition");
+            throw new DlcsException("Unable to process error condition", response.StatusCode);
         }
         catch (Exception ex) when (ex is not DlcsException)
         {
-            return new DlcsException("Could not find a DlcsError in response", ex);
+            return new DlcsException("Could not find a DlcsError in response", ex, response.StatusCode);
         }
     }
 

--- a/src/IIIFPresentation/DLCS/API/DlcsHttpContent.cs
+++ b/src/IIIFPresentation/DLCS/API/DlcsHttpContent.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http.Json;
+﻿using System.Net;
+using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -58,7 +59,7 @@ internal static class DlcsHttpContent
         }
         catch (JsonReaderException jre)
         {
-            throw new DlcsException("Error reading DLCS response", jre, response.StatusCode);
+            throw new DlcsException("Error reading DLCS response", jre, HttpStatusCode.InternalServerError);
         }
     }
     

--- a/src/IIIFPresentation/DLCS/Exceptions/DlcsException.cs
+++ b/src/IIIFPresentation/DLCS/Exceptions/DlcsException.cs
@@ -8,14 +8,14 @@ namespace DLCS.Exceptions;
 /// </summary>
 public class DlcsException : Exception
 {
-    public HttpStatusCode? StatusCode { get; }
+    public HttpStatusCode StatusCode { get; }
     
-    public DlcsException(string? message, HttpStatusCode? statusCode) : base(message)
+    public DlcsException(string message, HttpStatusCode statusCode) : base(message)
     {
         StatusCode = statusCode;
     }
 
-    public DlcsException(string? message, Exception? innerException, HttpStatusCode? statusCode) : base(message, innerException)
+    public DlcsException(string message, Exception? innerException, HttpStatusCode statusCode) : base(message, innerException)
     {
         StatusCode = statusCode;
     }

--- a/src/IIIFPresentation/DLCS/Exceptions/DlcsException.cs
+++ b/src/IIIFPresentation/DLCS/Exceptions/DlcsException.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Core;
 
 namespace DLCS.Exceptions;
@@ -7,14 +8,15 @@ namespace DLCS.Exceptions;
 /// </summary>
 public class DlcsException : Exception
 {
-    WriteResult writeResult;
+    public HttpStatusCode? StatusCode { get; }
     
-    public DlcsException(string? message) : base(message)
+    public DlcsException(string? message, HttpStatusCode? statusCode) : base(message)
     {
-        writeResult = WriteResult.Error;
+        StatusCode = statusCode;
     }
 
-    public DlcsException(string? message, Exception? innerException) : base(message, innerException)
+    public DlcsException(string? message, Exception? innerException, HttpStatusCode? statusCode) : base(message, innerException)
     {
+        StatusCode = statusCode;
     }
 }

--- a/src/IIIFPresentation/DLCS/Exceptions/DlcsException.cs
+++ b/src/IIIFPresentation/DLCS/Exceptions/DlcsException.cs
@@ -1,3 +1,5 @@
+using Core;
+
 namespace DLCS.Exceptions;
 
 /// <summary>
@@ -5,8 +7,11 @@ namespace DLCS.Exceptions;
 /// </summary>
 public class DlcsException : Exception
 {
+    WriteResult writeResult;
+    
     public DlcsException(string? message) : base(message)
     {
+        writeResult = WriteResult.Error;
     }
 
     public DlcsException(string? message, Exception? innerException) : base(message, innerException)


### PR DESCRIPTION
Resolves #257

This PR allows a status code to be passed out from a DLCS exception, which can then be used by various callers to correctly set a response status code
