### PR TITLE
Stop processing manifests from being shown in public storage collection views

### DIFF
--- a/src/IIIFPresentation/API.Tests/Helpers/PresentationContextXTests.cs
+++ b/src/IIIFPresentation/API.Tests/Helpers/PresentationContextXTests.cs
@@ -21,14 +21,22 @@ public class PresentationContextXTests
     public void RetrieveCollectionItems_ReturnsCanonicalOnlyManifestAndCollection()
     {
         var result = dbContext.RetrieveCollectionItems(1, "root");
-        var expectedSlugs = new[] { "first-child", "iiif-collection", "iiif-collection-with-items", "iiif-manifest", "non-public" };
+        var expectedSlugs = new[]
+        {
+            "first-child",
+            "iiif-collection", 
+            "iiif-collection-with-items", 
+            "iiif-manifest", 
+            "non-public", 
+            "iiif-manifest-processing"
+        };
 
-        result.Count().Should().Be(5);
+        result.Count().Should().Be(6);
         result.Select(h => h.Slug).Should().BeEquivalentTo(expectedSlugs);
     }
     
     [Fact]
-    public void RetrieveCollectionItems_CanExcludeNonPublicCollections()
+    public void RetrieveCollectionItems_CanExcludeNonPublicCollectionsAndProcessingManifests()
     {
         var result = dbContext.RetrieveCollectionItems(1, "root", true);
         var expectedSlugs = new[] { "first-child", "iiif-collection", "iiif-collection-with-items", "iiif-manifest" };
@@ -43,7 +51,7 @@ public class PresentationContextXTests
         var result = dbContext.RetrieveCollectionItems(1, "root").ToList();
 
         result.Where(r => r.Collection != null).Should().HaveCount(4);
-        result.Where(r => r.Manifest != null).Should().HaveCount(1);
+        result.Where(r => r.Manifest != null).Should().HaveCount(2);
         result.Should().AllSatisfy(h => h.ResourceId.Should().NotBeNullOrEmpty());
     }
 }

--- a/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
@@ -16,7 +16,7 @@ namespace API.Tests.Integration;
 public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
 {
     private readonly HttpClient httpClient;
-    private const int TotalDatabaseChildItems = 5;
+    private const int TotalDatabaseChildItems = 6;
     private readonly IAmazonS3 amazonS3;
 
     public GetCollectionTests(StorageFixture storageFixture, PresentationAppFactory<Program> factory)
@@ -40,7 +40,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         collection!.Id.Should().Be("http://localhost/1");
-        collection.Items.Count.Should().Be(TotalDatabaseChildItems - 1, "One child item is non-public");
+        collection.Items.Count.Should().Be(TotalDatabaseChildItems - 2, "Two child items are non-public");
         var firstItem = (Collection)collection.Items[0];
         firstItem.Id.Should().Be("http://localhost/1/first-child");
         firstItem.Behavior.Should().BeNull();
@@ -236,7 +236,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
     {
         // Arrange
         var requestMessage = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get, $"1/collections/{RootCollection.Id}");
-        var expectedTotals = new DescendantCounts(2, 2, 1); 
+        var expectedTotals = new DescendantCounts(2, 2, 2); 
 
         // Act
         var response = await httpClient.AsCustomer().SendAsync(requestMessage);
@@ -497,7 +497,7 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
     [Theory]
     [InlineData("id", "collections/NonPublic")]
     [InlineData("slug", "collections/NonPublic")]
-    [InlineData("created", "manifests/FirstChildManifest")]
+    [InlineData("created", "manifests/FirstChildManifestProcessing")]
     public async Task Get_RootFlat_ReturnsFirstPageWithSecondItem_WhenCalledWithSmallPageSizeAndOrderByDescending(string field, string expectedItemId)
     {
         // Arrange

--- a/src/IIIFPresentation/API/Features/Storage/Helpers/PresentationContextX.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Helpers/PresentationContextX.cs
@@ -149,7 +149,8 @@ public static class PresentationContextX
 
         if (publicOnly)
         {
-            hierarchy = hierarchy.Where(c => c.Collection == null || c.Collection.IsPublic);
+            hierarchy = hierarchy.Where(c => (c.Collection != null && c.Collection.IsPublic) ||  
+                                             (c.Manifest != null && c.Manifest.LastProcessed != null));
         }
 
         return hierarchy;

--- a/src/IIIFPresentation/Test.Helpers/Integration/PresentationContextFixture.cs
+++ b/src/IIIFPresentation/Test.Helpers/Integration/PresentationContextFixture.cs
@@ -240,6 +240,26 @@ public class PresentationContextFixture : IAsyncLifetime
             LastProcessed = DateTime.UtcNow
         });
         
+        // processing child manifest
+        await DbContext.Manifests.AddAsync(new Manifest
+        {
+            Id = "FirstChildManifestProcessing",
+            CustomerId = CustomerId,
+            Created = DateTime.UtcNow,
+            Modified = DateTime.UtcNow,
+            CreatedBy = "admin",
+            Hierarchy =
+            [
+                new Hierarchy
+                {
+                    Slug = "iiif-manifest-processing",
+                    Parent = RootCollection.Id,
+                    Type = ResourceType.IIIFManifest,
+                    Canonical = true
+                }
+            ]
+        });
+        
         await DbContext.SaveChangesAsync();
     }
     
@@ -281,6 +301,6 @@ public class PresentationContextFixture : IAsyncLifetime
         DbContext.Database.ExecuteSqlRaw(
             "DELETE FROM collections WHERE customer_id != 1 AND id NOT IN ('root','FirstChildCollection','SecondChildCollection', 'NonPublic', 'IiifCollection')");
         DbContext.Database.ExecuteSqlRaw(
-            "DELETE FROM manifests WHERE customer_id != 1 AND id NOT IN ('FirstChildManifest')");
+            "DELETE FROM manifests WHERE customer_id != 1 AND id NOT IN ('FirstChildManifest', 'FirstChildManifestProcessing')");
     }
 }


### PR DESCRIPTION
Resolves #288 

This PR makes it so that manifests that have never been processed to not be shown in the items of a hierarchical call for a storage collection