### PR TITLE
Allow assets or items in updates to empty manifests

### DIFF
--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestUpdateTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestUpdateTests.cs
@@ -570,4 +570,25 @@ public class ModifyManifestUpdateTests : IClassFixture<PresentationAppFactory<Pr
         error.ErrorTypeUri.Should()
             .Be("http://localhost/errors/ModifyCollectionType/ManifestCreatedWithAssetsCannotBeUpdatedWithItems");
     }
+    
+    [Fact]
+    public async Task UpdateManifest_UpdatesManifest_WhenExistingManifestNoItemsOrAssets()
+    {
+        // Arrange
+        var dbManifest =
+            (await dbContext.Manifests.AddTestManifest(ingested: true)).Entity;
+        await dbContext.SaveChangesAsync();
+        var parent = RootCollection.Id;
+        
+        var requestMessage =
+            HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Put, $"{Customer}/manifests/{dbManifest.Id}",
+                dbManifest.ToPresentationManifest(parent: parent).AsJson());
+        etagManager.SetCorrectEtag(requestMessage, dbManifest.Id, Customer);
+
+        // Act
+        var response = await httpClient.AsCustomer().SendAsync(requestMessage);
+        
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
 }

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
@@ -200,15 +200,18 @@ public class ManifestWriteService(
         
         var hasAsset = request.PresentationManifest.PaintedResources.HasAsset();
         var noBatches = existingManifest.Batches.IsNullOrEmpty();
-        
-        if (!hasAsset && !noBatches)
+
+        if (existingManifest.CanvasPaintings?.Count > 0)
         {
-            return ErrorHelper.ManifestCreatedWithAssetsCannotBeUpdatedWithItems<PresentationManifest>();
-        }
-        
-        if (hasAsset && noBatches)
-        {
-            return ErrorHelper.ManifestCreatedWithItemsCannotBeUpdatedWithAssets<PresentationManifest>();
+            if (!hasAsset && !noBatches)
+            {
+                return ErrorHelper.ManifestCreatedWithAssetsCannotBeUpdatedWithItems<PresentationManifest>();
+            }
+            
+            if (hasAsset && noBatches)
+            {
+                return ErrorHelper.ManifestCreatedWithItemsCannotBeUpdatedWithAssets<PresentationManifest>();
+            }
         }
 
         var parsedParentSlugResult = await parentSlugParser.Parse(request.PresentationManifest, request.CustomerId,


### PR DESCRIPTION
This PR allows a manifest to be created as an empty manifest and then updated with either assets or items