### PR TITLE
Pass assets through to SetGeneratedFields

### DIFF
--- a/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
@@ -232,7 +232,8 @@ public class ManifestWriteService(
             await SaveToS3(dbManifest!, request, saveToStaging, cancellationToken);
 
             return PresUpdateResult.Success(
-                request.PresentationManifest.SetGeneratedFields(dbManifest!, pathGenerator),
+                request.PresentationManifest.SetGeneratedFields(dbManifest!, pathGenerator, 
+                    await manifestRead.GetAssets(request.CustomerId, dbManifest, cancellationToken)),
                 request.PresentationManifest.PaintedResources.HasAsset() ? WriteResult.Accepted : WriteResult.Updated);
         }
     }


### PR DESCRIPTION
Fixes an issue where assets weren't correctly passed through to the response.  This was due to assets not being correctly passed through to `SetGeneratedFields`