### PR TITLE
Allow orchestrator uri to be set per customer

### DIFF
--- a/src/IIIFPresentation/DLCS.Tests/DlcsSettingsTests.cs
+++ b/src/IIIFPresentation/DLCS.Tests/DlcsSettingsTests.cs
@@ -1,0 +1,63 @@
+﻿namespace DLCS.Tests;
+
+public class DlcsSettingsTests
+{
+    [Fact]
+    public void GetOrchestratorUri_Throws_IfNoDefaultAndNoOverrides()
+    {
+        var settings = GetSettings(settings => settings.OrchestratorUri = null);
+
+        Action act = () => settings.GetOrchestratorUri(10);
+        act.Should().ThrowExactly<ArgumentNullException>();
+    }
+    
+    [Fact]
+    public void GetOrchestratorUri_ReturnsDefault_IfNoOverride()
+    {
+        var defaultUri = new Uri("https://dlcs.default");
+        var settings = GetSettings(settings => settings.OrchestratorUri = defaultUri);
+
+        settings.GetOrchestratorUri(100).Should().Be(defaultUri, "Default returned, no overrides");
+    }
+    
+    [Fact]
+    public void GetOrchestratorUri_ReturnsDefault_IfCustomerOverrideForDifferentCustomer()
+    {
+        var defaultUri = new Uri("https://dlcs.default");
+        var customerUri = new Uri("https://dlcs.customer");
+        const int customerId = 100;
+        var settings = GetSettings(settings =>
+        {
+            settings.OrchestratorUri = defaultUri;
+            settings.CustomerOrchestratorUri[customerId + 100] = customerUri; 
+        });
+
+        settings.GetOrchestratorUri(customerId).Should().Be(defaultUri, "Default returned, no override for customer");
+    }
+    
+    [Fact]
+    public void GetOrchestratorUri_ReturnsCustomerSpecific_IfFound()
+    {
+        var defaultUri = new Uri("https://dlcs.default");
+        var customerUri = new Uri("https://dlcs.customer");
+        const int customerId = 100;
+        var settings = GetSettings(settings =>
+        {
+            settings.OrchestratorUri = defaultUri;
+            settings.CustomerOrchestratorUri[customerId] = customerUri; 
+        });
+        
+        settings.GetOrchestratorUri(customerId).Should().Be(customerUri, "Customer specific returned");
+    }
+
+    // Get and setup settings with default values set
+    private DlcsSettings GetSettings(Action<DlcsSettings> setup)
+    {
+        var settings = new DlcsSettings
+        {
+            ApiUri = new Uri("https://dlcs.api"),
+        };
+        setup(settings);
+        return settings;
+    }
+}

--- a/src/IIIFPresentation/DLCS/API/DlcsOrchestratorClient.cs
+++ b/src/IIIFPresentation/DLCS/API/DlcsOrchestratorClient.cs
@@ -23,10 +23,15 @@ public class DlcsOrchestratorClient(
     {
         var batchString = string.Join(',', batches);
 
-        var requestUri =
-            $"/iiif-resource/v3/{customerId}/{settings.ManifestNamedQueryName}/{batchString}?cacheBust={DateTime.UtcNow.Ticks}";
+        var hostname = settings.GetOrchestratorUri(customerId);
+
+        var uriBuilder = new UriBuilder(hostname)
+        {
+            Path = $"/iiif-resource/v3/{customerId}/{settings.ManifestNamedQueryName}/{batchString}",
+            Query = $"cacheBust={DateTime.UtcNow.Ticks}"
+        };
         
-        var response = await httpClient.GetAsync(requestUri, cancellationToken);
+        var response = await httpClient.GetAsync(uriBuilder.Uri, cancellationToken);
         return await response.ReadAsIIIFResponse<Manifest>(cancellationToken);
     }
 }

--- a/src/IIIFPresentation/DLCS/DlcsSettings.cs
+++ b/src/IIIFPresentation/DLCS/DlcsSettings.cs
@@ -1,3 +1,5 @@
+using Core.Helpers;
+
 namespace DLCS;
 
 public class DlcsSettings
@@ -13,6 +15,19 @@ public class DlcsSettings
     /// URL root of DLCS Orchestrator 
     /// </summary>
     public Uri? OrchestratorUri { get; set; }
+    
+    /// <summary>
+    /// Optional dictionary of customerId:orchestratorUri, allows overriding per customer
+    /// </summary>
+    public Dictionary<int, Uri> CustomerOrchestratorUri { get; set; } = new();
+
+    /// <summary>
+    /// Get Orchestrator URI to use for customer 
+    /// </summary>
+    /// <param name="customerId">CustomerId to get URI for</param>
+    /// <returns>Customer specific overrides, or default if not found.</returns>
+    public Uri GetOrchestratorUri(int customerId)
+        => CustomerOrchestratorUri.GetValueOrDefault(customerId, OrchestratorUri.ThrowIfNull(nameof(OrchestratorUri)));
         
     /// <summary>
     /// Default timeout (in ms) use for HttpClient.Timeout in the API.

--- a/src/IIIFPresentation/DLCS/ServiceCollectionX.cs
+++ b/src/IIIFPresentation/DLCS/ServiceCollectionX.cs
@@ -36,9 +36,7 @@ public static class ServiceCollectionX
     {
         services
             .AddTransient<TimingHandler>()
-            .AddHttpClient<IDlcsOrchestratorClient, DlcsOrchestratorClient>(client =>
-            {
-                client.BaseAddress = dlcsSettings.OrchestratorUri;
+            .AddHttpClient<IDlcsOrchestratorClient, DlcsOrchestratorClient>(client => {
                 client.Timeout = TimeSpan.FromMilliseconds(dlcsSettings.OrchestratorDefaultTimeoutMs);
             })
             .AddHttpMessageHandler<TimingHandler>();


### PR DESCRIPTION
Resolves #367 

Adds new optional appsetting, which is orchestrator uri per customer:

```json
{
    "OrchestratorUri": "https://dlcs.default",
    "CustomerOrchestratorUri": {
      "7": "https://dlcs.customer7"
    }
}
```

Using above, customer 7 would use `https://dlcs.customer7/*` and all other customers `https://dlcs.default`.

This will control which uri the NQ is requested on, which allows for custom path formats to be used (via https://github.com/dlcs/protagonist/issues/983)