### PR TITLE
Use pathGenerator to get hierarch manifest redirect

### DIFF
--- a/src/IIIFPresentation/API.Tests/Integration/GetManifestTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/GetManifestTests.cs
@@ -99,6 +99,57 @@ public class GetManifestTests : IClassFixture<PresentationAppFactory<Program>>
                 A<CancellationToken>._))
             .ReturnsLazily(() => [ingestingAsset, errorAsset]);
     }
+    
+    [Fact]
+    public async Task Get_Hierarchical_ReturnsNotFound_WhenAuthAndShowExtrasHeaders_IfNotFound()
+    {
+        // Arrange
+        var requestMessage = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get, "1/no-here");
+        
+        // Act
+        var response = await httpClient.AsCustomer().SendAsync(requestMessage);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+    
+    [Fact]
+    public async Task Get_Hierarchical_ReturnsNotFound_WhenNoAuth_IfNotFound()
+    {
+        // Arrange
+        var requestMessage = new HttpRequestMessage(HttpMethod.Get, "1/no-here");
+        
+        // Act
+        var response = await httpClient.AsCustomer().SendAsync(requestMessage);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+    
+    [Fact]
+    public async Task Get_Hierarchical_ReturnsSeeOther_WhenAuthAndShowExtrasHeaders()
+    {
+        // Arrange
+        var requestMessage = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get, "1/iiif-manifest");
+        
+        // Act
+        var response = await httpClient.AsCustomer().SendAsync(requestMessage);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.SeeOther);
+        response.Headers.Location.Should().NotBeNull();
+        response.Headers.Location!.Should().Be("http://localhost/1/manifests/FirstChildManifest");
+    }
+    
+    [Fact]
+    public async Task Get_Flat_ReturnsNotFound_WhenNotExtraHeaders()
+    {
+        var requestMessage = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get, "1/manifests/no-here");
+        var response = await httpClient.AsCustomer().SendAsync(requestMessage);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
 
     [Fact]
     public async Task Get_IiifManifest_Flat_ReturnsRedirect_WhenNoExtraHeaders()

--- a/src/IIIFPresentation/API/Features/Storage/StorageController.cs
+++ b/src/IIIFPresentation/API/Features/Storage/StorageController.cs
@@ -46,10 +46,12 @@ public class StorageController(
         {
             case ResourceType.IIIFManifest:
                 if (Request.HasShowExtraHeader() && await authenticator.ValidateRequest(Request) == AuthResult.Success)
+                {
                     return hierarchy.ManifestId == null
                         ? this.PresentationNotFound()
-                        : SeeOther($"manifests/{hierarchy.ManifestId}");
-                
+                        : SeeOther(pathGenerator.GenerateFlatId(hierarchy));
+                }
+
                 var storedManifest = await mediator.Send(new GetManifestHierarchical(hierarchy));
                 return storedManifest == null ? this.PresentationNotFound() : this.PresentationContent(storedManifest);
 
@@ -61,9 +63,9 @@ public class StorageController(
 
                 if (Request.HasShowExtraHeader() && await authenticator.ValidateRequest(Request) == AuthResult.Success)
                 {
-                    var relativeUrl = pathGenerator.GenerateFlatCollectionId(storageRoot.Collection);
-                    relativeUrl = QueryHelpers.AddQueryString(relativeUrl, Request.Query);
-                    return SeeOther(relativeUrl);
+                    var absoluteUri = pathGenerator.GenerateFlatId(hierarchy);
+                    absoluteUri = QueryHelpers.AddQueryString(absoluteUri, Request.Query);
+                    return SeeOther(absoluteUri);
                 }
 
                 return storageRoot.StoredCollection == null

--- a/src/IIIFPresentation/Test.Helpers/Integration/PresentationContextFixture.cs
+++ b/src/IIIFPresentation/Test.Helpers/Integration/PresentationContextFixture.cs
@@ -43,7 +43,9 @@ public class PresentationContextFixture : IAsyncLifetime
          *     - SecondChildCollection/
          *   - NonPublic/
          *   - IiifCollection/
+         *   - IiifCollectionWithItems/
          *   - FirstChildManifest/
+         *   - FirstChildManifestProcessing/
          */
         
         // Root collection


### PR DESCRIPTION
Was generating path in method but missing customerId. 

Updated Collection and Manifest redirects to use same `GenerateFlatId()` method (Collection was previously using `GenerateFlatCollectionId()`, which outputs the same value).

Fixes #360 