### PR TITLE
Fix duplicate canvasOrder error when there are null choice orders

### DIFF
--- a/src/IIIFPresentation/API.Tests/Features/Manifest/Validators/PresentationManifestValidatorTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Manifest/Validators/PresentationManifestValidatorTests.cs
@@ -181,6 +181,8 @@ public class PresentationManifestValidatorTests
     {
         var manifest = new PresentationManifest
         {
+            Slug = "someSlug",
+            Parent = "https://someParent",
             PaintedResources =
             [
                 new PaintedResource
@@ -188,8 +190,7 @@ public class PresentationManifestValidatorTests
                     CanvasPainting = new CanvasPainting
                     {
                         CanvasId = "someCanvasId-1",
-                        CanvasOrder = 1,
-                        ChoiceOrder = 1
+                        CanvasOrder = 1
                     }
                 },
 
@@ -200,6 +201,16 @@ public class PresentationManifestValidatorTests
                         CanvasId = "someCanvasId-2",
                         CanvasOrder = 1
                     }
+                },
+                
+                new PaintedResource
+                {
+                    CanvasPainting = new CanvasPainting
+                    {
+                        CanvasId = "someCanvasId-3",
+                        CanvasOrder = 1,
+                        ChoiceOrder = 1
+                    }
                 }
             ],
         };
@@ -207,6 +218,8 @@ public class PresentationManifestValidatorTests
         var result = sut.TestValidate(manifest);
         result.ShouldHaveValidationErrorFor(m => m.PaintedResources)
             .WithErrorMessage("'choiceOrder' cannot be null within a duplicate 'canvasOrder'");
+        
+        result.Errors.Should().HaveCount(1);
     }
     
     [Fact]

--- a/src/IIIFPresentation/API/Features/Manifest/Validators/PresentationManifestValidator.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/Validators/PresentationManifestValidator.cs
@@ -33,7 +33,7 @@ public class PresentationManifestValidator : AbstractValidator<PresentationManif
                 .Any(s => s.Any(g => g.CanvasPainting.ChoiceOrder == null)))
             .When(f => !f.PaintedResources.IsNullOrEmpty() && !f.PaintedResources.Any(pr => pr.CanvasPainting == null))
             .WithMessage("'choiceOrder' cannot be null within a duplicate 'canvasOrder'");
-        
+
         RuleFor(f => f.PaintedResources)
             .Must(lpr => !lpr.Where(pr => pr.CanvasPainting.CanvasOrder != null)
                 .GroupBy(pr => pr.CanvasPainting.CanvasOrder)
@@ -43,7 +43,8 @@ public class PresentationManifestValidator : AbstractValidator<PresentationManif
 
                     return distinctChoiceOrder != s.Count();
                 }))
-            .When(f => !f.PaintedResources.IsNullOrEmpty() && !f.PaintedResources.Any(pr => pr.CanvasPainting == null))
+            .When(f => !f.PaintedResources.IsNullOrEmpty() &&
+                       f.PaintedResources.All(pr => pr.CanvasPainting?.ChoiceOrder != null))
             .WithMessage("'choiceOrder' cannot be a duplicate within a 'canvasOrder'");
 
         RuleFor(f => f.PaintedResources)


### PR DESCRIPTION
Resolves #338

This PR disables the `'choiceOrder' cannot be a duplicate within a 'canvasOrder'` check when there are `null` `choiceOrder` values as this error is caught by `'choiceOrder' cannot be null within a duplicate 'canvasOrder'`