### PR TITLE
Get fully tracked manifests to return immediately

### DIFF
--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
@@ -7,6 +7,8 @@ using DLCS.Exceptions;
 using DLCS.Models;
 using FakeItEasy;
 using IIIF.Presentation.V3;
+using IIIF.Presentation.V3.Annotation;
+using IIIF.Presentation.V3.Content;
 using IIIF.Presentation.V3.Strings;
 using IIIF.Serialisation;
 using Microsoft.EntityFrameworkCore;
@@ -36,6 +38,7 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
     private readonly IAmazonS3 amazonS3;
     private const int NewlyCreatedSpace = 999;
     private static readonly IDlcsApiClient DLCSApiClient = A.Fake<IDlcsApiClient>();
+    private static readonly IDlcsOrchestratorClient DLCSOrchestratorClient = A.Fake<IDlcsOrchestratorClient>();
 
     public ModifyManifestAssetCreationTests(StorageFixture storageFixture, PresentationAppFactory<Program> factory)
     {
@@ -62,7 +65,10 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
 
         httpClient = factory.ConfigureBasicIntegrationTestHttpClient(storageFixture.DbFixture,
             appFactory => appFactory.WithLocalStack(storageFixture.LocalStackFixture),
-            services => services.AddSingleton(DLCSApiClient));
+            services => services
+                .AddSingleton(DLCSApiClient)
+                .AddSingleton(DLCSOrchestratorClient)
+            );
 
         storageFixture.DbFixture.CleanUp();
     }
@@ -1203,47 +1209,6 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
                 .Excluding(cp => cp.Modified)
                 .Excluding(cp => cp.Created));
     }
-
-    [Fact]
-    public async Task CreateManifest_FindsAssetInDlcs_ThrowsExceptionWhenOnlyAsset()
-    {
-        // THIS TEST WILL FAIL ONCE #352 IS IMPLEMENTED
-
-        // Arrange
-        var slug = nameof(CreateManifest_FindsAssetInDlcs_ThrowsExceptionWhenOnlyAsset);
-        var assetId = "testAssetByPresentation-exception-thrown";
-
-        await dbContext.SaveChangesAsync();
-
-        var manifestWithoutSpace = $$"""
-                                     {
-                                         "type": "Manifest",
-                                         "slug": "{{slug}}",
-                                         "parent": "http://localhost/{{Customer}}/collections/root",
-                                         "paintedResources": [
-                                             {
-                                                "canvasPainting":{
-                                                   "canvasOrder": 1
-                                                },
-                                                 "asset": {
-                                                     "id": "fromDlcs_{{assetId}}_1",
-                                                     "mediaType": "image/jpg"
-                                                 }
-                                             }
-                                         ] 
-                                     }
-                                     """;
-
-        var requestMessage =
-            HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Post, $"{Customer}/manifests",
-                manifestWithoutSpace);
-
-        // Act
-        var response = await httpClient.AsCustomer().SendAsync(requestMessage);
-
-        // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
-    }
     
     [Fact]
     public async Task CreateManifest_FindsAssetInDlcs_WhenMixOfNewAndOldAssets()
@@ -1262,8 +1227,7 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
                                                  }
                                                  """)).ToList()));
         
-        var slug = nameof(CreateManifest_FindsAssetInDlcs_WhenMixOfNewAndOldAssets);
-        var assetId = "testAssetByPresentation-only-calls-new";
+        var (slug, _, assetId) = TestIdentifiers.SlugResourceAsset();
         
         await dbContext.SaveChangesAsync();
         var batchId = TestIdentifiers.BatchId();
@@ -1319,5 +1283,75 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
         
         A.CallTo(() => DLCSApiClient.UpdateAssetManifest(Customer, 
                 A<List<string>>._, A<OperationType>._, A<List<string>>._, A<CancellationToken>._)).MustHaveHappened();
+    }
+    
+    [Fact]
+    public async Task CreateManifest_BuildsManifest_WhenAllAssetsTrackedInDlcs()
+    {
+        // Arrange
+        A.CallTo(() => DLCSApiClient.GetCustomerImages(Customer, 
+                A<ICollection<string>>.That.Matches(o => o.First().Split('/', StringSplitOptions.None).Last().StartsWith("fromDlcs_")), 
+                A<CancellationToken>._))
+            .ReturnsLazily((int customerId, ICollection<string> assetIds, CancellationToken can) =>
+                Task.FromResult((IList<JObject>)assetIds.Where(a => a.Split('/', StringSplitOptions.None).Last().StartsWith("fromDlcs_"))
+                    .Select(x => JObject.Parse($$"""
+
+                                                 {
+                                                   "id": "{{x.Split('/').Last()}}",
+                                                   "space": {{NewlyCreatedSpace}}
+                                                 }
+                                                 """)).ToList()));
+        
+        var (slug, _, assetId) = TestIdentifiers.SlugResourceAsset();
+        
+        A.CallTo(() =>
+                DLCSOrchestratorClient.RetrieveAssetsForManifest(A<int>.Ignored, A<string>.Ignored,
+                    A<CancellationToken>.Ignored))
+            .ReturnsLazily(() => ManifestTestCreator.New()
+                .WithCanvas(new AssetId(Customer, NewlyCreatedSpace, $"fromDlcs_{assetId}_1"), c => c.WithImage())
+                .Build());
+        
+        await dbContext.SaveChangesAsync();
+
+        var manifestWithoutSpace = $$"""
+                          {
+                              "type": "Manifest",
+                              "slug": "{{slug}}",
+                              "parent": "http://localhost/{{Customer}}/collections/root",
+                              "paintedResources": [
+                                  {
+                                     "canvasPainting":{
+                                        "canvasOrder": 1
+                                     },
+                                      "asset": {
+                                          "id": "fromDlcs_{{assetId}}_1",
+                                          "mediaType": "image/jpg"
+                                      }
+                                  }
+                              ] 
+                          }
+                          """;
+
+        var requestMessage =
+            HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Post, $"{Customer}/manifests",
+                manifestWithoutSpace);
+        
+        // Act
+        var response = await httpClient.AsCustomer().SendAsync(requestMessage);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var responseManifest = await response.ReadAsPresentationResponseAsync<PresentationManifest>();
+
+        responseManifest!.PaintedResources.Should().HaveCount(1);
+        responseManifest.Items[0].Items[0].Items[0].As<PaintingAnnotation>().Body.As<Image>().Height.Should()
+            .Be(100, "Generated immediately");
+        
+        var dbManifest = dbContext.Manifests
+            .Include(m => m.CanvasPaintings)
+            .Include(m => m.Batches)
+            .First(x => x.Id == responseManifest.Id!.Split('/', StringSplitOptions.TrimEntries).Last());
+        
+        dbManifest.CanvasPaintings.First(cp => cp.CanvasOrder == 1).Should().NotBeNull("asset added to manifest");
     }
 }

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
@@ -1318,6 +1318,6 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
         dbManifest.CanvasPaintings.First(cp => cp.CanvasOrder == 1).Should().NotBeNull("asset added to manifest");
         
         A.CallTo(() => DLCSApiClient.UpdateAssetManifest(Customer, 
-                A<List<AssetId>>._, A<OperationType>._, A<List<string>>._, A<CancellationToken>._)).MustHaveHappened();
+                A<List<string>>._, A<OperationType>._, A<List<string>>._, A<CancellationToken>._)).MustHaveHappened();
     }
 }

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetUpdateTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetUpdateTests.cs
@@ -8,6 +8,8 @@ using DLCS.Exceptions;
 using DLCS.Models;
 using FakeItEasy;
 using IIIF.Presentation.V3;
+using IIIF.Presentation.V3.Annotation;
+using IIIF.Presentation.V3.Content;
 using IIIF.Presentation.V3.Strings;
 using IIIF.Serialisation;
 using Microsoft.EntityFrameworkCore;
@@ -36,6 +38,7 @@ public class ModifyManifestAssetUpdateTests : IClassFixture<PresentationAppFacto
     private const int NewlyCreatedSpace = 999;
     private readonly IAmazonS3 amazonS3;
     private static readonly IDlcsApiClient DLCSApiClient = A.Fake<IDlcsApiClient>();
+    private static readonly IDlcsOrchestratorClient DLCSOrchestratorClient = A.Fake<IDlcsOrchestratorClient>();
     private readonly IETagManager etagManager;
     
     public ModifyManifestAssetUpdateTests(StorageFixture storageFixture, PresentationAppFactory<Program> factory)
@@ -60,7 +63,10 @@ public class ModifyManifestAssetUpdateTests : IClassFixture<PresentationAppFacto
 
         httpClient = factory.ConfigureBasicIntegrationTestHttpClient(storageFixture.DbFixture,
             appFactory => appFactory.WithLocalStack(storageFixture.LocalStackFixture),
-            services => services.AddSingleton(DLCSApiClient));
+            services => 
+                services
+                    .AddSingleton(DLCSApiClient)
+                    .AddSingleton(DLCSOrchestratorClient));
         
         etagManager = (IETagManager)factory.Services.GetRequiredService(typeof(IETagManager));
 
@@ -1609,7 +1615,7 @@ public class ModifyManifestAssetUpdateTests : IClassFixture<PresentationAppFacto
             },
             new()
             {
-                Id = "addedToAvoidAllTrackedError",
+                Id = "addedToAvoidAllTracked",
                 CanvasOrder = 2,
                 CustomerId = Customer,
                 AssetId = new AssetId(Customer, NewlyCreatedSpace, $"{assetId}-4"),
@@ -1647,7 +1653,7 @@ public class ModifyManifestAssetUpdateTests : IClassFixture<PresentationAppFacto
                                    },
                                    {
                                        "canvasPainting": {
-                                           "canvasId": "addedToAvoidAllTrackedError",
+                                           "canvasId": "addedToAvoidAllTracked",
                                        },
                                        "asset": {
                                            "id": "{{assetId}}-4",
@@ -2116,65 +2122,102 @@ public class ModifyManifestAssetUpdateTests : IClassFixture<PresentationAppFacto
     }
     
     [Fact]
-    public async Task UpdateManifest_BadRequest_WhenAssetsMatchedFromAnotherManifest()
+    public async Task UpdateManifest_DoesNotRequireFurtherProcessing_WhenAllAssetsTracked()
     {
-        // THIS TEST WILL FAIL ONCE #352 IS IMPLEMENTED
-        
         // Arrange
-        var slug = nameof(UpdateManifest_BadRequest_WhenAssetsMatchedFromAnotherManifest);
-        var id = $"{nameof(UpdateManifest_BadRequest_WhenAssetsMatchedFromAnotherManifest)}_id";
-        var assetId = "testAssetByPresentation-update-assetInAnotherManifest";
-        
-        await dbContext.Manifests.AddTestManifest(id: id, slug: slug, batchId: 920, ingested: true);
-        await dbContext.Manifests.AddTestManifest(id: $"{id}_anotherManifest", slug: $"{slug}_another_slug", ingested: true, canvasPaintings:
-        [
-            new CanvasPainting
+        var (slug, id, assetId) = TestIdentifiers.SlugResourceAsset();
+
+        var initialCanvasPaintings = new List<CanvasPainting>
+        {
+            new()
             {
                 Id = "first",
-                StaticWidth = 1200,
-                StaticHeight = 1800,
                 CanvasOrder = 1,
                 ChoiceOrder = 1,
-                AssetId = new AssetId(Customer, NewlyCreatedSpace, assetId)
+                AssetId = new AssetId(Customer, NewlyCreatedSpace, $"{assetId}_1")
+            },
+            new()
+            {
+                Id = "second",
+                CanvasOrder = 2,
+                ChoiceOrder = 1,
+                AssetId = new AssetId(Customer, NewlyCreatedSpace, $"{assetId}_2")
             }
-        ]);
+        };
+
+        await dbContext.Manifests.AddTestManifest(id: id, slug: slug, canvasPaintings: initialCanvasPaintings,
+            batchId: TestIdentifiers.BatchId(), ingested: true);
         await dbContext.SaveChangesAsync();
-        
-        var batchId = TestIdentifiers.BatchId();
-        var manifestWithoutSpace = $$"""
+
+        A.CallTo(() =>
+                DLCSOrchestratorClient.RetrieveAssetsForManifest(A<int>.Ignored, A<string>.Ignored,
+                    A<CancellationToken>.Ignored))
+            .ReturnsLazily(() => ManifestTestCreator.New()
+                .WithCanvas(new AssetId(Customer, NewlyCreatedSpace, $"{assetId}_1"), c => c.WithImage())
+                .WithCanvas(new AssetId(Customer, NewlyCreatedSpace, $"{assetId}_2"), c => c.WithImage())
+                .Build());
+
+        var payload = $$"""
                          {
                              "type": "Manifest",
                              "slug": "{{slug}}",
                              "parent": "http://localhost/{{Customer}}/collections/root",
                              "paintedResources": [
                                  {
-                                    "canvasPainting":{
-                                        "label": {
-                                             "en": [
-                                                 "canvas testing"
-                                             ]
-                                         }
-                                    },
-                                     "asset": {
-                                         "id": "{{assetId}}",
-                                         "batch": "{{batchId}}",
-                                         "mediaType": "image/jpg"
-                                     }
-                                 }
+                                     "canvasPainting":{
+                                        "canvasOrder": 1
+                                     },
+                                      "asset": {
+                                          "id": "{{assetId}}_1",
+                                          "mediaType": "image/jpg"
+                                      }
+                                  },
+                                  {
+                                     "canvasPainting":{
+                                          "canvasOrder": 2
+                                     },
+                                      "asset": {
+                                          "id": "{{assetId}}_2",
+                                          "mediaType": "image/jpg"
+                                      }
+                                  }
                              ] 
                          }
                          """;
 
         var requestMessage =
             HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Put, $"{Customer}/manifests/{id}",
-                manifestWithoutSpace);
+                payload);
         etagManager.SetCorrectEtag(requestMessage, id, Customer);
         
         // Act
         var response = await httpClient.AsCustomer().SendAsync(requestMessage);
 
         // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.InternalServerError, "The asset is picked up from another manifest, which means that all assets are tracked");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var responseManifest = await response.ReadAsPresentationResponseAsync<PresentationManifest>();
+
+        responseManifest!.Id.Should().NotBeNull();
+        responseManifest.Modified.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(2));
+        responseManifest.CreatedBy.Should().Be("Admin");
+        responseManifest.Slug.Should().Be(slug);
+        responseManifest.Parent.Should().Be($"http://localhost/1/collections/{RootCollection.Id}");
+        responseManifest.Items[0].Items[0].Items[0].As<PaintingAnnotation>().Body.As<Image>().Height.Should()
+            .Be(100, "Generated immediately");
+        
+        var dbManifest = dbContext.Manifests
+            .Include(m => m.CanvasPaintings)
+            .Include(m => m.Batches)
+            .First(x => x.Id == id);
+        dbManifest.CanvasPaintings.Should().HaveCount(2);
+        dbManifest.Batches.Should().HaveCount(1, "Only the initial batch is created");
+        
+        var savedS3 =
+            await amazonS3.GetObjectAsync(LocalStackFixture.StorageBucketName,
+                $"{Customer}/manifests/{dbManifest.Id}");
+        var s3Manifest = savedS3.ResponseStream.FromJsonStream<Manifest>();
+        s3Manifest.Id.Should().EndWith(dbManifest.Id);
+        s3Manifest.Items.Should().NotBeNull("Manifest generated upfront");
     }
 }
 

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetUpdateTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetUpdateTests.cs
@@ -309,6 +309,7 @@ public class ModifyManifestAssetUpdateTests : IClassFixture<PresentationAppFacto
              canvasPainting.CanvasOrder.Should().Be(currentCanvasOrder);
              canvasPainting.AssetId.ToString().Should()
                  .Be($"{Customer}/{NewlyCreatedSpace}/{assetId}-{currentCanvasOrder}");
+             canvasPainting.Ingesting.Should().BeTrue();
              currentCanvasOrder++;
          }
      }
@@ -1596,7 +1597,7 @@ public class ModifyManifestAssetUpdateTests : IClassFixture<PresentationAppFacto
                 Target = "xywh=0,0,200,200",
                 CustomerId = Customer,
                 AssetId = new AssetId(Customer, NewlyCreatedSpace, $"{assetId}-1"),
-                Ingesting = true,
+                Ingesting = false,
             },
             new()
             {
@@ -1604,7 +1605,7 @@ public class ModifyManifestAssetUpdateTests : IClassFixture<PresentationAppFacto
                 CanvasOrder = 1,
                 CustomerId = Customer,
                 AssetId = new AssetId(Customer, NewlyCreatedSpace, $"{assetId}-3"),
-                Ingesting = true,
+                Ingesting = false,
             },
             new()
             {
@@ -1714,7 +1715,7 @@ public class ModifyManifestAssetUpdateTests : IClassFixture<PresentationAppFacto
                 Target = "xywh=0,0,200,200",
                 CustomerId = Customer,
                 AssetId = new AssetId(Customer, NewlyCreatedSpace, $"{assetId}-1"),
-                Ingesting = true,
+                Ingesting = false,
             },
             new()
             {
@@ -1732,7 +1733,7 @@ public class ModifyManifestAssetUpdateTests : IClassFixture<PresentationAppFacto
                 CanvasOrder = 2,
                 CustomerId = Customer,
                 AssetId = new AssetId(Customer, NewlyCreatedSpace, $"{assetId}-3"),
-                Ingesting = true,
+                Ingesting = false,
             }
         ];
 
@@ -1827,7 +1828,7 @@ public class ModifyManifestAssetUpdateTests : IClassFixture<PresentationAppFacto
                 CanvasOrder = 0,
                 CustomerId = Customer,
                 AssetId = new AssetId(Customer, NewlyCreatedSpace, $"{assetId}-1"),
-                Ingesting = true,
+                Ingesting = false,
             },
             new()
             {

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetUpdateTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetUpdateTests.cs
@@ -1548,7 +1548,7 @@ public class ModifyManifestAssetUpdateTests : IClassFixture<PresentationAppFacto
         dbManifest.CanvasPaintings.First(cp => cp.CanvasOrder == 3).Should().NotBeNull("asset added to manifest");
         
         A.CallTo(() => DLCSApiClient.UpdateAssetManifest(Customer,
-            A<List<AssetId>>.That.Matches(a => a.Single().Asset == $"fromDlcs_{assetId}_2"), 
+            A<List<string>>.That.Matches(a => a.Single() == $"{Customer}/{NewlyCreatedSpace}/fromDlcs_{assetId}_2"), 
             A<OperationType>.That.Matches(a => a == OperationType.Add),
             A<List<string>>._, A<CancellationToken>._)).MustHaveHappened();
         
@@ -2109,7 +2109,7 @@ public class ModifyManifestAssetUpdateTests : IClassFixture<PresentationAppFacto
         dbManifest.Batches.Should().HaveCount(2, "batch created for asset 2");
         
         A.CallTo(() => DLCSApiClient.UpdateAssetManifest(Customer,
-            A<List<AssetId>>.That.Matches(a => a.Single().Asset == $"{assetId}_1"),
+            A<List<string>>.That.Matches(a => a.Single() == $"{Customer}/{NewlyCreatedSpace}/{assetId}_1"),
             A<OperationType>.That.Matches(a => a == OperationType.Remove),
             A<List<string>>._, A<CancellationToken>._)).MustHaveHappened();
     }

--- a/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
@@ -188,7 +188,7 @@ public class DlcsManifestCoordinator(
         
         assetsTrackedElsewhere.AddRange(dlcsAssets.Select(a => a.GetAssetId(customerId)));
 
-        if (assetsInDatabase.Count + dlcsAssets.Count == assets.Count)
+        if (assetsTrackedElsewhere.Count == assets.Count)
         {
             logger.LogTrace("all assets tracked for {ManifestId}", dbManifest?.Id ?? "new manifest");
             return ([], assetsTrackedElsewhere);

--- a/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
@@ -181,14 +181,13 @@ public class DlcsManifestCoordinator(
 
     private static List<JObject> CombineTrackedAssets(List<JObject> assets, List<CanvasPainting> assetsInDatabase, List<AssetId> dlcsAssets)
     {
+        var combinedAssets = dlcsAssets.ToList();
+        combinedAssets.AddRange(assetsInDatabase.Select(a => a.AssetId));
+
         var trackedAssets = assets.Where(a =>
-            assetsInDatabase.Any(b =>
-                b.AssetId.Asset == a.TryGetValue(AssetProperties.Id)?.ToString() && 
-                b.AssetId.Space == a.TryGetValue(AssetProperties.Space)?.Value<int>())).ToList();
-        trackedAssets.AddRange(assets.Where(a =>
-            dlcsAssets.Any(b =>
+            combinedAssets.Any(b =>
                 b.Asset == a.TryGetValue(AssetProperties.Id)?.ToString() &&
-                b.Space == a.TryGetValue(AssetProperties.Space)?.Value<int>())));
+                b.Space == a.TryGetValue(AssetProperties.Space)?.Value<int>())).ToList();
         return trackedAssets;
     }
 

--- a/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
@@ -190,7 +190,7 @@ public class DlcsManifestCoordinator(
 
         if (assetsTrackedElsewhere.Count == assets.Count)
         {
-            logger.LogTrace("all assets tracked for {ManifestId}", dbManifest?.Id ?? "new manifest");
+            logger.LogTrace("All assets tracked for {ManifestId}", dbManifest?.Id ?? "new manifest");
             return ([], assetsTrackedElsewhere);
         }
         
@@ -203,13 +203,12 @@ public class DlcsManifestCoordinator(
     private static List<JObject> GetUntrackedAssets(List<JObject> payloadAssets, List<CanvasPainting> assetsInDatabase, 
         List<AssetId> dlcsAssetIds)
     {
-        var knownAssets = dlcsAssetIds.ToList();
-        knownAssets.AddRange(assetsInDatabase.Select(a => a.AssetId)!);
+        var knownAssets = dlcsAssetIds.Union(assetsInDatabase.Select(a => a.AssetId));
 
         var untrackedAssets = payloadAssets.Where(a =>
             !knownAssets.Any(b =>
-                b.Asset == a.TryGetValue(AssetProperties.Id)?.ToString() &&
-                b.Space == a.TryGetValue(AssetProperties.Space)?.Value<int>())).ToList();
+                b.Asset == a.GetRequiredValue(AssetProperties.Id).ToString() &&
+                b.Space == a.GetRequiredValue(AssetProperties.Space).Value<int>())).ToList();
         return untrackedAssets;
     }
 

--- a/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
@@ -23,7 +23,7 @@ public class DlcsInteractionResult(EntityResult? error, int? spaceId, bool canBe
     public EntityResult? Error { get; } = error;
     public int? SpaceId { get; } = spaceId;
     
-    public bool CanBeBuiltUpfront = canBeBuiltUpfront;
+    public bool CanBeBuiltUpfront { get; } = canBeBuiltUpfront;
     
     public static readonly DlcsInteractionResult NoInteraction = new(null, null);
         
@@ -173,7 +173,6 @@ public class DlcsManifestCoordinator(
         }
         
         var untrackedAssets = GetUntrackedAssets(assets, assetsInDatabase, dlcsAssetIds);
-        //var untrackedAssets = GetUntrackedAssets(assets, trackedAssets);
         
         return (untrackedAssets, dlcsAssetIds);
     }

--- a/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
@@ -172,20 +172,20 @@ public class DlcsManifestCoordinator(
             return ([], dlcsAssetIds);
         }
         
-        var trackedAssets = CombineTrackedAssets(assets, assetsInDatabase, dlcsAssetIds);
-        var untrackedAssets = GetUntrackedAssets(assets, trackedAssets);
+        var untrackedAssets = GetUntrackedAssets(assets, assetsInDatabase, dlcsAssetIds);
+        //var untrackedAssets = GetUntrackedAssets(assets, trackedAssets);
         
         return (untrackedAssets, dlcsAssetIds);
     }
 
 
-    private static List<JObject> CombineTrackedAssets(List<JObject> assets, List<CanvasPainting> assetsInDatabase, List<AssetId> dlcsAssets)
+    private static List<JObject> GetUntrackedAssets(List<JObject> assets, List<CanvasPainting> assetsInDatabase, List<AssetId> dlcsAssets)
     {
         var combinedAssets = dlcsAssets.ToList();
-        combinedAssets.AddRange(assetsInDatabase.Select(a => a.AssetId));
-
+        combinedAssets.AddRange(assetsInDatabase.Select(a => a.AssetId)!);
+        
         var trackedAssets = assets.Where(a =>
-            combinedAssets.Any(b =>
+            !combinedAssets.Any(b =>
                 b.Asset == a.TryGetValue(AssetProperties.Id)?.ToString() &&
                 b.Space == a.TryGetValue(AssetProperties.Space)?.Value<int>())).ToList();
         return trackedAssets;
@@ -196,11 +196,6 @@ public class DlcsManifestCoordinator(
             .Select(p => p.Asset)
             .OfType<JObject>()
             .ToList() ?? [];
-    
-    private static List<JObject> GetUntrackedAssets(List<JObject> assets, List<JObject> trackedAssets) =>
-        assets.Where(
-                a => trackedAssets.All(b => b.TryGetValue(AssetProperties.Id) != a.TryGetValue(AssetProperties.Id)))
-            .ToList();
     
     private async Task<int?> CreateSpace(int customerId, string manifestId,
         CancellationToken cancellationToken)

--- a/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
@@ -86,9 +86,9 @@ public class DlcsManifestCoordinator(
         var checkedAssets =
             await FindAssetsThatRequireAdditionalWork(assets, dbManifest, request.CustomerId, cancellationToken);
         
-        await UpdateDlcsAssets(request, manifestId, cancellationToken, checkedAssets.dlcsAssetIds);
+        await UpdateDlcsAssets(request, manifestId, checkedAssets.dlcsAssetIds, cancellationToken);
 
-        await RemoveUnusedAssets(dbManifest, assets, manifestId, cancellationToken);
+        await RemoveUnusedAssets(dbManifest, assets, cancellationToken);
         
         SetUntrackedAssetsToIngesting(request, checkedAssets.untrackedAssets);
 
@@ -116,7 +116,7 @@ public class DlcsManifestCoordinator(
     }
 
     private async Task UpdateDlcsAssets(WriteManifestRequest request, string manifestId,
-        CancellationToken cancellationToken, List<AssetId> dlcsAssets)
+        List<AssetId> dlcsAssets, CancellationToken cancellationToken)
     {
         if (dlcsAssets.Count != 0)
         {
@@ -127,7 +127,7 @@ public class DlcsManifestCoordinator(
     }
 
     private async Task RemoveUnusedAssets(Models.Database.Collections.Manifest? dbManifest, List<JObject> assets, 
-        string manifestId, CancellationToken cancellationToken)
+        CancellationToken cancellationToken)
     {
         if (dbManifest == null) return;
 

--- a/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
@@ -99,6 +99,10 @@ public class DlcsManifestCoordinator(
         return new DlcsInteractionResult(batchError, spaceId, canBeBuiltUpfront);
     }
 
+    /// <summary>
+    /// Makes sure that all assets which have been ingested into the DLCS are marked as ingesting
+    /// in the <see cref="Models.API.Manifest.CanvasPainting"/>> record
+    /// </summary>
     private static void SetUntrackedAssetsToIngesting(WriteManifestRequest request,
         List<JObject> untrackedAssets)
     {

--- a/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
@@ -101,7 +101,8 @@ public class DlcsManifestCoordinator(
     {
         if (checkedAssets.dlcsAssets.Count != 0)
         {
-            await dlcsApiClient.UpdateAssetManifest(request.CustomerId, checkedAssets.dlcsAssets, OperationType.Add, [manifestId],
+            await dlcsApiClient.UpdateAssetManifest(request.CustomerId,
+                checkedAssets.dlcsAssets.Select(x => x.ToString()).ToList(), OperationType.Add, [manifestId],
                 cancellationToken);
         }
     }
@@ -125,7 +126,7 @@ public class DlcsManifestCoordinator(
     private async Task RemoveManifestsFromAssets(Models.Database.Collections.Manifest dbManifest, 
         IEnumerable<CanvasPainting> canvasPaintingsToRemove, CancellationToken cancellationToken) =>
         await dlcsApiClient.UpdateAssetManifest(dbManifest.CustomerId,
-        canvasPaintingsToRemove.Select(cp => cp.AssetId).ToList()!, OperationType.Remove,
+        canvasPaintingsToRemove.Select(cp => cp.AssetId?.ToString()).ToList(), OperationType.Remove,
     [dbManifest.Id], cancellationToken);
     
     private async Task<(List<JObject> untrackedAssets, List<AssetId> dlcsAssets)> FindTrackedAssets(List<JObject> assets, 

--- a/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
@@ -163,7 +163,7 @@ public class DlcsManifestCoordinator(
             // all assets are tracked
             if (assetsInDatabase.Count == assets.Count)
             {
-                logger.LogTrace("all assets tracked in database for {ManifestId}", dbManifest.Id);
+                logger.LogTrace("All assets tracked in database for {ManifestId}", dbManifest.Id);
                 return ([], []);
             }
         }

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestReadService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestReadService.cs
@@ -35,7 +35,7 @@ public interface IManifestRead
 
 public class ManifestReadService(
     PresentationContext dbContext,
-    IIIFS3Service iiifS3,
+    IIIIFS3Service iiifS3,
     IDlcsApiClient dlcsApiClient,
     IPathGenerator pathGenerator,
     ILogger<ManifestReadService> logger) : IManifestRead

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
@@ -350,7 +350,7 @@ public class ManifestWriteService(
 
         if (canBeBuiltUpfront)
         {
-            var manifest = await manifestStorageManager.CreateManifestInStorage(iiifManifest, dbManifest, cancellationToken);
+            var manifest = await manifestStorageManager.UpsertManifestInStorage(iiifManifest, dbManifest, cancellationToken);
             request.PresentationManifest.Items = manifest.Items;
         }
         else

--- a/src/IIIFPresentation/API/Features/Manifest/Requests/DeleteManifest.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/Requests/DeleteManifest.cs
@@ -17,7 +17,7 @@ public class DeleteManifest(int customerId, string manifestId)
 
 public class DeleteManifestHandler(
     PresentationContext dbContext,
-    IIIFS3Service iiifS3,
+    IIIIFS3Service iiifS3,
     ILogger<DeleteManifestHandler> logger)
     : IRequestHandler<DeleteManifest, ResultMessage<DeleteResult, DeleteManifestType>>
 {

--- a/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
@@ -37,7 +37,7 @@ public class CreateCollection(int customerId, PresentationCollection collection,
 public class CreateCollectionHandler(
     PresentationContext dbContext,
     ILogger<CreateCollectionHandler> logger,
-    IIIFS3Service iiifS3,
+    IIIIFS3Service iiifS3,
     IdentityManager identityManager,
     IPathGenerator pathGenerator,
     IParentSlugParser parentSlugParser,

--- a/src/IIIFPresentation/API/Features/Storage/Requests/DeleteCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/DeleteCollection.cs
@@ -18,7 +18,7 @@ public class DeleteCollection (int customerId, string collectionId) : IRequest<R
 
 public class DeleteCollectionHandler(
     PresentationContext dbContext,
-    IIIFS3Service iiifS3,
+    IIIIFS3Service iiifS3,
     ILogger<DeleteCollectionHandler> logger)
     : IRequestHandler<DeleteCollection, ResultMessage<DeleteResult, DeleteCollectionType>>
 {

--- a/src/IIIFPresentation/API/Features/Storage/Requests/GetCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/GetCollection.cs
@@ -34,7 +34,7 @@ public class GetCollection(
     };
 }
 
-public class GetCollectionHandler(PresentationContext dbContext, IIIFS3Service iiifS3, IPathGenerator pathGenerator) 
+public class GetCollectionHandler(PresentationContext dbContext, IIIIFS3Service iiifS3, IPathGenerator pathGenerator) 
     : IRequestHandler<GetCollection, FetchEntityResult<PresentationCollection>>
 {
     public async Task<FetchEntityResult<PresentationCollection>> Handle(GetCollection request,

--- a/src/IIIFPresentation/API/Features/Storage/Requests/PostHierarchicalCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/PostHierarchicalCollection.cs
@@ -35,7 +35,7 @@ public class PostHierarchicalCollectionHandler(
     PresentationContext dbContext,    
     ILogger<PostHierarchicalCollectionHandler> logger,
     IdentityManager identityManager,
-    IIIFS3Service iiifS3,
+    IIIIFS3Service iiifS3,
     IPathGenerator pathGenerator)
     : IRequestHandler<PostHierarchicalCollection, ModifyEntityResult<Collection, ModifyCollectionType>>
 {

--- a/src/IIIFPresentation/API/Features/Storage/Requests/UpsertCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/UpsertCollection.cs
@@ -43,7 +43,7 @@ public class UpsertCollectionHandler(
     PresentationContext dbContext,
     IETagManager eTagManager,
     ILogger<UpsertCollectionHandler> logger,
-    IIIFS3Service iiifS3,
+    IIIIFS3Service iiifS3,
     IPathGenerator pathGenerator,
     IParentSlugParser parentSlugParser,
     IOptions<ApiSettings> options)

--- a/src/IIIFPresentation/API/Infrastructure/ServiceCollectionX.cs
+++ b/src/IIIFPresentation/API/Infrastructure/ServiceCollectionX.cs
@@ -69,7 +69,7 @@ public static class ServiceCollectionX
         services
             .AddSingleton<IBucketReader, S3BucketReader>()
             .AddSingleton<IBucketWriter, S3BucketWriter>()
-            .AddSingleton<IIIFS3Service>();
+            .AddSingleton<IIIIFS3Service, IIIFS3Service>();
 
         services
             .SetupAWS(configuration, webHostEnvironment)

--- a/src/IIIFPresentation/API/Program.cs
+++ b/src/IIIFPresentation/API/Program.cs
@@ -18,6 +18,7 @@ using Repository;
 using Repository.Paths;
 using Serilog;
 using Services.Manifests;
+using Services.Manifests.AWS;
 
 const string corsPolicyName = "CorsPolicy";
 
@@ -54,6 +55,7 @@ var dlcs = dlcsSettings.Get<DlcsSettings>()!;
 
 builder.Services
     .AddDlcsApiClient(dlcs)
+    .AddDlcsOrchestratorClient(dlcs)
     .AddDelegatedAuthHandler(opts => { opts.Realm = "DLCS-API"; });
 builder.Services.ConfigureDefaultCors(corsPolicyName);
 builder.Services.AddDataAccess(builder.Configuration);
@@ -69,6 +71,8 @@ builder.Services
     .AddSingleton<ManifestPaintedResourceParser>()
     .AddSingleton<IPathGenerator, HttpRequestBasedPathGenerator>()
     .AddSingleton<IPresentationPathGenerator, ConfigDrivenPresentationPathGenerator>()
+    .AddSingleton<IManifestMerger, ManifestMerger>()
+    .AddSingleton<IManifestStorageManager, ManifestS3Manager>()
     .AddScoped<IParentSlugParser, ParentSlugParser>()
     .AddHttpContextAccessor()
     .AddOutgoingHeaders();

--- a/src/IIIFPresentation/API/appsettings.Example.json
+++ b/src/IIIFPresentation/API/appsettings.Example.json
@@ -25,7 +25,8 @@
     }
   },
   "DLCS": {
-    "ApiUri": "https://api.dlcs.digirati.io",
+    "ApiUri": "https://api.dlcs.io",
+    "OrchestratorUri": "https://orchestrator.dlcs.io"
   },
   "PathRules": {
     "Defaults": {

--- a/src/IIIFPresentation/API/appsettings.Example.json
+++ b/src/IIIFPresentation/API/appsettings.Example.json
@@ -25,8 +25,8 @@
     }
   },
   "DLCS": {
-    "ApiUri": "https://api.dlcs.io",
-    "OrchestratorUri": "https://orchestrator.dlcs.io"
+    "ApiUri": "https://api.dlcs.test",
+    "OrchestratorUri": "https://orchestrator.dlcs.test"
   },
   "PathRules": {
     "Defaults": {

--- a/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionMessageHandlerTests.cs
+++ b/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionMessageHandlerTests.cs
@@ -87,7 +87,7 @@ public class BatchCompletionMessageHandlerTests
         // Act and Assert
         (await sut.HandleMessage(message, CancellationToken.None)).Should().BeTrue();
         A.CallTo(() =>
-                dlcsClient.RetrieveAssetsForManifest(A<int>._, A<List<int>>._, A<CancellationToken>._))
+                dlcsClient.RetrieveAssetsForManifest(A<int>._, A<string>._, A<CancellationToken>._))
             .MustNotHaveHappened();
     }
     
@@ -110,7 +110,7 @@ public class BatchCompletionMessageHandlerTests
 
         // Act and Assert
         (await sut.HandleMessage(message, CancellationToken.None)).Should().BeTrue();
-        A.CallTo(() => dlcsClient.RetrieveAssetsForManifest(A<int>._, A<List<int>>._, A<CancellationToken>._))
+        A.CallTo(() => dlcsClient.RetrieveAssetsForManifest(A<int>._, A<string>._, A<CancellationToken>._))
             .MustNotHaveHappened();
         var batch = await dbContext.Batches.Include(b => b.Manifest).SingleAsync(b => b.Id == batchId);
         batch.Status.Should().Be(BatchStatus.Completed);
@@ -141,7 +141,7 @@ public class BatchCompletionMessageHandlerTests
 
         var message = QueueHelper.CreateQueueMessage(batchId, CustomerId);
 
-        A.CallTo(() => dlcsClient.RetrieveAssetsForManifest(A<int>._, A<List<int>>._, A<CancellationToken>._))
+        A.CallTo(() => dlcsClient.RetrieveAssetsForManifest(A<int>._, A<string>._, A<CancellationToken>._))
             .Returns(ManifestTestCreator.GenerateMinimalNamedQueryManifest(assetId, backgroundHandlerSettings.PresentationApiUrl));
         ResourceBase? resourceBase = null;
         A.CallTo(() => iiifS3.SaveIIIFToS3(A<ResourceBase>._, A<Manifest>.That.Matches(m => m.Id == manifest.Id),
@@ -189,7 +189,7 @@ public class BatchCompletionMessageHandlerTests
 
         var message = QueueHelper.CreateQueueMessage(batchId, CustomerId);
 
-        A.CallTo(() => dlcsClient.RetrieveAssetsForManifest(A<int>._, A<List<int>>._, A<CancellationToken>._))
+        A.CallTo(() => dlcsClient.RetrieveAssetsForManifest(A<int>._, A<string>._, A<CancellationToken>._))
             .Returns(ManifestTestCreator.GenerateMinimalNamedQueryManifest(assetId, backgroundHandlerSettings.PresentationApiUrl));
 
         // Act
@@ -221,7 +221,7 @@ public class BatchCompletionMessageHandlerTests
         var finished = DateTime.UtcNow.AddHours(-1);
         var message = QueueHelper.CreateOldQueueMessage(batchId, CustomerId, finished);
 
-        A.CallTo(() => dlcsClient.RetrieveAssetsForManifest(A<int>._, A<List<int>>._, A<CancellationToken>._))
+        A.CallTo(() => dlcsClient.RetrieveAssetsForManifest(A<int>._, A<string>._, A<CancellationToken>._))
             .Returns(ManifestTestCreator.GenerateMinimalNamedQueryManifest(assetId, backgroundHandlerSettings.PresentationApiUrl));
 
         // Act
@@ -229,7 +229,7 @@ public class BatchCompletionMessageHandlerTests
 
         // Assert
         handleMessage.Should().BeTrue();
-        A.CallTo(() => dlcsClient.RetrieveAssetsForManifest(A<int>._, A<List<int>>._, A<CancellationToken>._))
+        A.CallTo(() => dlcsClient.RetrieveAssetsForManifest(A<int>._, A<string>._, A<CancellationToken>._))
             .MustHaveHappened();
 
         var batch = dbContext.Batches.Include(b => b.Manifest).Single(b => b.Id == batchId);

--- a/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionPathRewriteTests.cs
+++ b/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionPathRewriteTests.cs
@@ -114,7 +114,7 @@ public class BatchCompletionPathRewriteTests
 
         var message = QueueHelper.CreateQueueMessage(batchId, customerId);
 
-        A.CallTo(() => dlcsClient.RetrieveAssetsForManifest(A<int>._, A<List<int>>._, A<CancellationToken>._))
+        A.CallTo(() => dlcsClient.RetrieveAssetsForManifest(A<int>._, A<string>._, A<CancellationToken>._))
             .Returns(ManifestTestCreator.GenerateMinimalNamedQueryManifest(assetId, backgroundHandlerSettings.PresentationApiUrl));
         
         IIIFManifest updatedManifest = null;
@@ -158,7 +158,7 @@ public class BatchCompletionPathRewriteTests
 
         var message = QueueHelper.CreateQueueMessage(batchId, customerId);
 
-        A.CallTo(() => dlcsClient.RetrieveAssetsForManifest(A<int>._, A<List<int>>._, A<CancellationToken>._))
+        A.CallTo(() => dlcsClient.RetrieveAssetsForManifest(A<int>._, A<string>._, A<CancellationToken>._))
             .Returns(ManifestTestCreator.GenerateMinimalNamedQueryManifest(assetId, backgroundHandlerSettings.PresentationApiUrl));
         
         IIIFManifest updatedManifest = null;
@@ -202,7 +202,7 @@ public class BatchCompletionPathRewriteTests
 
         var message = QueueHelper.CreateQueueMessage(batchId, customerId);
 
-        A.CallTo(() => dlcsClient.RetrieveAssetsForManifest(A<int>._, A<List<int>>._, A<CancellationToken>._))
+        A.CallTo(() => dlcsClient.RetrieveAssetsForManifest(A<int>._, A<string>._, A<CancellationToken>._))
             .Returns(ManifestTestCreator.GenerateMinimalNamedQueryManifest(assetId, backgroundHandlerSettings.PresentationApiUrl));
         
         IIIFManifest updatedManifest = null;

--- a/src/IIIFPresentation/BackgroundHandler/BatchCompletion/BatchCompletionMessageHandler.cs
+++ b/src/IIIFPresentation/BackgroundHandler/BatchCompletion/BatchCompletionMessageHandler.cs
@@ -68,7 +68,7 @@ public class BatchCompletionMessageHandler(
             try
             {
                 CompleteBatch(batch, batchCompletionMessage.Finished, true);
-                await manifestS3Manager.UpdateManifestInStorage(batches, batch.Manifest!, cancellationToken);
+                await manifestS3Manager.UpdateManifestInStorage(batch.Manifest!, cancellationToken);
             }
             catch (Exception e)
             {

--- a/src/IIIFPresentation/BackgroundHandler/BatchCompletion/BatchCompletionMessageHandler.cs
+++ b/src/IIIFPresentation/BackgroundHandler/BatchCompletion/BatchCompletionMessageHandler.cs
@@ -68,7 +68,7 @@ public class BatchCompletionMessageHandler(
             try
             {
                 CompleteBatch(batch, batchCompletionMessage.Finished, true);
-                await manifestS3Manager.UpdateManifestInStorage(batch.Manifest!, cancellationToken);
+                await manifestS3Manager.UpsertManifestInStorage(batch.Manifest!, cancellationToken);
             }
             catch (Exception e)
             {

--- a/src/IIIFPresentation/Core.Tests/Helpers/JObjectXTests.cs
+++ b/src/IIIFPresentation/Core.Tests/Helpers/JObjectXTests.cs
@@ -21,20 +21,4 @@ public class JObjectXTests
         Action action = () => jobject.GetRequiredValue("foo");
         action.Should().ThrowExactly<InvalidOperationException>().WithMessage("Object missing 'foo' property");
     }
-    
-    [Fact]
-    public void TryGetValue_ReturnsValue_IfFound()
-    {
-        var jobject = JObject.Parse("{ \"name\": \"John Doe\" }");
-
-        jobject.TryGetValue("name").ToString().Should().BeEquivalentTo("John Doe");
-    }
-    
-    [Fact]
-    public void TryGetValue_DoesNotThrow_IfNotFound()
-    {
-        var jobject = JObject.Parse("{ \"name\": \"John Doe\" }");
-
-        jobject.TryGetValue("foo").Should().BeNull();
-    }
 }

--- a/src/IIIFPresentation/Core.Tests/Helpers/JObjectXTests.cs
+++ b/src/IIIFPresentation/Core.Tests/Helpers/JObjectXTests.cs
@@ -21,4 +21,20 @@ public class JObjectXTests
         Action action = () => jobject.GetRequiredValue("foo");
         action.Should().ThrowExactly<InvalidOperationException>().WithMessage("Object missing 'foo' property");
     }
+    
+    [Fact]
+    public void TryGetRequiredValue_ReturnsValue_IfFound()
+    {
+        var jobject = JObject.Parse("{ \"name\": \"John Doe\" }");
+
+        jobject.TryGetValue("name").ToString().Should().BeEquivalentTo("John Doe");
+    }
+    
+    [Fact]
+    public void TryGetRequiredValue_Throws_IfNotFound()
+    {
+        var jobject = JObject.Parse("{ \"name\": \"John Doe\" }");
+
+        jobject.TryGetValue("foo").Should().BeNull();
+    }
 }

--- a/src/IIIFPresentation/Core.Tests/Helpers/JObjectXTests.cs
+++ b/src/IIIFPresentation/Core.Tests/Helpers/JObjectXTests.cs
@@ -23,7 +23,7 @@ public class JObjectXTests
     }
     
     [Fact]
-    public void TryGetRequiredValue_ReturnsValue_IfFound()
+    public void TryGetValue_ReturnsValue_IfFound()
     {
         var jobject = JObject.Parse("{ \"name\": \"John Doe\" }");
 
@@ -31,7 +31,7 @@ public class JObjectXTests
     }
     
     [Fact]
-    public void TryGetRequiredValue_Throws_IfNotFound()
+    public void TryGetValue_DoesNotThrow_IfNotFound()
     {
         var jobject = JObject.Parse("{ \"name\": \"John Doe\" }");
 

--- a/src/IIIFPresentation/Core/Helpers/JObjectX.cs
+++ b/src/IIIFPresentation/Core/Helpers/JObjectX.cs
@@ -12,12 +12,4 @@ public static class JObjectX
         => !jObject.TryGetValue(property, out var val) 
             ? throw new InvalidOperationException($"Object missing '{property}' property") 
             : val;
-    
-    /// <summary>
-    /// Get specified property value from jObject. Null if not found
-    /// </summary>
-    public static JToken? TryGetValue(this JObject jObject, string property) 
-        => !jObject.TryGetValue(property, out var val) 
-            ? null
-            : val;
 }

--- a/src/IIIFPresentation/DLCS.Tests/API/DlcsApiClientTests.cs
+++ b/src/IIIFPresentation/DLCS.Tests/API/DlcsApiClientTests.cs
@@ -279,7 +279,7 @@ public class DlcsApiClientTests
     }
     
     [Fact]
-    public async Task UpdateAssetWithManifest_ReturnsAssetIds_WhenSuccess()
+    public async Task UpdateAssetWithManifest_ReturnsAssets_WhenSuccess()
     {
         using var stub = new ApiStub();
         const int customerId = 4;
@@ -304,7 +304,7 @@ public class DlcsApiClientTests
     }
     
     [Fact]
-    public async Task UpdateAssetWithManifest_ReturnsMultipleAssetIds_WhenMultipleSuccess()
+    public async Task UpdateAssetWithManifest_ReturnsMultipleAssets_WhenMultipleSuccess()
     {
         using var stub = new ApiStub();
         const int customerId = 4;

--- a/src/IIIFPresentation/DLCS.Tests/API/DlcsOrchestratorClientTests.cs
+++ b/src/IIIFPresentation/DLCS.Tests/API/DlcsOrchestratorClientTests.cs
@@ -18,11 +18,11 @@ public class DlcsOrchestratorClientTests
         using var stub = new ApiStub();
         const int customerId = 3;
         stub.Get(
-            $"/iiif-resource/v3/{customerId}/batch-query/1,2",
+            $"/iiif-resource/v3/{customerId}/manifest-query/first",
             (_, _) => string.Empty).StatusCode((int)httpStatusCode);
         var sut = GetClient(stub);
         
-        Func<Task> action = () => sut.RetrieveAssetsForManifest(customerId, [1, 2], CancellationToken.None);
+        Func<Task> action = () => sut.RetrieveAssetsForManifest(customerId, "first", CancellationToken.None);
         await action.Should().ThrowAsync<DlcsException>()
             .Where(e => e.Message == "Could not find a DlcsError in response" && e.StatusCode == httpStatusCode);
     }
@@ -35,11 +35,11 @@ public class DlcsOrchestratorClientTests
     {
         using var stub = new ApiStub();
         const int customerId = 4;
-        stub.Get($"/iiif-resource/v3/{customerId}/batch-query/1,2", (_, _) => "{\"description\":\"I am broken\"}")
+        stub.Get($"/iiif-resource/v3/{customerId}/manifest-query/first", (_, _) => "{\"description\":\"I am broken\"}")
             .StatusCode((int)httpStatusCode);
         var sut = GetClient(stub);
         
-        Func<Task> action = () => sut.RetrieveAssetsForManifest(customerId, [1, 2], CancellationToken.None);
+        Func<Task> action = () => sut.RetrieveAssetsForManifest(customerId, "first", CancellationToken.None);
         await action.Should().ThrowAsync<DlcsException>()
             .Where(e => e.Message == "I am broken" && e.StatusCode == httpStatusCode);
     }
@@ -49,13 +49,13 @@ public class DlcsOrchestratorClientTests
     {
         using var stub = new ApiStub();
         const int customerId = 5;
-        stub.Get($"/iiif-resource/v3/{customerId}/batch-query/1",
+        stub.Get($"/iiif-resource/v3/{customerId}/manifest-query/first",
                 (_, _) => "{\"id\":\"some/id\", \"type\": \"Manifest\" }")
             .StatusCode(200);
         var sut = GetClient(stub);
         var expected = new Manifest() { Id = "some/id" }; 
         
-        var retrievedManifest = await sut.RetrieveAssetsForManifest(customerId, [1], CancellationToken.None);
+        var retrievedManifest = await sut.RetrieveAssetsForManifest(customerId, "first", CancellationToken.None);
 
         retrievedManifest.Should().BeEquivalentTo(expected);
     }
@@ -65,7 +65,7 @@ public class DlcsOrchestratorClientTests
     {
         using var stub = new ApiStub();
         const int customerId = -5;
-        stub.Get($"/iiif-resource/v3/{customerId}/batch-query/1",
+        stub.Get($"/iiif-resource/v3/{customerId}/manifest-query/first",
                 (_, _) => "{\"id\":\"some/id\", \"type\": \"Manifest\" }")
             .StatusCode(200);
         var sut = GetClient(stub, settings =>
@@ -75,7 +75,7 @@ public class DlcsOrchestratorClientTests
         });
         var expected = new Manifest() { Id = "some/id" }; 
         
-        var retrievedManifest = await sut.RetrieveAssetsForManifest(customerId, [1], CancellationToken.None);
+        var retrievedManifest = await sut.RetrieveAssetsForManifest(customerId, "first", CancellationToken.None);
 
         retrievedManifest.Should().BeEquivalentTo(expected);
     }
@@ -86,7 +86,7 @@ public class DlcsOrchestratorClientTests
         using var stub = new ApiStub();
         const int customerId = 6;
         string? passedQueryParam = null;
-        stub.Get($"/iiif-resource/v3/{customerId}/batch-query/1",
+        stub.Get($"/iiif-resource/v3/{customerId}/manifest-query/first",
                 (req, _) =>
                 {
                     passedQueryParam = req.Query["cacheBust"];
@@ -95,7 +95,7 @@ public class DlcsOrchestratorClientTests
             .StatusCode(200);
         var sut = GetClient(stub);
         
-        await sut.RetrieveAssetsForManifest(customerId, [1], CancellationToken.None);
+        await sut.RetrieveAssetsForManifest(customerId, "first", CancellationToken.None);
 
         passedQueryParam.Should().NotBeNull("?cacheBust query param passed to avoid caching issues");
     }

--- a/src/IIIFPresentation/DLCS/API/DlcsOrchestratorClient.cs
+++ b/src/IIIFPresentation/DLCS/API/DlcsOrchestratorClient.cs
@@ -6,9 +6,9 @@ namespace DLCS.API;
 public interface IDlcsOrchestratorClient
 {
     /// <summary>
-    /// Retrieves a DLCS generated manifest containing assets in given batch ids
+    /// Retrieves a DLCS generated manifest containing assets in a given manifest
     /// </summary>
-    public Task<Manifest?> RetrieveAssetsForManifest(int customerId, List<int> batches,
+    public Task<Manifest?> RetrieveAssetsForManifest(int customerId, string manifestId,
         CancellationToken cancellationToken = default);
 }
 
@@ -18,16 +18,14 @@ public class DlcsOrchestratorClient(
 {
     private readonly DlcsSettings settings = dlcsOptions.Value;
 
-    public async Task<Manifest?> RetrieveAssetsForManifest(int customerId, List<int> batches,
+    public async Task<Manifest?> RetrieveAssetsForManifest(int customerId, string manifestId,
         CancellationToken cancellationToken = default)
     {
-        var batchString = string.Join(',', batches);
-
         var hostname = settings.GetOrchestratorUri(customerId);
 
         var uriBuilder = new UriBuilder(hostname)
         {
-            Path = $"/iiif-resource/v3/{customerId}/{settings.ManifestNamedQueryName}/{batchString}",
+            Path = $"/iiif-resource/v3/{customerId}/{settings.ManifestNamedQueryName}/{manifestId}",
             Query = $"cacheBust={DateTime.UtcNow.Ticks}"
         };
         

--- a/src/IIIFPresentation/DLCS/DLCS.csproj
+++ b/src/IIIFPresentation/DLCS/DLCS.csproj
@@ -16,7 +16,6 @@
 
     <ItemGroup>
       <ProjectReference Include="..\Core\Core.csproj" />
-      <ProjectReference Include="..\Models\Models.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/IIIFPresentation/DLCS/DlcsSettings.cs
+++ b/src/IIIFPresentation/DLCS/DlcsSettings.cs
@@ -47,7 +47,7 @@ public class DlcsSettings
     /// <summary>
     /// The name of the query used for retrieving images
     /// </summary>
-    public string ManifestNamedQueryName { get; set; } = "batch-query";
+    public string ManifestNamedQueryName { get; set; } = "manifest-query";
 
     /// <summary>
     ///     The maximum number of images that can be requested

--- a/src/IIIFPresentation/DLCS/Models/BulkPatchAssets.cs
+++ b/src/IIIFPresentation/DLCS/Models/BulkPatchAssets.cs
@@ -1,6 +1,5 @@
 ﻿using System.Runtime.Serialization;
 using System.Text.Json.Serialization;
-using Models.DLCS;
 
 namespace DLCS.Models;
 
@@ -31,7 +30,7 @@ public enum OperationType
     Replace,
 }
 
-public class IdentifierOnly(AssetId id)
+public class IdentifierOnly(string id)
 {
-    public string Id { get; set; } = id.ToString();
+    public string Id { get; set; } = id;
 }

--- a/src/IIIFPresentation/DLCS/Models/BulkPatchAssets.cs
+++ b/src/IIIFPresentation/DLCS/Models/BulkPatchAssets.cs
@@ -15,7 +15,7 @@ public class BulkPatchAssets
     public required List<string>? Value { get; set; }
     
     [JsonPropertyName("member")]
-    public List<IdentifierOnly> Members { get; set; }
+    public required List<IdentifierOnly> Members { get; set; }
 }
 
 public enum OperationType

--- a/src/IIIFPresentation/Models/API/Manifest/PresentationManifest.cs
+++ b/src/IIIFPresentation/Models/API/Manifest/PresentationManifest.cs
@@ -64,6 +64,8 @@ public class CanvasPainting
     public int? StaticWidth { get; set; }
     public int? StaticHeight { get; set; }
     public double? Duration { get; set; }
+
+    [JsonIgnore] public bool Ingesting { get; set; }
 }
 
 public class IngestingAssets

--- a/src/IIIFPresentation/Services.Tests/Manifests/ManifestPaintedResourceParserTests.cs
+++ b/src/IIIFPresentation/Services.Tests/Manifests/ManifestPaintedResourceParserTests.cs
@@ -64,7 +64,7 @@ public class ManifestPaintedResourceParserTests
                 CanvasOrder = 0,
                 ChoiceOrder = null,
                 Target = null,
-                Ingesting = true,
+                Ingesting = false,
             },
         };
         
@@ -94,7 +94,7 @@ public class ManifestPaintedResourceParserTests
                 CanvasOrder = 0,
                 ChoiceOrder = null,
                 Target = null,
-                Ingesting = true,
+                Ingesting = false,
             },
             new()
             {
@@ -103,7 +103,7 @@ public class ManifestPaintedResourceParserTests
                 CanvasOrder = 1,
                 ChoiceOrder = null,
                 Target = null,
-                Ingesting = true,
+                Ingesting = false,
             },
         };
         
@@ -130,6 +130,7 @@ public class ManifestPaintedResourceParserTests
                         StaticWidth = 513,
                         Label = new LanguageMap("en", "label"),
                         Thumbnail = "https://localhost/thumbnail",
+                        Ingesting = true
                     }
                 }
             ]
@@ -176,6 +177,7 @@ public class ManifestPaintedResourceParserTests
                         StaticWidth = 513,
                         Label = new LanguageMap("en", "label"),
                         Thumbnail = "https://localhost/thumbnail",
+                        Ingesting = true
                     }
                 },
                 new PaintedResource
@@ -189,6 +191,7 @@ public class ManifestPaintedResourceParserTests
                         StaticWidth = 12,
                         Label = new LanguageMap("en", "label2"),
                         Thumbnail = "https://localhost/thumbnail2",
+                        Ingesting = true
                     }
                 }
             ]
@@ -208,7 +211,7 @@ public class ManifestPaintedResourceParserTests
                 Thumbnail = new Uri("https://localhost/thumbnail"),
                 ChoiceOrder = null,
                 Target = null,
-                Ingesting = true,
+                Ingesting = true
             },
             new()
             {
@@ -222,7 +225,7 @@ public class ManifestPaintedResourceParserTests
                 Thumbnail = new Uri("https://localhost/thumbnail2"),
                 ChoiceOrder = null,
                 Target = null,
-                Ingesting = true,
+                Ingesting = true
             },
         };
         
@@ -250,6 +253,7 @@ public class ManifestPaintedResourceParserTests
                         StaticWidth = 513,
                         Label = new LanguageMap("en", "label"),
                         Thumbnail = "https://localhost/thumbnail",
+                        Ingesting = true
                     }
                 },
                 new PaintedResource
@@ -264,6 +268,7 @@ public class ManifestPaintedResourceParserTests
                         StaticWidth = 12,
                         Label = new LanguageMap("en", "label2"),
                         Thumbnail = "https://localhost/thumbnail2",
+                        Ingesting = true
                     }
                 }
             ]
@@ -346,7 +351,7 @@ public class ManifestPaintedResourceParserTests
                 CanvasOrder = 1,
                 ChoiceOrder = null,
                 Target = "#xywh=200,2000,200,200",
-                Ingesting = true,
+                Ingesting = false,
             },
             new()
             {
@@ -356,7 +361,7 @@ public class ManifestPaintedResourceParserTests
                 CanvasOrder = 2,
                 ChoiceOrder = null,
                 Target = "#xywh=0,0,200,200",
-                Ingesting = true,
+                Ingesting = false,
             },
         };
         
@@ -383,6 +388,7 @@ public class ManifestPaintedResourceParserTests
                         CanvasOrder = 18,
                         CanvasLabel = new LanguageMap("en", "ms125 9r fragments and multi-spectral"),
                         Label = new LanguageMap("en", "ms125 9r background"),
+                        Ingesting = true
                     },
                 },
                 new PaintedResource
@@ -394,6 +400,7 @@ public class ManifestPaintedResourceParserTests
                         CanvasOrder = 19,
                         Label = new LanguageMap("en", "ms125 9r fragment 3"),
                         Target = "xywh=800,1000,900,900",
+                        Ingesting = true
                     }
                 },
                 new PaintedResource
@@ -406,6 +413,7 @@ public class ManifestPaintedResourceParserTests
                         ChoiceOrder = 1,
                         Label = new LanguageMap("en", "ms125 9r fragment 2 natural"),
                         Target = "xywh=300,500,650,900",
+                        Ingesting = true
                     }
                 },
                 new PaintedResource
@@ -418,6 +426,7 @@ public class ManifestPaintedResourceParserTests
                         ChoiceOrder = 2,
                         Label = new LanguageMap("en", "ms125 9r fragment 2 IR"),
                         Target = "xywh=300,500,650,900",
+                        Ingesting = true
                     }
                 },
                 new PaintedResource
@@ -429,6 +438,7 @@ public class ManifestPaintedResourceParserTests
                         CanvasOrder = 21,
                         Label = new LanguageMap("en", "ms125 9r fragment 1"),
                         Target = "xywh=100,100,1000,500",
+                        Ingesting = true
                     }
                 }
             ]

--- a/src/IIIFPresentation/Services/Manifests/AWS/ManifestS3Manager.cs
+++ b/src/IIIFPresentation/Services/Manifests/AWS/ManifestS3Manager.cs
@@ -18,13 +18,13 @@ public class ManifestS3Manager(
     ILogger<ManifestS3Manager> logger) : IManifestStorageManager
 {
     /// <summary>
-    /// Upserts a manifest from the standard environment
+    /// Writes a manifest to the final manifest location
     /// </summary>
     public async Task<Manifest> UpsertManifestInStorage(Manifest manifest,
         Models.Database.Collections.Manifest dbManifest,
         CancellationToken cancellationToken)
     {
-        logger.LogInformation("creating manifest {Manifest} in S3", dbManifest.Id);
+        logger.LogInformation("Creating manifest {Manifest} in S3", dbManifest.Id);
 
         var mergedManifest = await UpsertManifest(manifest, dbManifest, cancellationToken);
 

--- a/src/IIIFPresentation/Services/Manifests/AWS/ManifestS3Manager.cs
+++ b/src/IIIFPresentation/Services/Manifests/AWS/ManifestS3Manager.cs
@@ -28,7 +28,7 @@ public class ManifestS3Manager(
         manifest.ThrowIfNull(nameof(manifest), "Manifest was not found in staging location");
         
         var namedQueryManifest =
-            await dlcsOrchestratorClient.RetrieveAssetsForManifest(dbManifest.CustomerId, batches,
+            await dlcsOrchestratorClient.RetrieveAssetsForManifest(dbManifest.CustomerId, dbManifest.Id,
                 cancellationToken);
 
         var mergedManifest = manifestMerger.ProcessCanvasPaintings(

--- a/src/IIIFPresentation/Services/Manifests/ManifestPaintedResourceParser.cs
+++ b/src/IIIFPresentation/Services/Manifests/ManifestPaintedResourceParser.cs
@@ -56,7 +56,7 @@ public class ManifestPaintedResourceParser(ILogger<ManifestItemsParser> logger) 
             CanvasOrder = canvasOrder,
             AssetId = assetId,
             ChoiceOrder = payloadCanvasPainting?.ChoiceOrder,
-            Ingesting = true, // TODO - this needs to conditionally be set once #351 implemented
+            Ingesting = payloadCanvasPainting.Ingesting,
             StaticWidth = payloadCanvasPainting?.StaticWidth,
             StaticHeight = payloadCanvasPainting?.StaticHeight,
             Duration = payloadCanvasPainting?.Duration,

--- a/src/IIIFPresentation/Services/Manifests/ManifestPaintedResourceParser.cs
+++ b/src/IIIFPresentation/Services/Manifests/ManifestPaintedResourceParser.cs
@@ -56,7 +56,7 @@ public class ManifestPaintedResourceParser(ILogger<ManifestItemsParser> logger) 
             CanvasOrder = canvasOrder,
             AssetId = assetId,
             ChoiceOrder = payloadCanvasPainting?.ChoiceOrder,
-            Ingesting = payloadCanvasPainting.Ingesting,
+            Ingesting = payloadCanvasPainting?.Ingesting ?? false,
             StaticWidth = payloadCanvasPainting?.StaticWidth,
             StaticHeight = payloadCanvasPainting?.StaticHeight,
             Duration = payloadCanvasPainting?.Duration,


### PR DESCRIPTION
Resolves #352

This PR updates the manifest functions to return a full manifest immediately if it is possible to do so.

This will happen if all assets are tracked in the database, tracked by the DLCS, or some combination of the 2.

In order to facilitate this, the API now requires a `OrchestratorUri` to be set in the `DLCS` settings to allow the API to talk to orchestrator.
This means that the settings now looks like this:

```json
"DLCS": {
    "ApiUri": "https://api.dlcs.test",
    "OrchestratorUri": "https://orchestrator.dlcs.test"
  }
```

Additionally, the response status code has been changed to show either `OK` or `Created` instead of `Accepted` when this occurs

Finally, this PR resolves [this](https://github.com/dlcs/iiif-presentation/issues/351#issuecomment-2897572704) comment allowing the `Ingested` property to be set per canvas painting in the database, rather than always setting `true`

> [!IMPORTANT] 
> This PR has changed from retrieving named queries using batch id's, to usnig manifest id's.  This means that #349 will need to be completed in order to not break existing manifests 

> [!NOTE] 
> this PR will require changes to the environment when released