### PR TITLE
Allow the canvas id to be successfully picked up from rewritten paths

### DIFF
--- a/src/IIIFPresentation/API.Tests/Integration/ModifyRewrittenPathTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyRewrittenPathTests.cs
@@ -1,11 +1,9 @@
 ﻿using System.Net;
-using API.Infrastructure.Helpers;
 using API.Tests.Integration.Infrastructure;
 using Core.Infrastructure;
 using Core.Response;
 using DLCS.API;
 using DLCS.Models;
-using Docker.DotNet.Models;
 using FakeItEasy;
 using IIIF.Presentation.V3.Strings;
 using IIIF.Serialisation;

--- a/src/IIIFPresentation/Repository.Tests/Paths/PathParserTests.cs
+++ b/src/IIIFPresentation/Repository.Tests/Paths/PathParserTests.cs
@@ -42,67 +42,6 @@ public class PathParserTests
         act.Should().Throw<FormatException>()
             .WithMessage($"Unable to extract AssetId from {incorrectId}");
     }
-
-    [Theory]
-    [InlineData("https://dlcs.example/1/canvases/someId")]
-    [InlineData("someId")]
-    public void GetCanvasId_RetrievesCorrectCanvasId_whenCalled(string canvasId)
-    {
-        var canvasPainting = new CanvasPainting()
-        {
-            CanvasId = canvasId
-        };
-        
-        var canvasFromPathParser = PathParser.GetCanvasId(canvasPainting, 1);
-        
-        canvasFromPathParser.Should().Be("someId");
-    }
-    
-    [Theory]
-    [InlineData("https://dlcs.example/1/canvases/foo/bar/baz", "foo/bar/baz")]
-    [InlineData("https://dlcs.example/1/canvases/someId?foo=bar", "someId?foo=bar")]
-    [InlineData("foo/bar/baz", "foo/bar/baz")]
-    public void GetCanvasId_ThrowsAnError_WhenCalledWithMultipleSlashes(string canvasId, string expected)
-    {
-        var canvasPainting = new CanvasPainting
-        {
-            CanvasId = canvasId
-        };
-
-        Action act = () =>  PathParser.GetCanvasId(canvasPainting, 1);
-        act.Should().Throw<InvalidCanvasIdException>()
-            .WithMessage(
-                $"Canvas Id {expected} contains a prohibited character. Cannot contain any of: '/','=','=',','");
-    }
-    
-    [Fact]
-    public void GetCanvasId_ThrowsAnError_WhenCalledWithNullCanvasId()
-    {
-        var canvasPainting = new CanvasPainting
-        {
-            CanvasId = null
-        };
-
-        Action act = () =>  PathParser.GetCanvasId(canvasPainting, 1);
-        act.Should().Throw<ArgumentNullException>()
-            .WithParameterName("canvasPainting");
-    }
-    
-    [Theory]
-    [InlineData("https://dlcs.example/1/random/foo/bar/baz", "Canvas Id /1/random/foo/bar/baz is not valid")]
-    [InlineData("https://dlcs.example/1/canvases", "Canvas Id /1/canvases is not valid")]
-    [InlineData("https://dlcs.example/1/canvases/", "Canvas Id /1/canvases/ is not valid")]
-    public void GetCanvasId_ThrowsAnError_WhenCalledWithInvalidUri(string canvasId, string expectedError)
-    {
-        var canvasPainting = new CanvasPainting
-        {
-            CanvasId = canvasId
-        };
-
-        Action act = () =>  PathParser.GetCanvasId(canvasPainting, 1);
-        act.Should().Throw<InvalidCanvasIdException>()
-            .WithMessage(expectedError);
-    }
     
     [Fact]
     public void GetParentUriFromPublicId_ReturnsSlugFromPath()

--- a/src/IIIFPresentation/Repository.Tests/Paths/PathRewriteParserTests.cs
+++ b/src/IIIFPresentation/Repository.Tests/Paths/PathRewriteParserTests.cs
@@ -2,61 +2,17 @@
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Repository.Paths;
+using Test.Helpers.Helpers;
 
 namespace Repository.Tests.Paths;
 
 public class PathRewriteParserTests
 {
     private readonly PathRewriteParser pathRewriteParser;
-    
-    private readonly TypedPathTemplateOptions defaultTypedPathTemplateOptions = new ()
-    {
-        Defaults = new Dictionary<string, string>
-        {
-            ["ManifestPrivate"] = "/{customerId}/manifests/{resourceId}",
-            ["CollectionPrivate"] = "/{customerId}/collections/{resourceId}",
-            ["ResourcePublic"] = "/{customerId}/{hierarchyPath}",
-            ["Canvas"] = "/{customerId}/canvases/{resourceId}"
-        },
-        Overrides =
-        {
-            // override everything
-            ["foo.com"] = new Dictionary<string, string>
-            {
-                ["ManifestPrivate"] = "/foo/{customerId}/manifests/{resourceId}",
-                ["CollectionPrivate"] = "/foo/{customerId}/collections/{resourceId}",
-                ["ResourcePublic"] = "/foo/{customerId}/{hierarchyPath}",
-                ["Canvas"] = "/foo/{customerId}/canvases/{resourceId}"
-            },
-            // fallback to defaults
-            ["no-customer.com"] = new Dictionary<string, string>
-            {
-                ["ManifestPrivate"] = "/manifests/{resourceId}",
-                ["CollectionPrivate"] = "/collections/{resourceId}",
-                ["ResourcePublic"] = "/{hierarchyPath}",
-                ["Canvas"] = "/canvases/{resourceId}"
-            },
-            ["additional-path-no-customer.com"] = new Dictionary<string, string>
-            {
-                ["ManifestPrivate"] = "/foo/manifests/{resourceId}",
-                ["CollectionPrivate"] = "/foo/collections/{resourceId}",
-                ["ResourcePublic"] = "/foo/{hierarchyPath}",
-                ["Canvas"] = "/foo/canvases/{resourceId}"
-            },
-            // custom base URL
-            ["fully-qualified.com"] = new Dictionary<string, string>
-            {
-                ["ManifestPrivate"] = "https://foo.com/{customerId}/manifests/{resourceId}",
-                ["CollectionPrivate"] = "https://foo.com/{customerId}/collections/{resourceId}",
-                ["ResourcePublic"] = "https://foo.com/{customerId}/{hierarchyPath}",
-                ["Canvas"] = "https://foo.com/{customerId}/canvases/{resourceId}"
-            }
-        }
-    };
 
     public PathRewriteParserTests()
     {
-        pathRewriteParser = new PathRewriteParser(Options.Create(defaultTypedPathTemplateOptions),
+        pathRewriteParser = new PathRewriteParser(Options.Create(PathRewriteOptions.Default),
             new NullLogger<PathRewriteParser>());
     }
     

--- a/src/IIIFPresentation/Repository/Paths/PathParser.cs
+++ b/src/IIIFPresentation/Repository/Paths/PathParser.cs
@@ -30,39 +30,6 @@ public static class PathParser
         }
     }
 
-    public static string GetCanvasId(CanvasPainting canvasPainting, int customerId)
-    {
-        var canvasId = canvasPainting.CanvasId.ThrowIfNull(nameof(canvasPainting));
-
-        if (!Uri.IsWellFormedUriString(canvasId, UriKind.Absolute))
-        {
-            CheckForProhibitedCharacters(canvasId);
-            return canvasId;
-        }
-
-        var convertedCanvasId = new Uri(canvasId).PathAndQuery;
-        var customerCanvasesPath = $"/{customerId}/canvases/";
-
-        if (!convertedCanvasId.StartsWith(customerCanvasesPath) || convertedCanvasId.Equals(customerCanvasesPath))
-        {
-            throw new InvalidCanvasIdException(convertedCanvasId);
-        }
-
-        var actualCanvasId = convertedCanvasId[customerCanvasesPath.Length..];
-        CheckForProhibitedCharacters(actualCanvasId);
-
-        return actualCanvasId;
-    }
-
-    private static void CheckForProhibitedCharacters(string canvasId)
-    {
-        if (ProhibitedCharacters.Any(canvasId.Contains))
-        {
-            throw new InvalidCanvasIdException(canvasId,
-                $"Canvas Id {canvasId} contains a prohibited character. Cannot contain any of: {ProhibitedCharacterDisplay}");
-        }
-    }
-
     /// <summary>
     /// Gets a hierarchical path from a full array of path elements
     /// </summary>
@@ -105,7 +72,4 @@ public static class PathParser
 
     public static Uri GetParentUriFromPublicId(string publicId) => 
         new(publicId[..publicId.LastIndexOf(PathSeparator)]);
-
-    private static readonly List<char> ProhibitedCharacters = ['/', '=', '=', ',',];
-    private static string ProhibitedCharacterDisplay = string.Join(',', ProhibitedCharacters.Select(p => $"'{p}'"));
 }

--- a/src/IIIFPresentation/Test.Helpers/Helpers/PathRewriteOptions.cs
+++ b/src/IIIFPresentation/Test.Helpers/Helpers/PathRewriteOptions.cs
@@ -1,0 +1,51 @@
+﻿using Core.Web;
+
+namespace Test.Helpers.Helpers;
+
+public static class PathRewriteOptions
+{
+    public static TypedPathTemplateOptions Default = new ()
+    {
+        Defaults = new Dictionary<string, string>
+        {
+            ["ManifestPrivate"] = "/{customerId}/manifests/{resourceId}",
+            ["CollectionPrivate"] = "/{customerId}/collections/{resourceId}",
+            ["ResourcePublic"] = "/{customerId}/{hierarchyPath}",
+            ["Canvas"] = "/{customerId}/canvases/{resourceId}"
+        },
+        Overrides =
+        {
+            // override everything
+            ["foo.com"] = new Dictionary<string, string>
+            {
+                ["ManifestPrivate"] = "/foo/{customerId}/manifests/{resourceId}",
+                ["CollectionPrivate"] = "/foo/{customerId}/collections/{resourceId}",
+                ["ResourcePublic"] = "/foo/{customerId}/{hierarchyPath}",
+                ["Canvas"] = "/foo/{customerId}/canvases/{resourceId}"
+            },
+            // fallback to defaults
+            ["no-customer.com"] = new Dictionary<string, string>
+            {
+                ["ManifestPrivate"] = "/manifests/{resourceId}",
+                ["CollectionPrivate"] = "/collections/{resourceId}",
+                ["ResourcePublic"] = "/{hierarchyPath}",
+                ["Canvas"] = "/canvases/{resourceId}"
+            },
+            ["additional-path-no-customer.com"] = new Dictionary<string, string>
+            {
+                ["ManifestPrivate"] = "/foo/manifests/{resourceId}",
+                ["CollectionPrivate"] = "/foo/collections/{resourceId}",
+                ["ResourcePublic"] = "/foo/{hierarchyPath}",
+                ["Canvas"] = "/foo/canvases/{resourceId}"
+            },
+            // custom base URL
+            ["fully-qualified.com"] = new Dictionary<string, string>
+            {
+                ["ManifestPrivate"] = "https://foo.com/{customerId}/manifests/{resourceId}",
+                ["CollectionPrivate"] = "https://foo.com/{customerId}/collections/{resourceId}",
+                ["ResourcePublic"] = "https://foo.com/{customerId}/{hierarchyPath}",
+                ["Canvas"] = "https://foo.com/{customerId}/canvases/{resourceId}"
+            }
+        }
+    };
+}


### PR DESCRIPTION
Resolves #435

Fixes the API to accept a rewritten `canvasId` to correctly set the value
