### PR TITLE
Update develop to match main

### DIFF
--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
@@ -44,11 +44,11 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
     {
         dbContext = storageFixture.DbFixture.DbContext;
         amazonS3 = storageFixture.LocalStackFixture.AWSS3ClientFactory();
-
+        
         // Always return Space 999 when call to create space
         A.CallTo(() => DLCSApiClient.CreateSpace(Customer, A<string>._, A<CancellationToken>._))
             .Returns(new Space { Id = NewlyCreatedSpace, Name = "test" });
-
+        
         // Echo back "batch" value set in first Asset
         A.CallTo(() => DLCSApiClient.IngestAssets(Customer, A<List<JObject>>._, A<CancellationToken>._))
             .ReturnsLazily(x => Task.FromResult(

--- a/src/IIIFPresentation/API/API.csproj
+++ b/src/IIIFPresentation/API/API.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.10.0" />
-        <PackageReference Include="iiif-net" Version="0.3.6" />
+        <PackageReference Include="iiif-net" Version="0.3.8" />
         <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.8" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.7" />

--- a/src/IIIFPresentation/Core/Core.csproj
+++ b/src/IIIFPresentation/Core/Core.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="iiif-net" Version="0.3.6" />
+      <PackageReference Include="iiif-net" Version="0.3.8" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>

--- a/src/IIIFPresentation/Models/Models.csproj
+++ b/src/IIIFPresentation/Models/Models.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="iiif-net" Version="0.3.6" />
+      <PackageReference Include="iiif-net" Version="0.3.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/IIIFPresentation/Repository/Repository.csproj
+++ b/src/IIIFPresentation/Repository/Repository.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="EFCore.NamingConventions" Version="8.0.3" />
-        <PackageReference Include="iiif-net" Version="0.3.6" />
+        <PackageReference Include="iiif-net" Version="0.3.8" />
         <PackageReference Include="MediatR" Version="12.4.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.4" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />

--- a/src/IIIFPresentation/Services/Manifests/ManifestItemsParser.cs
+++ b/src/IIIFPresentation/Services/Manifests/ManifestItemsParser.cs
@@ -122,7 +122,7 @@ public class ManifestItemsParser(ILogger<ManifestItemsParser> logger) : ICanvasP
     private CanvasPainting CreatePartialCanvasPainting(ResourceBase resource,
         string? canvasOriginalId,
         int canvasOrder,
-        IStructuralLocation? target,
+        ResourceBase? target,
         Canvas currentCanvas,
         int? choiceOrder = null)
     {
@@ -153,7 +153,7 @@ public class ManifestItemsParser(ILogger<ManifestItemsParser> logger) : ICanvasP
         return Uri.TryCreate(thumbnail, UriKind.Absolute, out var thumbnailUri) ? thumbnailUri : null;
     }
 
-    private static string? TargetAsString(IStructuralLocation? target, Canvas currentCanvas)
+    private static string? TargetAsString(ResourceBase? target, Canvas currentCanvas)
     {
         switch (target)
         {

--- a/src/IIIFPresentation/Services/Services.csproj
+++ b/src/IIIFPresentation/Services/Services.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="iiif-net" Version="0.3.6" />
+      <PackageReference Include="iiif-net" Version="0.3.8" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This PR updates the `develop` branch to match changes made in `main`.  This is mainly bringing the version of `iiif-net` up to 0.3.8

pull requests to be merged in:
https://github.com/dlcs/iiif-presentation/pull/416 (already in)
https://github.com/dlcs/iiif-presentation/pull/415 