### PR TITLE
Allow canvas ID to be a mix of specified and unspecified values

### DIFF
--- a/src/IIIFPresentation/API.Tests/Features/Manifest/Validators/PresentationManifestValidatorTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Manifest/Validators/PresentationManifestValidatorTests.cs
@@ -390,34 +390,4 @@ public class PresentationManifestValidatorTests
         result.ShouldHaveValidationErrorFor(m => m.PaintedResources)
             .WithErrorMessage("'canvasOrder' is required on all resources when used in at least one");
     }
-    
-    [Fact]
-    public void CanvasPaintingAndItems_Manifest_ErrorWhenNotEveryItemHasCanvasId()
-    {
-        var manifest = new PresentationManifest
-        {
-            PaintedResources =
-            [
-                new PaintedResource
-                {
-                    CanvasPainting = new CanvasPainting
-                    {
-                        CanvasId = "someCanvasId"
-                    }
-                },
-
-                new PaintedResource
-                {
-                    CanvasPainting = new CanvasPainting
-                    {
-                        CanvasId = null
-                    }
-                }
-            ],
-        };
-        
-        var result = sut.TestValidate(manifest);
-        result.ShouldHaveValidationErrorFor(m => m.PaintedResources)
-            .WithErrorMessage("'canvasId' is required on all resources when used in at least one");
-    }
 }

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
@@ -1294,13 +1294,14 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
         responseManifest.Should().NotBeNull();
         responseManifest!.PaintedResources.Should().NotBeNull();
         responseManifest.PaintedResources!.Count.Should().Be(2);
+        
         responseManifest.PaintedResources.First().CanvasPainting.CanvasId.Should().Be("http://localhost/1/canvases/canvasId");
         responseManifest.PaintedResources.First().Asset!.TryGetValue("@id", out var assetId).Should().BeTrue();
         assetId!.Type.Should().Be(JTokenType.String);
         assetId.Value<string>().Should()
             .EndWith($"/customers/{Customer}/spaces/{NewlyCreatedSpace}/images/{postedAssetId}");
         
-        responseManifest.PaintedResources.Last().CanvasPainting.CanvasId.Should().NotBeNull();
+        responseManifest.PaintedResources.Last().CanvasPainting.CanvasId.Should().NotBeNullOrEmpty();
         responseManifest.PaintedResources.Last().Asset!.TryGetValue("@id", out var secondAssetId).Should().BeTrue();
         secondAssetId!.Type.Should().Be(JTokenType.String);
         secondAssetId.Value<string>().Should()

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
@@ -1251,9 +1251,9 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
     [Fact]
     public async Task CreateManifest_CreatesManifest_WhenWithAndWithoutCanvasId()
     {
-        const string postedAssetId = "theAssetId";
+        const string postedAssetId = "AnAssetId";
         // Arrange
-        var slug = nameof(CreateManifest_CreateSpace_ForSpacelessAssets_WhenNoSpaceHeader);
+        var slug = nameof(CreateManifest_CreatesManifest_WhenWithAndWithoutCanvasId);
         var manifest = new PresentationManifest
         {
             Parent = $"http://localhost/1/collections/{RootCollection.Id}",
@@ -1266,11 +1266,11 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
                     {
                         CanvasId = $"https://iiif.example/{Customer}/canvases/canvasId"
                     },
-                    Asset = new(new JProperty("id", postedAssetId), new JProperty("batch", 123))
+                    Asset = new(new JProperty("id", postedAssetId), new JProperty("batch", 124))
                 },
                 new ()
                 {
-                    Asset = new(new JProperty("id", $"{postedAssetId}-2"), new JProperty("batch", 123))
+                    Asset = new(new JProperty("id", $"{postedAssetId}-2"), new JProperty("batch", 124))
                 }
             }
         };

--- a/src/IIIFPresentation/API/Features/Manifest/Validators/PresentationManifestValidator.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/Validators/PresentationManifestValidator.cs
@@ -55,12 +55,6 @@ public class PresentationManifestValidator : AbstractValidator<PresentationManif
             .When(f => !f.PaintedResources.IsNullOrEmpty() && f.PaintedResources.All(pr => pr.CanvasPainting != null))
             .WithMessage(
                 "'static_width' and 'static_height' have to be both set or both absent within a 'canvasPainting'");
-        
-        RuleFor(f => f.PaintedResources)
-            .Must(lpr => lpr.Any(pr => pr.CanvasPainting.CanvasId != null) 
-                         != lpr.Any(pr => pr.CanvasPainting.CanvasId == null))
-            .When(f => !f.PaintedResources.IsNullOrEmpty() && !f.PaintedResources.Any(pr => pr.CanvasPainting == null))
-            .WithMessage("'canvasId' is required on all resources when used in at least one");
 
         RuleFor(c => c).SetValidator(new PresentationValidator());
     }


### PR DESCRIPTION
Resolves #341

This PR modifies the validators to allow a mix of specified and unspecified asset ID's, with the unspecified values being autogenerated