### PR TITLE
Update API to return common error responses

### DIFF
--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestUpdateTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestUpdateTests.cs
@@ -544,5 +544,6 @@ public class ModifyManifestUpdateTests : IClassFixture<PresentationAppFactory<Pr
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         var errorResponse = await response.ReadAsPresentationResponseAsync<Error>();
         errorResponse!.Detail.Should().Be("Could not deserialize manifest");
+        errorResponse.ErrorTypeUri.Should().Be("http://localhost/errors/ModifyCollectionType/CannotDeserialize");
     }
 }

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestController.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestController.cs
@@ -14,6 +14,7 @@ using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
+using Models.API.General;
 using Models.API.Manifest;
 
 namespace API.Features.Manifest;
@@ -109,7 +110,7 @@ public class ManifestController(IOptions<ApiSettings> options, IAuthenticator au
         if (presentationManifest.Error)
         {
             return this.PresentationProblem("Could not deserialize manifest", null, (int) HttpStatusCode.BadRequest,
-                "Deserialization Error");
+                "Deserialization Error", this.GetErrorType(ModifyCollectionType.CannotDeserialize));
         }
 
         var validation = await validator.ValidateAsync(presentationManifest.ConvertedIIIF!, cancellationToken);

--- a/src/IIIFPresentation/API/Infrastructure/PresentationController.cs
+++ b/src/IIIFPresentation/API/Infrastructure/PresentationController.cs
@@ -173,11 +173,11 @@ public abstract class PresentationController : Controller
         }
         catch (APIException apiEx)
         {
-            return Problem(apiEx.Message, null, apiEx.StatusCode ?? 500, apiEx.Label);
+            return this.PresentationProblem(apiEx.Message, null, apiEx.StatusCode ?? 500, apiEx.Label);
         }
         catch (Exception ex)
         {
-            return Problem(ex.Message, null, 500, errorTitle);
+            return this.PresentationProblem(ex.Message, null, 500, errorTitle);
         }
     }
 }

--- a/src/IIIFPresentation/Models/API/General/ModifyCollectionType.cs
+++ b/src/IIIFPresentation/Models/API/General/ModifyCollectionType.cs
@@ -17,5 +17,6 @@ public enum ModifyCollectionType
     CouldNotRetrieveAssetId = 13,
     DlcsException = 14,
     ValidationFailed = 15,
+    CannotDeserialize = 16,
     Unknown = 1000
 }


### PR DESCRIPTION
Resolves #176 

Refactors the last sections of the API that use `Problem`, to use `PresentationProblem`, which should sort out the last few areas of the code that don't send a correct `error` response

Additionally, returns a correct error type for a manifest deserialization failure