### PR TITLE
Impl #232 - static image width/height handling

### DIFF
--- a/src/IIIFPresentation/API.Tests/Features/Manifest/Validators/PresentationManifestValidatorTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Manifest/Validators/PresentationManifestValidatorTests.cs
@@ -239,6 +239,51 @@ public class PresentationManifestValidatorTests
         var result = sut.TestValidate(manifest);
         result.ShouldNotHaveValidationErrorFor(m => m.PaintedResources);
     }
+
+    [Fact]
+    public void CanvasPaintig_WithStaticSize_NoErrorWhenBothValues()
+    {
+        var manifest = new PresentationManifest
+        {
+            PaintedResources =
+            [
+                new PaintedResource
+                {
+                    CanvasPainting = new()
+                    {
+                        CanvasId = "someCanvasId-2137",
+                        StaticWidth = 100,
+                        StaticHeight = 100
+                    }
+                }
+            ]
+        };
+
+        var result = sut.TestValidate(manifest);
+        result.ShouldNotHaveValidationErrorFor(m => m.PaintedResources);
+    }
+
+    [Fact]
+    public void CanvasPaintig_WithStaticSize_ErrorWhenOneMissing()
+    {
+        var manifest = new PresentationManifest
+        {
+            PaintedResources =
+            [
+                new PaintedResource
+                {
+                    CanvasPainting = new()
+                    {
+                        CanvasId = "someCanvasId-2137",
+                        StaticWidth = 100
+                    }
+                }
+            ]
+        };
+
+        var result = sut.TestValidate(manifest);
+        result.ShouldHaveValidationErrorFor(m => m.PaintedResources);
+    }
     
     [Fact]
     public void CanvasPaintingAndItems_Manifest_NoErrorWhenNoChoiceNoCanvasMultiple()

--- a/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingResolver.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingResolver.cs
@@ -207,7 +207,9 @@ public class CanvasPaintingResolver(
                 CanvasOrder = paintedResource.CanvasPainting?.CanvasOrder ?? count,
                 AssetId = assetId,
                 ChoiceOrder = paintedResource.CanvasPainting?.ChoiceOrder ?? -1,
-                Ingesting = true
+                Ingesting = true,
+                StaticWidth = paintedResource.CanvasPainting?.StaticWidth,
+                StaticHeight = paintedResource.CanvasPainting?.StaticHeight
             };
 
             count++;

--- a/src/IIIFPresentation/API/Features/Manifest/Validators/PresentationManifestValidator.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/Validators/PresentationManifestValidator.cs
@@ -48,5 +48,15 @@ public class PresentationManifestValidator : AbstractValidator<PresentationManif
                 }))
             .When(f => !f.PaintedResources.IsNullOrEmpty() && !f.PaintedResources.Any(pr => pr.CanvasPainting == null))
             .WithMessage("'choiceOrder' cannot be a duplicate within a 'canvasOrder'");
+
+        RuleFor(f => f.PaintedResources)
+            .Must(lpr =>
+                lpr!.All(
+                    // either both have value, or none
+                    pr => pr.CanvasPainting!.StaticHeight.HasValue == pr.CanvasPainting.StaticWidth.HasValue))
+            .When(f => !f.PaintedResources.IsNullOrEmpty() && f.PaintedResources.All(pr => pr.CanvasPainting != null))
+            .WithMessage(
+                "'static_width' and 'static_height' have to be both set or both absent within a 'canvasPainting'");
+
     }
 }

--- a/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionMessageHandlerTests.cs
+++ b/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionMessageHandlerTests.cs
@@ -136,7 +136,7 @@ public class BatchCompletionMessageHandlerTests
                 Id = identifier
             });
 
-        var manifest = await dbContext.Manifests.AddTestManifest(batchId: batchId, spaceId: space);
+        var manifest = await dbContext.Manifests.AddTestManifest(batchId: batchId);
         var assetId = new AssetId(CustomerId, space, identifier);
         await dbContext.CanvasPaintings.AddTestCanvasPainting(manifest.Entity, assetId: assetId, ingesting: true,
             width: 80, height: 80);

--- a/src/IIIFPresentation/BackgroundHandler/BatchCompletion/BatchCompletionMessageHandler.cs
+++ b/src/IIIFPresentation/BackgroundHandler/BatchCompletion/BatchCompletionMessageHandler.cs
@@ -5,6 +5,7 @@ using BackgroundHandler.Helpers;
 using Core.Helpers;
 using Core.IIIF;
 using DLCS.API;
+using IIIF.ImageApi.V3;
 using IIIF.Presentation.V3;
 using IIIF.Presentation.V3.Content;
 using Microsoft.EntityFrameworkCore;
@@ -184,8 +185,14 @@ public class BatchCompletionMessageHandler(
             canvasPainting.Thumbnail = thumbnailPath != null ? new Uri(thumbnailPath) : null;
             canvasPainting.Ingesting = false;
             canvasPainting.Modified = DateTime.UtcNow;
-            canvasPainting.StaticHeight = item.Height;
-            canvasPainting.StaticWidth = item.Width;
+
+            //#232 Use ImageService - leaving previous values as fallback, seems safer - PK
+            var (height, width) = item.Service?.OfType<ImageService3>().FirstOrDefault()
+                is { } imageService
+                ? (imageService.Height, imageService.Width)
+                : (item.Height, item.Width);
+            canvasPainting.StaticHeight = height;
+            canvasPainting.StaticWidth = width;
         }
     }
 

--- a/src/IIIFPresentation/BackgroundHandler/BatchCompletion/BatchCompletionMessageHandler.cs
+++ b/src/IIIFPresentation/BackgroundHandler/BatchCompletion/BatchCompletionMessageHandler.cs
@@ -203,8 +203,7 @@ public class BatchCompletionMessageHandler(
                 }
             }
             else if (canvasPainting is {StaticWidth: { } staticWidth, StaticHeight: { } staticHeight}
-                     && item.Items?.GetFirstPaintingAnnotation()?.Body is Image image
-                     && manifest.SpaceId.HasValue) // required for ImageRequest parsing and modification
+                     && item.Items?.GetFirstPaintingAnnotation()?.Body is Image image) 
             {
                 // #232: if static_width/height provided in canvasPainting
                 // then don't use ones from NQ
@@ -213,8 +212,8 @@ public class BatchCompletionMessageHandler(
                 image.Width = staticWidth;
                 image.Height = staticHeight;
 
-                image.Id = pathGenerator.GetModifiedImageRequest(image.Id, manifest.CustomerId,
-                    manifest.SpaceId.Value, staticWidth, staticHeight);
+                image.Id = pathGenerator.GetModifiedImageRequest(image.Id, canvasPainting.AssetId!.Customer,
+                    canvasPainting.AssetId!.Space, staticWidth, staticHeight);
             }
         }
     }

--- a/src/IIIFPresentation/BackgroundHandler/BatchCompletion/BatchCompletionMessageHandler.cs
+++ b/src/IIIFPresentation/BackgroundHandler/BatchCompletion/BatchCompletionMessageHandler.cs
@@ -5,8 +5,11 @@ using BackgroundHandler.Helpers;
 using Core.Helpers;
 using Core.IIIF;
 using DLCS.API;
+using IIIF;
+using IIIF.ImageApi.V2;
 using IIIF.ImageApi.V3;
 using IIIF.Presentation.V3;
+using IIIF.Presentation.V3.Annotation;
 using IIIF.Presentation.V3.Content;
 using Microsoft.EntityFrameworkCore;
 using Models.Database.General;
@@ -173,8 +176,9 @@ public class BatchCompletionMessageHandler(
                 "Received a batch completion notification with no canvas paintings on the batch {BatchId}", batch.Id);
             return;
         }
-        
-        foreach (var canvasPainting in batch.Manifest.CanvasPaintings)
+
+        var manifest = batch.Manifest;
+        foreach (var canvasPainting in manifest.CanvasPaintings)
         {
             itemDictionary.TryGetValue(canvasPainting.AssetId!, out var item);
             
@@ -186,16 +190,86 @@ public class BatchCompletionMessageHandler(
             canvasPainting.Ingesting = false;
             canvasPainting.Modified = DateTime.UtcNow;
 
-            //#232 Use ImageService - leaving previous values as fallback, seems safer - PK
-            var (height, width) = item.Service?.OfType<ImageService3>().FirstOrDefault()
-                is { } imageService
-                ? (imageService.Height, imageService.Width)
-                : (item.Height, item.Width);
-            canvasPainting.StaticHeight = height;
-            canvasPainting.StaticWidth = width;
+            if (canvasPainting is {StaticWidth: null, StaticHeight: null})
+            {
+                // #232: set static width/height if not provided.
+                // if canvas painting comes with statics, use them
+                // otherwise, if we can find dimensions within, use those
+                // ReSharper disable once InvertIf
+                if (GetCanvasDimensions(item) is var (width, height))
+                {
+                    canvasPainting.StaticWidth = width;
+                    canvasPainting.StaticHeight = height;
+                }
+            }
+            else if (canvasPainting is {StaticWidth: { } staticWidth, StaticHeight: { } staticHeight}
+                     && item.Items?.GetFirstPaintingAnnotation()?.Body is Image image
+                     && manifest.SpaceId.HasValue) // required for ImageRequest parsing and modification
+            {
+                // #232: if static_width/height provided in canvasPainting
+                // then don't use ones from NQ
+                // and set the body to those dimensions + resized id (image request uri)
+
+                image.Width = staticWidth;
+                image.Height = staticHeight;
+
+                image.Id = pathGenerator.GetModifiedImageRequest(image.Id, manifest.CustomerId,
+                    manifest.SpaceId.Value, staticWidth, staticHeight);
+            }
         }
     }
 
+    private static (int width, int height)? GetCanvasDimensions(Canvas canvas)
+    {
+        switch (canvas.GetFirstPaintingAnnotation()?.Body)
+        {
+            case null:
+                // Just get from the services or from canvas itself as fallback
+                if (GetItemDimensionsFromServices(canvas.Service) is { } canvasDimensions)
+                    return canvasDimensions;
+                return canvas is {Width: { } cWidth, Height: { } cHeight}
+                    ? (cWidth, cHeight)
+                    : null;
+
+            case PaintingChoice choice:
+                // Again, try first from services
+                if (GetItemDimensionsFromServices(choice.Service) is { } choiceDimensions)
+                    return choiceDimensions;
+
+                // otherwise find like, first image with dimensions, if any
+                return GetItemDimensionsFromImage(choice.Items?.OfType<Image>()
+                    .FirstOrDefault(x => x is {Width: not null, Height: not null}));
+
+            case Image image:
+                return GetItemDimensionsFromImage(image);
+
+            default: return null;
+        }
+    }
+
+    private static (int width, int height)? GetItemDimensionsFromImage(Image? image) =>
+        image switch
+        {
+            null => null,
+            not null when GetItemDimensionsFromServices(image.Service) is { } imageDimensions => imageDimensions,
+            {Width: { } iWidth, Height: { } iHeight} => (iWidth, iHeight),
+            _ => null
+        };
+
+    private static (int width, int height)? GetItemDimensionsFromServices(IList<IService>? services)
+    {
+        if (services.IsNullOrEmpty())
+            return null;
+
+        if (services.OfType<ImageService3>().FirstOrDefault() is { } is3)
+            return (is3.Width, is3.Height);
+
+        if (services.OfType<ImageService2>().FirstOrDefault() is { } is2)
+            return (is2.Width, is2.Height);
+
+        return null;
+    }
+    
     private static BatchCompletionMessage DeserializeMessage(QueueMessage message)
     {
         var deserialized = JsonSerializer.Deserialize<BatchCompletionMessage>(message.Body, JsonSerializerOptions);

--- a/src/IIIFPresentation/BackgroundHandler/Helpers/ImageX.cs
+++ b/src/IIIFPresentation/BackgroundHandler/Helpers/ImageX.cs
@@ -1,0 +1,15 @@
+﻿using IIIF.Presentation.V3.Content;
+
+namespace BackgroundHandler.Helpers;
+
+public static class ImageX
+{
+    public static (int width, int height)? GetItemDimensionsFromImage(this Image? image) =>
+        image switch
+        {
+            null => null,
+            not null when image.Service.GetItemDimensionsFromServices() is { } imageDimensions => imageDimensions,
+            {Width: { } iWidth, Height: { } iHeight} => (iWidth, iHeight),
+            _ => null
+        };
+}

--- a/src/IIIFPresentation/BackgroundHandler/Helpers/ServiceListX.cs
+++ b/src/IIIFPresentation/BackgroundHandler/Helpers/ServiceListX.cs
@@ -1,0 +1,23 @@
+﻿using Core.Helpers;
+using IIIF;
+using IIIF.ImageApi.V2;
+using IIIF.ImageApi.V3;
+
+namespace BackgroundHandler.Helpers;
+
+public static class ServiceListX
+{
+    public static (int width, int height)? GetItemDimensionsFromServices(this IList<IService>? services)
+    {
+        if (services.IsNullOrEmpty())
+            return null;
+
+        if (services.OfType<ImageService3>().FirstOrDefault() is { } is3)
+            return (is3.Width, is3.Height);
+
+        if (services.OfType<ImageService2>().FirstOrDefault() is { } is2)
+            return (is2.Width, is2.Height);
+
+        return null;
+    }
+}

--- a/src/IIIFPresentation/Repository.Tests/Paths/PathGeneratorTests.cs
+++ b/src/IIIFPresentation/Repository.Tests/Paths/PathGeneratorTests.cs
@@ -375,6 +375,53 @@ public class PathGeneratorTests
         pathGenerator.GenerateHierarchicalFromFullPath(5, fullPath)
             .Should().Be(expected, "full path appended to customer");
     }
+
+    [Fact]
+    public void GetModifiedImageRequest_ReturnsNull_IfExistingIsNull()
+    {
+        pathGenerator.GetModifiedImageRequest(null, 1, 2, 3, 4)
+            .Should().BeNull("null in, null out");
+    }
+
+    [Fact]
+    public void GetModifiedImageRequest_ConstructsPrefix()
+    {
+        const int customerId = 123;
+        const int spaceId = 456;
+        var requestPath = $"iiif-img/{customerId}/{spaceId}/manifest_345/full/100,100/0/default.jpg";
+
+        pathGenerator.GetModifiedImageRequest(requestPath, customerId, spaceId, 100, 100)
+            .Should().Be(requestPath, "same size params should result in reconstructed identical URI");
+    }
+
+    [Fact]
+    public void GetModifiedImageRequest_SetsSizeParam()
+    {
+        const int customerId = 123;
+        const int spaceId = 456;
+        const int width = 75;
+        const int height = 50;
+        var requestPath = $"iiif-img/{customerId}/{spaceId}/manifest_345/full/100,100/0/default.jpg";
+
+        pathGenerator.GetModifiedImageRequest(requestPath, customerId, spaceId, width, height)
+            .Should().Contain($"/{width},{height}/");
+    }
+
+    [Fact]
+    public void GetModifiedImageRequest_SetsSizeParam_WhenFullUri()
+    {
+        const int customerId = 123;
+        const int spaceId = 456;
+        const int width = 75;
+        const int height = 50;
+        const string server = "https://example.com:8080";
+        var requestPath =
+            $"{server}/iiif-img/{customerId}/{spaceId}/manifest_345/full/100,100/0/default.jpg";
+
+        pathGenerator.GetModifiedImageRequest(requestPath, customerId, spaceId, width, height)
+            .Should().Contain($"/{width},{height}/")
+            .And.StartWith(server);
+    }
     
     private static List<Hierarchy> GetDefaultHierarchyList(string? fullPath = null) =>  
         [new() { Slug = "slug", FullPath = fullPath }];

--- a/src/IIIFPresentation/Repository/Paths/IPathGenerator.cs
+++ b/src/IIIFPresentation/Repository/Paths/IPathGenerator.cs
@@ -99,4 +99,6 @@ public interface IPathGenerator
     /// Generate the hierarchical id for specified customer and path slugs 
     /// </summary>
     string GenerateHierarchicalFromFullPath(int customerId, string? fullPath);
+
+    string? GetModifiedImageRequest(string? existing, int customerId, int spaceId, int width, int height);
 }

--- a/src/IIIFPresentation/Repository/Paths/IPathGenerator.cs
+++ b/src/IIIFPresentation/Repository/Paths/IPathGenerator.cs
@@ -100,5 +100,14 @@ public interface IPathGenerator
     /// </summary>
     string GenerateHierarchicalFromFullPath(int customerId, string? fullPath);
 
+    /// <summary>
+    ///     Parses an image request URI and rewrites it using provided width and height values
+    /// </summary>
+    /// <param name="existing">Existing image request uri</param>
+    /// <param name="customerId">existing image request customer id segment</param>
+    /// <param name="spaceId">existing image request space id segment</param>
+    /// <param name="width">new width to use</param>
+    /// <param name="height">new height to use</param>
+    /// <returns></returns>
     string? GetModifiedImageRequest(string? existing, int customerId, int spaceId, int width, int height);
 }

--- a/src/IIIFPresentation/Repository/Paths/PathGeneratorBase.cs
+++ b/src/IIIFPresentation/Repository/Paths/PathGeneratorBase.cs
@@ -1,4 +1,5 @@
-﻿using Models.Database;
+﻿using IIIF.ImageApi;
+using Models.Database;
 using Models.Database.Collections;
 using Models.Database.General;
 
@@ -97,6 +98,19 @@ public abstract class PathGeneratorBase : IPathGenerator
             Path = $"/customers/{canvasPainting.AssetId.Customer}/spaces/{canvasPainting.AssetId.Space}/images/{canvasPainting.AssetId.Asset}",
         };
         return uriBuilder.Uri;
+    }
+
+    public string? GetModifiedImageRequest(string? existing, int customerId, int spaceId, int width, int height)
+    {
+        const string dlcsImagePath = "iiif-img";
+        if (existing is null)
+            return null;
+
+        var prefix = $"{dlcsImagePath}/{customerId}/{spaceId}";
+
+        var ir = ImageRequest.Parse(existing, prefix);
+        ir.Size = new() {Width = width, Height = height};
+        return ir.ToString();
     }
 
     private string GetSlug(ResourceType resourceType) 

--- a/src/IIIFPresentation/Repository/Paths/PathGeneratorBase.cs
+++ b/src/IIIFPresentation/Repository/Paths/PathGeneratorBase.cs
@@ -109,7 +109,7 @@ public abstract class PathGeneratorBase : IPathGenerator
         var uriPrefix = string.Empty;
         if (Uri.TryCreate(existing, UriKind.Absolute, out var uri))
             uriPrefix = uri.GetComponents(UriComponents.SchemeAndServer, UriFormat.UriEscaped) + "/";
-        var prefix = $"{uriPrefix}{dlcsImagePath}/{customerId}/{spaceId}";
+        var prefix = $"{uriPrefix}{dlcsImagePath}/{customerId}/{spaceId}/";
 
         var ir = ImageRequest.Parse(existing, prefix);
         ir.Size = new() {Width = width, Height = height};

--- a/src/IIIFPresentation/Repository/Paths/PathGeneratorBase.cs
+++ b/src/IIIFPresentation/Repository/Paths/PathGeneratorBase.cs
@@ -106,7 +106,10 @@ public abstract class PathGeneratorBase : IPathGenerator
         if (existing is null)
             return null;
 
-        var prefix = $"{dlcsImagePath}/{customerId}/{spaceId}";
+        var uriPrefix = string.Empty;
+        if (Uri.TryCreate(existing, UriKind.Absolute, out var uri))
+            uriPrefix = uri.GetComponents(UriComponents.SchemeAndServer, UriFormat.UriEscaped) + "/";
+        var prefix = $"{uriPrefix}{dlcsImagePath}/{customerId}/{spaceId}";
 
         var ir = ImageRequest.Parse(existing, prefix);
         ir.Size = new() {Width = width, Height = height};

--- a/src/IIIFPresentation/Test.Helpers/Helpers/DatabaseTestDataPopulation.cs
+++ b/src/IIIFPresentation/Test.Helpers/Helpers/DatabaseTestDataPopulation.cs
@@ -16,12 +16,14 @@ public static class DatabaseTestDataPopulation
 {
     public static ValueTask<EntityEntry<Manifest>> AddTestManifest(this DbSet<Manifest> manifests,
         [CallerMemberName] string id = "", int customer = 1, DateTime? createdDate = null, string? slug = null,
-        string parent = "root", LanguageMap? label = null, int? batchId = null, bool ingested = false)
+        string parent = "root", LanguageMap? label = null, int? batchId = null, bool ingested = false,
+        int? spaceId = null)
     {
         createdDate ??= DateTime.UtcNow;
         return manifests.AddAsync(new Manifest
         {
             Id = id,
+            SpaceId = spaceId,
             CustomerId = customer,
             CreatedBy = "Admin",
             Created = createdDate.Value,


### PR DESCRIPTION
Implements changes described in #232 

---

- **Use `ImageService` w+h instead of `Canvas` w+h**
- **Validate that `static_width` is paired with `static_height` for `canvasPainting`**
- **Add `GetModifiedImageRequest` to `PathGenerator`**
- **In `BatchCompletionMessageHandler` handle static image sizes**
- **Add tests to cover #232 changes**
- **Handle fully qualified uris in `GetModifiedImageRequest`**

---

Code includes explanatory comments because it is neither obvious nor trivial.

To modify the `ImageRequest` size one has to know customer id and space id. While customer id is provided, space id is in theory optional.

While possible to manually deduce the space id from the existing image id, it feels like it is a bad idea to me, hence the image resizing will only happen if we have `SpaceId` on the manifest.

