### PR TITLE
Handle alt asset formats for setting w + h

### DIFF
--- a/src/IIIFPresentation/API/API.csproj
+++ b/src/IIIFPresentation/API/API.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.10.0" />
-        <PackageReference Include="iiif-net" Version="0.3.5" />
+        <PackageReference Include="iiif-net" Version="0.3.6" />
         <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.8" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.7" />

--- a/src/IIIFPresentation/BackgroundHandler.Tests/Helpers/ManifestTestCreator.cs
+++ b/src/IIIFPresentation/BackgroundHandler.Tests/Helpers/ManifestTestCreator.cs
@@ -280,7 +280,7 @@ public class ManifestTestCreator
             Label = new("en", $"{id}_Image")
         };
     
-    public static Manifest GenerateMinimalNamedQueryManifest(AssetId fullAssetId, Uri presentationUrl)
+    public static Manifest GenerateMinimalNamedQueryManifest(AssetId fullAssetId, Uri presentationUrl, string? bodyId = null)
     {
         var qualifiedAssetId = $"{presentationUrl}iiif-img/{fullAssetId}";
         var canvasId = $"{qualifiedAssetId}/canvas/c/1";
@@ -305,7 +305,7 @@ public class ManifestTestCreator
                                     Id = $"{canvasId}/page/image",
                                     Body = new Image
                                     {
-                                        Id = $"{qualifiedAssetId}/full/100,100/0/default.jpg",
+                                        Id = bodyId ?? $"{qualifiedAssetId}/full/100,100/0/default.jpg",
                                         Width = 100,
                                         Height = 100,
                                         Service =

--- a/src/IIIFPresentation/BackgroundHandler/BatchCompletion/BatchCompletionMessageHandler.cs
+++ b/src/IIIFPresentation/BackgroundHandler/BatchCompletion/BatchCompletionMessageHandler.cs
@@ -235,8 +235,7 @@ public class BatchCompletionMessageHandler(
                 image.Width = staticWidth;
                 image.Height = staticHeight;
 
-                image.Id = pathGenerator.GetModifiedImageRequest(image.Id, canvasPainting.AssetId!.Customer,
-                    canvasPainting.AssetId!.Space, staticWidth, staticHeight);
+                image.Id = pathGenerator.GetModifiedImageRequest(image.Id, staticWidth, staticHeight);
             }
         }
     }

--- a/src/IIIFPresentation/Core/Core.csproj
+++ b/src/IIIFPresentation/Core/Core.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="iiif-net" Version="0.3.5" />
+      <PackageReference Include="iiif-net" Version="0.3.6" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>

--- a/src/IIIFPresentation/Models/Models.csproj
+++ b/src/IIIFPresentation/Models/Models.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="iiif-net" Version="0.3.5" />
+      <PackageReference Include="iiif-net" Version="0.3.6" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/IIIFPresentation/Repository.Tests/Paths/PathGeneratorTests.cs
+++ b/src/IIIFPresentation/Repository.Tests/Paths/PathGeneratorTests.cs
@@ -381,7 +381,7 @@ public class PathGeneratorTests
     [Fact]
     public void GetModifiedImageRequest_ReturnsNull_IfExistingIsNull()
     {
-        pathGenerator.GetModifiedImageRequest(null, 1, 2, 3, 4)
+        pathGenerator.GetModifiedImageRequest(null, 1, 2)
             .Should().BeNull("null in, null out");
     }
 
@@ -392,7 +392,7 @@ public class PathGeneratorTests
         const int spaceId = 456;
         var requestPath = $"iiif-img/{customerId}/{spaceId}/manifest_345/full/100,100/0/default.jpg";
 
-        pathGenerator.GetModifiedImageRequest(requestPath, customerId, spaceId, 100, 100)
+        pathGenerator.GetModifiedImageRequest(requestPath, 100, 100)
             .Should().Be(requestPath, "same size params should result in reconstructed identical URI");
     }
 
@@ -405,7 +405,7 @@ public class PathGeneratorTests
         const int height = 50;
         var requestPath = $"iiif-img/{customerId}/{spaceId}/manifest_345/full/100,100/0/default.jpg";
 
-        pathGenerator.GetModifiedImageRequest(requestPath, customerId, spaceId, width, height)
+        pathGenerator.GetModifiedImageRequest(requestPath, width, height)
             .Should().Contain($"/{width},{height}/");
     }
 
@@ -420,9 +420,26 @@ public class PathGeneratorTests
         var requestPath =
             $"{server}/iiif-img/{customerId}/{spaceId}/manifest_345/full/100,100/0/default.jpg";
 
-        pathGenerator.GetModifiedImageRequest(requestPath, customerId, spaceId, width, height)
+        pathGenerator.GetModifiedImageRequest(requestPath, width, height)
             .Should().Contain($"/{width},{height}/")
             .And.StartWith(server);
+    }
+    
+    [Theory]
+    [InlineData("asset/iiif-img/1/2/foo/full/max/0/default.jpg", "asset/iiif-img/1/2/foo/full/75,50/0/default.jpg")]
+    [InlineData("https://dlcs.example/asset/iiif-img/1/2/foo/full/max/0/default.jpg", "https://dlcs.example/asset/iiif-img/1/2/foo/full/75,50/0/default.jpg")]
+    [InlineData("img/foo/full/!400,400/0/default.jpg", "img/foo/full/75,50/0/default.jpg")]
+    [InlineData("https://dlcs.example/img/foo/full/!400,400/0/default.jpg", "https://dlcs.example/img/foo/full/75,50/0/default.jpg")]
+    public void GetModifiedImageRequest_SetsSizeParam_WhenRewritten(string input, string expected)
+    {
+        // Verify that we can handle image paths for "rewritten" (non standard) asset paths
+        const int customerId = 123;
+        const int spaceId = 456;
+        const int width = 75;
+        const int height = 50;
+
+        pathGenerator.GetModifiedImageRequest(input, width, height)
+            .Should().Be(expected);
     }
     
     private static List<Hierarchy> GetDefaultHierarchyList(string? fullPath = null) =>  

--- a/src/IIIFPresentation/Repository/Paths/IPathGenerator.cs
+++ b/src/IIIFPresentation/Repository/Paths/IPathGenerator.cs
@@ -104,10 +104,8 @@ public interface IPathGenerator
     ///     Parses an image request URI and rewrites it using provided width and height values
     /// </summary>
     /// <param name="existing">Existing image request uri</param>
-    /// <param name="customerId">existing image request customer id segment</param>
-    /// <param name="spaceId">existing image request space id segment</param>
     /// <param name="width">new width to use</param>
     /// <param name="height">new height to use</param>
     /// <returns></returns>
-    string? GetModifiedImageRequest(string? existing, int customerId, int spaceId, int width, int height);
+    string? GetModifiedImageRequest(string? existing, int width, int height);
 }

--- a/src/IIIFPresentation/Repository/Paths/PathGeneratorBase.cs
+++ b/src/IIIFPresentation/Repository/Paths/PathGeneratorBase.cs
@@ -100,20 +100,13 @@ public abstract class PathGeneratorBase(IPresentationPathGenerator presentationP
         return uriBuilder.Uri;
     }
 
-    public string? GetModifiedImageRequest(string? existing, int customerId, int spaceId, int width, int height)
+    public string? GetModifiedImageRequest(string? existing, int width, int height)
     {
-        const string dlcsImagePath = "iiif-img";
-        if (existing is null)
-            return null;
+        if (string.IsNullOrEmpty(existing)) return existing;
+        if (!ImageRequest.TryParse(existing, out var imageRequest)) return existing;
 
-        var uriPrefix = string.Empty;
-        if (Uri.TryCreate(existing, UriKind.Absolute, out var uri))
-            uriPrefix = uri.GetComponents(UriComponents.SchemeAndServer, UriFormat.UriEscaped) + "/";
-        var prefix = $"{uriPrefix}{dlcsImagePath}/{customerId}/{spaceId}/";
-
-        var ir = ImageRequest.Parse(existing, prefix);
-        ir.Size = new() {Width = width, Height = height};
-        return ir.ToString();
+        imageRequest.Size = new() { Width = width, Height = height };
+        return imageRequest.ToString();
     }
 
     private string GetResourceType(ResourceType resourceType) 

--- a/src/IIIFPresentation/Repository/Repository.csproj
+++ b/src/IIIFPresentation/Repository/Repository.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="EFCore.NamingConventions" Version="8.0.3" />
-        <PackageReference Include="iiif-net" Version="0.3.5" />
+        <PackageReference Include="iiif-net" Version="0.3.6" />
         <PackageReference Include="MediatR" Version="12.4.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.4" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />


### PR DESCRIPTION
If staticWidth and staticHeight specified, use these to set image id. This handles non-canonical path formats introduced to Protagonist in https://github.com/dlcs/protagonist/issues/983

Follow on from impl for #375 