### PR TITLE
Rewrite NQ target to match canvasId

### DIFF
--- a/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionMessageHandlerTests.cs
+++ b/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionMessageHandlerTests.cs
@@ -236,11 +236,14 @@ public class BatchCompletionMessageHandlerTests
         A.CallTo(() => iiifS3.SaveIIIFToS3(A<ResourceBase>._, manifest, flatId, false, A<CancellationToken>._))
             .MustHaveHappened(1, Times.Exactly);
         var savedManifest = (IIIFManifest) resourceBase!;
-        savedManifest.Items[0].Id.Should().Be($"http://base/1/canvases/{canvasPaintingId}", "Canvas Id overwritten");
+        var expectedCanvasId = $"http://base/1/canvases/{canvasPaintingId}";
+        savedManifest.Items[0].Id.Should().Be(expectedCanvasId, "Canvas Id overwritten");
         savedManifest.Items[0].Items[0].Id.Should().Be($"http://base/1/canvases/{canvasPaintingId}/annopages/1",
             "AnnotationPage Id overwritten");
-        savedManifest.Items[0].Items[0].Items[0].As<PaintingAnnotation>().Id.Should().Be(
-            $"http://base/1/canvases/{canvasPaintingId}/annotations/1", "PaintingAnnotation Id overwritten");
+        var paintingAnnotation = savedManifest.Items[0].Items[0].Items[0].As<PaintingAnnotation>();
+        paintingAnnotation.Id.Should().Be($"http://base/1/canvases/{canvasPaintingId}/annotations/1",
+            "PaintingAnnotation Id overwritten");
+        paintingAnnotation.Target.As<Canvas>().Id.Should().Be(expectedCanvasId, "Target Id matches canvasId");
     }
 
     [Fact]

--- a/src/IIIFPresentation/BackgroundHandler/BatchCompletion/BatchCompletionMessageHandler.cs
+++ b/src/IIIFPresentation/BackgroundHandler/BatchCompletion/BatchCompletionMessageHandler.cs
@@ -125,7 +125,9 @@ public class BatchCompletionMessageHandler(
                     canvas.Id, dbManifest.CustomerId, dbManifest.Id);
                 canvas.Id = pathGenerator.GenerateCanvasId(canvasPaintingForAsset);
                 canvas.GetFirstAnnotationPage()!.Id = pathGenerator.GenerateAnnotationPagesId(canvasPaintingForAsset);
-                canvas.GetFirstPaintingAnnotation()!.Id = pathGenerator.GeneratePaintingAnnotationId(canvasPaintingForAsset);
+                var paintingAnnotation = canvas.GetFirstPaintingAnnotation().ThrowIfNull("canvas.PaintingAnnotation");
+                paintingAnnotation.Id = pathGenerator.GeneratePaintingAnnotationId(canvasPaintingForAsset);
+                paintingAnnotation.Target = new Canvas { Id = canvas.Id };
                 finalDictionary[assetId] = canvas;
             }
             return finalDictionary;


### PR DESCRIPTION
Fixes #326 

Sets target to match canvasId. `ManifestMerger` will ensure this value is pulled over to final manifest.

`paintingAnnotation.Target = new Canvas { Id = canvas.Id };` is rendered as just `"target" = "{id}"`, see https://github.com/digirati-co-uk/iiif-net?tab=readme-ov-file#canvas