### PR TITLE
Update iiif-net to 0.3.8

### DIFF
--- a/src/IIIFPresentation/API/API.csproj
+++ b/src/IIIFPresentation/API/API.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.10.0" />
-        <PackageReference Include="iiif-net" Version="0.3.6" />
+        <PackageReference Include="iiif-net" Version="0.3.8" />
         <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.8" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.7" />

--- a/src/IIIFPresentation/Core/Core.csproj
+++ b/src/IIIFPresentation/Core/Core.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="iiif-net" Version="0.3.6" />
+      <PackageReference Include="iiif-net" Version="0.3.8" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>

--- a/src/IIIFPresentation/Models/Models.csproj
+++ b/src/IIIFPresentation/Models/Models.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="iiif-net" Version="0.3.6" />
+      <PackageReference Include="iiif-net" Version="0.3.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/IIIFPresentation/Repository/Manifests/ManifestItemsParser.cs
+++ b/src/IIIFPresentation/Repository/Manifests/ManifestItemsParser.cs
@@ -121,7 +121,7 @@ public class ManifestItemsParser(ILogger<ManifestItemsParser> logger) : ICanvasP
     private CanvasPainting CreatePartialCanvasPainting(ResourceBase resource,
         string? canvasOriginalId,
         int canvasOrder,
-        IStructuralLocation? target,
+        ResourceBase? target,
         Canvas currentCanvas,
         int? choiceOrder = null)
     {
@@ -152,7 +152,7 @@ public class ManifestItemsParser(ILogger<ManifestItemsParser> logger) : ICanvasP
         return Uri.TryCreate(thumbnail, UriKind.Absolute, out var thumbnailUri) ? thumbnailUri : null;
     }
 
-    private static string? TargetAsString(IStructuralLocation? target, Canvas currentCanvas)
+    private static string? TargetAsString(ResourceBase? target, Canvas currentCanvas)
     {
         switch (target)
         {

--- a/src/IIIFPresentation/Repository/Repository.csproj
+++ b/src/IIIFPresentation/Repository/Repository.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="EFCore.NamingConventions" Version="8.0.3" />
-        <PackageReference Include="iiif-net" Version="0.3.6" />
+        <PackageReference Include="iiif-net" Version="0.3.8" />
         <PackageReference Include="MediatR" Version="12.4.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.4" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />


### PR DESCRIPTION
Resolves #410

Upgrades the iiif-net package to the latest version to add in fixes for https://github.com/digirati-co-uk/iiif-net/issues/69 and https://github.com/digirati-co-uk/iiif-net/issues/74

> [!note]
>  this PR [here](https://github.com/dlcs/iiif-presentation/pull/414) is the same as this PR, but it's retargeting to `main`