### PR TITLE
Increase logging around ETags and requests

### DIFF
--- a/src/IIIFPresentation/API.Tests/Attributes/ETagCachingAttributeTests.cs
+++ b/src/IIIFPresentation/API.Tests/Attributes/ETagCachingAttributeTests.cs
@@ -21,8 +21,6 @@ public class ETagCachingAttributeTests
 
     private class StubETagManager : IETagManager
     {
-        public int CacheTimeoutSeconds => 10;
-
         public bool TryGetETag(string resourcePath, out string? eTag)
         {
             eTag = null;

--- a/src/IIIFPresentation/API.Tests/Attributes/ETagCachingAttributeTests.cs
+++ b/src/IIIFPresentation/API.Tests/Attributes/ETagCachingAttributeTests.cs
@@ -23,7 +23,7 @@ public class ETagCachingAttributeTests
     {
         public int CacheTimeoutSeconds => 10;
 
-        public bool TryGetETag(string id, out string? eTag)
+        public bool TryGetETag(string resourcePath, out string? eTag)
         {
             eTag = null;
             return false;

--- a/src/IIIFPresentation/API/Infrastructure/Helpers/ETagManager.cs
+++ b/src/IIIFPresentation/API/Infrastructure/Helpers/ETagManager.cs
@@ -34,6 +34,6 @@ public class ETagManager(IAppCache appCache, IOptionsMonitor<CacheSettings> cach
     public void UpsertETag(string resourcePath, string etag)
     {
         logger.LogTrace("Caching etag {Etag} for {ResourcePath}", etag, resourcePath);
-        appCache.Add(resourcePath, etag, cacheOptions.CurrentValue.GetNonExpiringMemoryCacheOptions());
+        appCache.Add(resourcePath, etag, cacheOptions.CurrentValue.GetMemoryCacheOptions(CacheDuration.NeverExpire));
     }
 }

--- a/src/IIIFPresentation/API/Infrastructure/Helpers/IETagManager.cs
+++ b/src/IIIFPresentation/API/Infrastructure/Helpers/IETagManager.cs
@@ -5,14 +5,9 @@ namespace API.Infrastructure.Helpers;
 public interface IETagManager
 {
     /// <summary>
-    /// How long clients should cache the response
-    /// </summary>
-    public int CacheTimeoutSeconds { get; }
-    
-    /// <summary>
     /// Attempt to get ETag for specified id, where Id is the path of the resource
     /// </summary>
-    bool TryGetETag(string id, out string? eTag);
+    bool TryGetETag(string resourcePath, out string? eTag);
     
     /// <summary>
     /// Attempt to get ETag for specified resource

--- a/src/IIIFPresentation/API/Infrastructure/Mediatr/Behaviours/LoggingBehaviour.cs
+++ b/src/IIIFPresentation/API/Infrastructure/Mediatr/Behaviours/LoggingBehaviour.cs
@@ -8,7 +8,7 @@ namespace API.Infrastructure.Mediatr.Behaviours;
 ///     Will use ToString() property to log details
 /// </summary>
 public class LoggingBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
-    where TRequest : IRequest<TResponse>, ITimedRequest
+    where TRequest : IRequest<TResponse>, IBaseRequest
 {
     private readonly ILogger<LoggingBehavior<TRequest, TResponse>> logger;
 
@@ -20,26 +20,16 @@ public class LoggingBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, 
     public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next,
         CancellationToken cancellationToken)
     {
-        var logLevel = request.LoggingLevel ?? LogLevel.Debug;
-
         // This could be cleverer, currently will just log ToString()
-        logger.Log(logLevel, "Handling '{RequestType}' request. {Request}", typeof(TRequest).Name, request);
+        logger.LogTrace("Handling '{RequestType}' request. {Request}", typeof(TRequest).Name, request);
 
         var sw = Stopwatch.StartNew();
         var response = await next();
         sw.Stop();
 
-        logger.Log(logLevel, "Handled '{RequestType}' in {Elapsed}ms. {Request}", typeof(TRequest).Name,
+        logger.LogTrace("Handled '{RequestType}' in {Elapsed}ms. {Request}", typeof(TRequest).Name,
             sw.ElapsedMilliseconds, request);
 
         return response;
     }
-}
-
-/// <summary>
-///     Marker interface for requests that should be timed.
-/// </summary>
-public interface ITimedRequest : IRequest
-{
-    LogLevel? LoggingLevel { get; }
 }

--- a/src/IIIFPresentation/API/Settings/CacheSettings.cs
+++ b/src/IIIFPresentation/API/Settings/CacheSettings.cs
@@ -67,6 +67,18 @@ public class CacheSettings
             AbsoluteExpirationRelativeToNow =
                 TimeSpan.FromSeconds(GetTtl(duration, CacheSource.Memory)),
         };
+    
+    /// <summary>
+    /// Get <see cref="MemoryCacheEntryOptions"/> object that will never expire
+    /// </summary>
+    public MemoryCacheEntryOptions GetNonExpiringMemoryCacheOptions(
+        long size = 1,
+        CacheItemPriority priority = CacheItemPriority.Normal)
+        => new()
+        {
+            Priority = priority,
+            Size = size,
+        };
 }
 
 public class CacheGroupSettings

--- a/src/IIIFPresentation/API/Settings/CacheSettings.cs
+++ b/src/IIIFPresentation/API/Settings/CacheSettings.cs
@@ -60,25 +60,21 @@ public class CacheSettings
     public MemoryCacheEntryOptions GetMemoryCacheOptions(
         CacheDuration duration = CacheDuration.Default, long size = 1,
         CacheItemPriority priority = CacheItemPriority.Normal)
-        => new()
-        {
-            Priority = priority,
-            Size = size,
-            AbsoluteExpirationRelativeToNow =
-                TimeSpan.FromSeconds(GetTtl(duration, CacheSource.Memory)),
-        };
-    
-    /// <summary>
-    /// Get <see cref="MemoryCacheEntryOptions"/> object that will never expire
-    /// </summary>
-    public MemoryCacheEntryOptions GetNonExpiringMemoryCacheOptions(
-        long size = 1,
-        CacheItemPriority priority = CacheItemPriority.Normal)
-        => new()
+    {
+        var memoryCacheEntryOptions = new MemoryCacheEntryOptions
         {
             Priority = priority,
             Size = size,
         };
+
+        if (duration != CacheDuration.NeverExpire)
+        {
+            memoryCacheEntryOptions.AbsoluteExpirationRelativeToNow =
+                TimeSpan.FromSeconds(GetTtl(duration, CacheSource.Memory));
+        }
+        
+        return memoryCacheEntryOptions;
+    }
 }
 
 public class CacheGroupSettings
@@ -129,5 +125,6 @@ public enum CacheDuration
 {
     Short,
     Default,
-    Long
+    Long,
+    NeverExpire,
 }


### PR DESCRIPTION
Tweak `ETagManager` to cache items without an absolute expiry. MemoryCache is configured with a limit and compaction % so these should manage the cleanup when under pressure. 

_Note that we'll need to verify these settings when deploying._

Added trace logging to etag manager to help with issues when deployed. Also tweaked `LoggingBehaviour` to add trace logging for _all_ mediatr requests. Ultimately we want to be more targeted in this but it'll potentially help to see how long various requests are taking - current request logging will show the overall request but this will help to differentiate between the end to end request and just the business logic side (ie not streaming in/out content etc).