### PR TITLE
Fix #319 Exception when parent invalid

### DIFF
--- a/src/IIIFPresentation/API.Tests/Helpers/ParentSlugParserTests.cs
+++ b/src/IIIFPresentation/API.Tests/Helpers/ParentSlugParserTests.cs
@@ -296,6 +296,22 @@ public class ParentSlugParserTests
     }
     
     [Fact]
+    public async Task ParentSlugParser_Fails_InvalidHost()
+    {
+        var slug = nameof(ParentSlugParser_Fails_InvalidHost);
+        
+        // Act
+        var parentSlugParserResult = await parentSlugParser.Parse(new PresentationCollection
+        {
+            PublicId = $"http://example.com/{Customer}/{slug}",
+        }, Customer, null);
+
+        // Assert
+        parentSlugParserResult.IsError.Should().BeTrue();
+        parentSlugParserResult.Errors.Error.Should().Be("The parent collection could not be found");
+    }
+    
+    [Fact]
     public async Task ParentSlugParser_Fails_ParentIsIIIF()
     {
         // Arrange

--- a/src/IIIFPresentation/Repository.Tests/Paths/PathParserTests.cs
+++ b/src/IIIFPresentation/Repository.Tests/Paths/PathParserTests.cs
@@ -102,8 +102,7 @@ public class PathParserTests
     [Fact]
     public void GetHierarchicalSlugFromPath_ReturnsSlugFromPath()
     {
-        var slug = PathParser.GetHierarchicalFullPathFromPath("https://dlcs.example/1/slug/slug", 1,
-            "https://dlcs.example/");
+        var slug = PathParser.GetHierarchicalFullPathFromPath("/1/slug/slug", 1);
         
         slug.Should().Be("slug/slug");
     }

--- a/src/IIIFPresentation/Repository/Paths/PathParser.cs
+++ b/src/IIIFPresentation/Repository/Paths/PathParser.cs
@@ -1,5 +1,6 @@
 ﻿using Core.Helpers;
 using IIIF.Presentation.V3;
+using Models.API.Manifest;
 using Models.DLCS;
 
 namespace Repository.Paths;
@@ -26,7 +27,7 @@ public static class PathParser
         }
     }
 
-    public static string GetCanvasId(Models.API.Manifest.CanvasPainting canvasPainting, int customerId)
+    public static string GetCanvasId(CanvasPainting canvasPainting, int customerId)
     {
         var canvasId = canvasPainting.CanvasId.ThrowIfNull(nameof(canvasPainting));
 
@@ -57,10 +58,33 @@ public static class PathParser
             throw new ArgumentException($"canvas Id {canvasId} contains a prohibited character");
         }
     }
-    
-    public static string GetHierarchicalFullPathFromPath(string presentationParent, int customerId, string baseUrl) =>
-        presentationParent.Substring($"{baseUrl}/{customerId}".Length).TrimStart('/');
-    
+
+    public static string GetHierarchicalFullPathFromPath(string presentationParent, int customerId) =>
+        presentationParent.Trim('/').TrimExpect($"{customerId}").Trim('/');
+
+    /// <summary>
+    ///     Will ensure <paramref name="input" /> starts with entire <paramref name="expectation" />
+    ///     but will omit it from output. Throws if strings differ.
+    /// </summary>
+    /// <param name="input">a string</param>
+    /// <param name="expectation">string of characters expected to be present from <paramref name="input" /></param>
+    /// <returns><paramref name="input" /> with the <paramref name="expectation" /> omitted from the start</returns>
+    /// <exception cref="FormatException">
+    ///     if the <paramref name="input" /> does not start with <paramref name="expectation" />
+    /// </exception>
+    private static string TrimExpect(this string input, string expectation)
+    {
+        if (expectation.Length <= 0) return input;
+        var i = 0;
+        while (i < expectation.Length)
+        {
+            if (input[i] != expectation[i])
+                throw new FormatException($"Expected character '{expectation[i]}' but found '{input[i]}' at index {i}");
+            ++i;
+        }
+
+        return input[i..];
+    }
     public static Uri GetParentUriFromPublicId(string publicId) => 
         new(publicId[..publicId.LastIndexOf('/')]);
 


### PR DESCRIPTION
Fixes #319 

Existing implementation that used `.Substring($"{baseUrl}/{customerId}")` was prone to errors and potentially unpredictable behaviour in some potential parent/public id's. It did however prevent in most cases a misidentification of a path with one of a different customer.

I have expanded on this strength by checking separately for a matching host and separately performing "check and trim" of the path in the form of `/{customerId}/a/path/to/something/`.

Note that a failure when parsing/trimming the path should be very exceptional situation, hence handling via an exception, as it simplifies the code.