### PR TITLE
Draft: #424 Identify Assets in Items

### DIFF
--- a/src/IIIFPresentation/API.Tests/Features/Manifest/ManifestWriteServiceTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Manifest/ManifestWriteServiceTests.cs
@@ -63,7 +63,8 @@ public class ManifestWriteServiceTests
         var manifestRead = A.Fake<IManifestRead>();
 
         var dlcsClient = A.Fake<IDlcsApiClient>();
-        var managedResultFinder = new ManagedAssetResultFinder(dlcsClient, presentationContext,
+        var paintableAssetIdentifier = A.Fake<PaintableAssetIdentifier>();
+        var managedResultFinder = new ManagedAssetResultFinder(paintableAssetIdentifier, dlcsClient, presentationContext,
             new NullLogger<ManagedAssetResultFinder>());
         var dlcsManifestCoordinator = new DlcsManifestCoordinator(dlcsClient, presentationContext, managedResultFinder,
             new NullLogger<DlcsManifestCoordinator>());

--- a/src/IIIFPresentation/API.Tests/Features/Manifest/Validators/PresentationManifestValidatorTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Manifest/Validators/PresentationManifestValidatorTests.cs
@@ -71,43 +71,6 @@ public class PresentationManifestValidatorTests
     }
     
     [Fact]
-    public void CanvasPaintingAndItems_Manifest_NoErrorWhenSettings()
-    {
-        var sutAllowedItemsAndPaintedResource = new  PresentationManifestValidator(Options.Create(new ApiSettings()
-        {
-            AWS = new AWSSettings(),
-            DLCS = new DlcsSettings
-            {
-                ApiUri = new Uri("https://localhost")
-            }
-        }));
-        
-        var manifest = new PresentationManifest
-        {
-            Items =
-            [
-                new()
-                {
-                    Id = "someId",
-                }
-            ],
-            PaintedResources =
-            [
-                new()
-                {
-                    CanvasPainting = new CanvasPainting
-                    {
-                        CanvasId = "someCanvasId"
-                    }
-                }
-            ],
-        };
-        
-        var result = sutAllowedItemsAndPaintedResource.TestValidate(manifest);
-        result.ShouldNotHaveValidationErrorFor(m => m.Items);
-    }
-    
-    [Fact]
     public void PaintedResource_Manifest_ErrorWhenDuplicateChoiceWithCanvasOrder()
     {
         var manifest = new PresentationManifest

--- a/src/IIIFPresentation/API.Tests/Features/Manifest/Validators/PresentationManifestValidatorTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Manifest/Validators/PresentationManifestValidatorTests.cs
@@ -43,7 +43,7 @@ public class PresentationManifestValidatorTests
     }
     
     [Fact]
-    public void CanvasPaintingAndItems_Manifest_ErrorWhenDefaultSettings()
+    public void CanvasPaintingAndItems_Manifest_NoErrorWhenMixedContent()
     {
         var manifest = new PresentationManifest
         {
@@ -67,8 +67,7 @@ public class PresentationManifestValidatorTests
         };
         
         var result = sut.TestValidate(manifest);
-        result.ShouldHaveValidationErrorFor(m => m.Items)
-            .WithErrorMessage("The properties \"items\" and \"paintedResource\" cannot be used at the same time");
+        result.ShouldNotHaveValidationErrorFor(m => m.Items);
     }
     
     [Fact]
@@ -77,7 +76,6 @@ public class PresentationManifestValidatorTests
         var sutAllowedItemsAndPaintedResource = new  PresentationManifestValidator(Options.Create(new ApiSettings()
         {
             AWS = new AWSSettings(),
-            IgnorePaintedResourcesWithItems = true,
             DLCS = new DlcsSettings
             {
                 ApiUri = new Uri("https://localhost")

--- a/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingResolver.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingResolver.cs
@@ -32,7 +32,7 @@ public class CanvasPaintingResolver(
         int customerId, PresentationManifest presentationManifest,
         Dictionary<IPaintable, AssetId> recognizedItemsAssets, CancellationToken cancellationToken = default)
     {
-        return await HandleInsert(customerId, presentationManifest, cancellationToken);
+        return await HandleInsert(customerId, presentationManifest, recognizedItemsAssets, cancellationToken);
     }
 
     /// <summary>
@@ -46,13 +46,14 @@ public class CanvasPaintingResolver(
         DbManifest existingManifest, Dictionary<IPaintable, AssetId> recognizedItemsAssets,
         CancellationToken cancellationToken = default)
     {
-        return await HandleUpdate(customerId, presentationManifest, existingManifest, cancellationToken);
+        return await HandleUpdate(customerId, presentationManifest, existingManifest, recognizedItemsAssets, cancellationToken);
     }
 
-    private async Task<PresUpdateResult?> HandleUpdate(int customerId, PresentationManifest presentationManifest, 
-        DbManifest existingManifest, CancellationToken cancellationToken)
+    private async Task<PresUpdateResult?> HandleUpdate(int customerId, PresentationManifest presentationManifest,
+        DbManifest existingManifest, Dictionary<IPaintable, AssetId> recognizedItemsAssets,
+        CancellationToken cancellationToken)
     {
-        var (error, incomingCanvasPaintings) = ParseManifest(customerId, presentationManifest);
+        var (error, incomingCanvasPaintings) = ParseManifest(customerId, presentationManifest, recognizedItemsAssets);
         if (error != null) return error;
         
         existingManifest.CanvasPaintings ??= [];
@@ -231,12 +232,13 @@ public class CanvasPaintingResolver(
         }
     }
     
-    private async Task<(PresUpdateResult? error, List<CanvasPainting>? canvasPaintings)> HandleInsert(int customerId, 
-        PresentationManifest presentationManifest, CancellationToken cancellationToken)
+    private async Task<(PresUpdateResult? error, List<CanvasPainting>? canvasPaintings)> HandleInsert(int customerId,
+        PresentationManifest presentationManifest, Dictionary<IPaintable, AssetId> recognizedItemsAssets,
+        CancellationToken cancellationToken)
     {
         try
         {
-            var (parseError, canvasPaintings) = ParseManifest(customerId, presentationManifest);
+            var (parseError, canvasPaintings) = ParseManifest(customerId, presentationManifest, recognizedItemsAssets);
             if (parseError != null) return (parseError, null);
 
             Debug.Assert(canvasPaintings is not null, "canvasPaintings is not null");
@@ -254,16 +256,16 @@ public class CanvasPaintingResolver(
         }
     } 
     
-    private (PresUpdateResult? error, List<CanvasPainting>? canvasPaintings) ParseManifest(int customerId, 
-        PresentationManifest presentationManifest)
+    private (PresUpdateResult? error, List<CanvasPainting>? canvasPaintings) ParseManifest(int customerId,
+        PresentationManifest presentationManifest, Dictionary<IPaintable, AssetId> recognizedItemsAssets)
     {
         try
         {
             var itemsCanvasPaintings =
-                manifestItemsParser.ParseToCanvasPainting(presentationManifest, customerId).ToList();
+                manifestItemsParser.ParseToCanvasPainting(presentationManifest, customerId, recognizedItemsAssets).ToList();
 
             var paintedResourceCanvasPaintings = manifestPaintedResourceParser
-                .ParseToCanvasPainting(presentationManifest, customerId).ToList();
+                .ParseToCanvasPainting(presentationManifest, customerId, recognizedItemsAssets).ToList();
 
             var res = canvasPaintingMerger.CombinePaintedResources(itemsCanvasPaintings,
                 paintedResourceCanvasPaintings, presentationManifest.Items);

--- a/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingResolver.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingResolver.cs
@@ -6,8 +6,10 @@ using API.Helpers;
 using API.Infrastructure.IdGenerator;
 using Core.Exceptions;
 using Core.Helpers;
+using IIIF.Presentation.V3.Annotation;
 using Models.API.Manifest;
 using Models.Database;
+using Models.DLCS;
 using Services.Manifests;
 using CanvasPainting = Models.Database.CanvasPainting;
 using DbManifest = Models.Database.Collections.Manifest;
@@ -27,9 +29,9 @@ public class CanvasPaintingResolver(
     /// </summary>
     /// <returns>Tuple of either error OR newly created </returns>
     public async Task<(PresUpdateResult? updateResult, List<CanvasPainting>? canvasPaintings)> GenerateCanvasPaintings(
-        int customerId, PresentationManifest presentationManifest, CancellationToken cancellationToken = default)
+        int customerId, PresentationManifest presentationManifest,
+        Dictionary<IPaintable, AssetId> recognizedItemsAssets, CancellationToken cancellationToken = default)
     {
-        //var parser = GetParserForManifest(presentationManifest);
         return await HandleInsert(customerId, presentationManifest, cancellationToken);
     }
 
@@ -39,8 +41,10 @@ public class CanvasPaintingResolver(
     /// created/updated/deleted accordingly) 
     /// </summary>
     /// <returns>Error, if processing fails</returns>
-    public async Task<PresUpdateResult?> UpdateCanvasPaintings(int customerId, PresentationManifest presentationManifest,
-        DbManifest existingManifest, CancellationToken cancellationToken = default)
+    public async Task<PresUpdateResult?> UpdateCanvasPaintings(int customerId,
+        PresentationManifest presentationManifest,
+        DbManifest existingManifest, Dictionary<IPaintable, AssetId> recognizedItemsAssets,
+        CancellationToken cancellationToken = default)
     {
         return await HandleUpdate(customerId, presentationManifest, existingManifest, cancellationToken);
     }
@@ -226,7 +230,7 @@ public class CanvasPaintingResolver(
             return null;
         }
     }
-
+    
     private async Task<(PresUpdateResult? error, List<CanvasPainting>? canvasPaintings)> HandleInsert(int customerId, 
         PresentationManifest presentationManifest, CancellationToken cancellationToken)
     {
@@ -263,7 +267,7 @@ public class CanvasPaintingResolver(
 
             var res = canvasPaintingMerger.CombinePaintedResources(itemsCanvasPaintings,
                 paintedResourceCanvasPaintings, presentationManifest.Items);
-
+            
             return (null, res);
         }
         catch (InvalidCanvasIdException cpId)

--- a/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
@@ -7,16 +7,19 @@ using Core;
 using DLCS.API;
 using DLCS.Exceptions;
 using DLCS.Models;
+using IIIF.Presentation.V3;
+using IIIF.Presentation.V3.Annotation;
+using IIIF.Presentation.V3.Content;
 using JsonDiffPatchDotNet;
 using Models.API.General;
 using Models.API.Manifest;
-using Models.Database.Collections;
 using Models.DLCS;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Repository;
 using CanvasPainting = Models.Database.CanvasPainting;
 using EntityResult = API.Infrastructure.Requests.ModifyEntityResult<Models.API.Manifest.PresentationManifest, Models.API.General.ModifyCollectionType>;
+using ManifestX = Models.Database.Collections.ManifestX;
 
 namespace API.Features.Manifest;
 
@@ -40,6 +43,14 @@ public class DlcsManifestCoordinator(
     IManagedAssetResultFinder knownAssetChecker,
     ILogger<DlcsManifestCoordinator> logger)
 {
+
+    public async Task<Dictionary<IPaintable, AssetId>> VerifyCanvasItemAssets(WriteManifestRequest request, 
+        CancellationToken cancellationToken = default)
+    {
+        var assets = await knownAssetChecker.FindManagedAssets(request.PresentationManifest, request.CustomerId, cancellationToken);
+        return assets.ToDictionary(tuple=>tuple.paintable!, tuple=>tuple.assetId!);
+    }
+    
     /// <summary>
     /// Carry out any required interactions with DLCS for given <see cref="WriteManifestRequest"/>, this can include
     /// creating a space and/or creating DLCS batches
@@ -52,7 +63,7 @@ public class DlcsManifestCoordinator(
         CancellationToken cancellationToken = default)
     {
         // NOTE - this must always happen before handing off to canvasPaintingResolve
-        var assets = GetAssetJObjectList(request);
+        var assets = GetAssetJObjectList(request.PresentationManifest.PaintedResources);
 
         if (!request.CreateSpace && assets.Count <= 0)
         {
@@ -108,12 +119,13 @@ public class DlcsManifestCoordinator(
         var dlcsInteractionRequests = await knownAssetChecker.FindAssetsThatRequireAdditionalWork(
             request.PresentationManifest, dbManifest, spaceId, spaceCreated, request.CustomerId, cancellationToken);
 
+        var assetsToIngest = dlcsInteractionRequests.Where(d => d.Ingest != IngestType.NoIngest).ToList();
+        
         MarkAssetsAsIngesting(request,
-            dlcsInteractionRequests.Where(d => d.Ingest != IngestType.NoIngest).Select(d => d.AssetId));
+            assetsToIngest.Select(d => d.AssetId));
         
         // create batches for assets
-        var batchError = await CreateBatches(request.CustomerId, manifestId,
-            dlcsInteractionRequests.Where(d => d.Ingest != IngestType.NoIngest).ToList(), cancellationToken);
+        var batchError = await CreateBatches(request.CustomerId, manifestId, assetsToIngest.ToList(), cancellationToken);
         
         if (batchError != null)  return new DlcsInteractionResult(batchError, spaceId);
         
@@ -176,12 +188,12 @@ public class DlcsManifestCoordinator(
         canvasPaintingsToRemove.Select(cp => cp.AssetId?.ToString()).ToList(), OperationType.Remove,
     [dbManifest.Id], cancellationToken);
 
-    private static List<JObject> GetAssetJObjectList(WriteManifestRequest request) =>
-        request.PresentationManifest.PaintedResources?
+    private static List<JObject> GetAssetJObjectList(List<PaintedResource>? paintedResources) =>
+        paintedResources?
             .Select(p => p.Asset)
             .OfType<JObject>()
             .ToList() ?? [];
-    
+
     private async Task<int?> CreateSpace(int customerId, string manifestId,
         CancellationToken cancellationToken)
     {
@@ -215,22 +227,26 @@ public class DlcsManifestCoordinator(
                     break;
             }
 
-            if (!assets.TryAdd(dlcsInteractionRequest.AssetId, dlcsInteractionRequest.Asset))
-            {
-                logger.LogDebug("Asset {AssetId} has been specified multiple times, validating they match", dlcsInteractionRequest.AssetId);
-                var assetInDictionary = assets[dlcsInteractionRequest.AssetId];
-                
-                if (!JToken.DeepEquals(assetInDictionary, dlcsInteractionRequest.Asset))
-                {
-                    var jsonDiffPatch = new JsonDiffPatch();
-                    var diff = jsonDiffPatch.Diff(assetInDictionary, dlcsInteractionRequest.Asset);
+            // If can add, move to next one
+            if (assets.TryAdd(dlcsInteractionRequest.AssetId, dlcsInteractionRequest.Asset)) continue;
+            
+            // else already specified
+            logger.LogDebug("Asset {AssetId} has been specified multiple times, validating they match", dlcsInteractionRequest.AssetId);
+            var assetInDictionary = assets[dlcsInteractionRequest.AssetId];
+
+            // if specified with the same data, we can ignore and continue
+            if (JToken.DeepEquals(assetInDictionary, dlcsInteractionRequest.Asset)) continue;
+            
+            // else report failure with details
+            var jsonDiffPatch = new JsonDiffPatch();
+            var diff = jsonDiffPatch.Diff(assetInDictionary, dlcsInteractionRequest.Asset);
                     
-                    return EntityResult.Failure(
-                        $"Asset {dlcsInteractionRequest.AssetId} is specified multiple times, but has conflicting data - diff: {JsonConvert.SerializeObject(diff)}",
-                        ModifyCollectionType.AssetsDoNotMatch, WriteResult.BadRequest);
-                }
-            }
+            return EntityResult.Failure(
+                $"Asset {dlcsInteractionRequest.AssetId} is specified multiple times, but has conflicting data - diff: {JsonConvert.SerializeObject(diff)}",
+                ModifyCollectionType.AssetsDoNotMatch, WriteResult.BadRequest);
         }
+        
+        // `assets` now contain all the assets that should be ingested by DLCS
         
         try
         {

--- a/src/IIIFPresentation/API/Features/Manifest/ManagedAssetResultFinder.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManagedAssetResultFinder.cs
@@ -1,6 +1,8 @@
 ﻿using System.Diagnostics;
 using API.Infrastructure.Helpers;
+using Core.Exceptions;
 using DLCS.API;
+using IIIF.Presentation.V3.Annotation;
 using Models.API.Manifest;
 using Models.DLCS;
 using Newtonsoft.Json.Linq;
@@ -10,6 +12,7 @@ using CanvasPainting = Models.Database.CanvasPainting;
 namespace API.Features.Manifest;
 
 public class ManagedAssetResultFinder(
+    PaintableAssetIdentifier paintableAssetIdentifier,
     IDlcsApiClient dlcsApiClient,
     PresentationContext dbContext,
     ILogger<ManagedAssetResultFinder> logger) : IManagedAssetResultFinder
@@ -70,7 +73,7 @@ public class ManagedAssetResultFinder(
         // run through every other asset
         foreach (var assetNotFoundInSameManifest in assetsNotFoundInSameManifest)
         {
-            // is this this asset is found in another manifest?
+            // is this asset found in another manifest?
             if (inAnotherManifest.Any(cp => cp.AssetId == assetNotFoundInSameManifest.assetId))
             {
                 IngestType ingestType;
@@ -115,6 +118,39 @@ public class ManagedAssetResultFinder(
         return dlcsInteractionRequests;
     }
 
+    public async Task<List<(IPaintable? paintable, AssetId? assetId)>> FindManagedAssets(
+        PresentationManifest presentationManifest, int customerId, CancellationToken cancellationToken)
+    {
+        var identifiedManagedAssets = presentationManifest.Items?
+            .SelectMany(c => c.Items ?? [])
+            .SelectMany(ap => ap.Items ?? [])
+            .OfType<PaintingAnnotation>()
+            .Select(pa => pa.Body)
+            .Select(paintable =>(paintable,  assetId: paintableAssetIdentifier.ResolvePaintableAsset(paintable, customerId)))
+            .Where(tuple => tuple.assetId != null)
+            .ToList() ?? [];
+        
+        IList<JObject> dlcsAssets;
+
+        try
+        {
+            dlcsAssets = await dlcsApiClient.GetCustomerImages(customerId,
+                identifiedManagedAssets.Select(a => a.assetId!.ToString()).ToList(), cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to retrieve DLCS assets");
+            throw;
+        }
+
+        var missingAssets = identifiedManagedAssets.Select(tuple=>tuple.assetId).Except(dlcsAssets.Select(d => d.GetAssetId(customerId))).ToArray();
+        if(missingAssets.Length != 0)
+            throw new PresentationException($"Managed assets not found: {string.Join(", ", missingAssets.Select(a=>$"'{a}'"))}");
+        
+        // All identified assets exist in DLCS
+        return identifiedManagedAssets;
+    }
+
     private List<CanvasPainting> FindAssetsInAnotherManifest(int customerId, 
         List<(AssetId assetId, PaintedResource paintedResource)> assetsNotFoundInSameManifest)
     {
@@ -144,7 +180,7 @@ public class ManagedAssetResultFinder(
     private async Task<List<DlcsInteractionRequest>> CheckDlcsForAssets(
         List<(AssetId assetId, PaintedResource paintedResource)> assetsToCheck, int customerId, CancellationToken cancellationToken)
     {
-        IList<JObject> dlcsAssets = [];
+        IList<JObject> dlcsAssets;
         
         try
         {
@@ -199,4 +235,8 @@ public interface IManagedAssetResultFinder
         PresentationManifest presentationManifest,
         Models.Database.Collections.Manifest? dbManifest, int? spaceId, bool spaceCreated, int customerId,
         CancellationToken cancellationToken);
+    
+    public Task<List<(IPaintable? paintable, AssetId? assetId)>> FindManagedAssets(
+        PresentationManifest presentationManifest,
+        int customerId, CancellationToken cancellationToken);
 }

--- a/src/IIIFPresentation/API/Features/Manifest/ManagedAssetResultFinder.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManagedAssetResultFinder.cs
@@ -129,6 +129,9 @@ public class ManagedAssetResultFinder(
             .Select(paintable =>(paintable,  assetId: paintableAssetIdentifier.ResolvePaintableAsset(paintable, customerId)))
             .Where(tuple => tuple.assetId != null)
             .ToList() ?? [];
+
+        if (identifiedManagedAssets.Count == 0)
+            return [];
         
         IList<JObject> dlcsAssets;
 

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
@@ -10,10 +10,12 @@ using Core.Auth;
 using Core.Helpers;
 using Core.IIIF;
 using DLCS.Exceptions;
+using IIIF.Presentation.V3.Annotation;
 using IIIF.Serialisation;
 using Models.API.General;
 using Models.API.Manifest;
 using Models.Database.General;
+using Models.DLCS;
 using Repository;
 using Repository.Helpers;
 using Repository.Paths;
@@ -160,14 +162,18 @@ public class ManifestWriteService(
             // Ensure we have a manifestId
             manifestId ??= await GenerateUniqueManifestId(request, cancellationToken);
             if (manifestId == null) return ErrorHelper.CannotGenerateUniqueId<PresentationManifest>();
+
+            // This will throw ManifestException if some of the rules for managed assets in .Items are broken
+            var recognizedItemsAssets =
+                await dlcsManifestCoordinator.VerifyCanvasItemAssets(request, cancellationToken);
             
-            // Carry out any DLCS interactions (for paintedResources with _assets_) 
+            // Carry out any DLCS interactions
             var dlcsInteractionResult =
                 await dlcsManifestCoordinator.HandleDlcsInteractions(request, manifestId, cancellationToken: cancellationToken);
             if (dlcsInteractionResult.Error != null) return dlcsInteractionResult.Error;
             
             var (error, dbManifest) =
-                await CreateDatabaseRecord(request, parsedParentSlug, manifestId, dlcsInteractionResult.SpaceId, dlcsInteractionResult, cancellationToken);
+                await CreateDatabaseRecord(request, parsedParentSlug, manifestId, dlcsInteractionResult.SpaceId, dlcsInteractionResult, recognizedItemsAssets, cancellationToken);
             if (error != null) return error;
             
             var hasAssets = PaintedResourcesHasAssets(request);
@@ -187,7 +193,7 @@ public class ManifestWriteService(
 
     private static bool PaintedResourcesHasAssets(WriteManifestRequest request)
     {
-        return request.PresentationManifest.PaintedResources?.Any(x => x.Asset != null) == true;
+        return request.PresentationManifest.PaintedResources.HasAsset();
     }
 
     private async Task<PresUpdateResult> UpdateInternal(UpsertManifestRequest request,
@@ -222,13 +228,17 @@ public class ManifestWriteService(
         using (logger.BeginScope("Updating Manifest {ManifestId} for Customer {CustomerId}",
                    request.ManifestId, request.CustomerId))
         {
+            // This will throw ManifestException if some of the rules for managed assets in .Items are broken
+            var recognizedItemsAssets =
+                await dlcsManifestCoordinator.VerifyCanvasItemAssets(request, cancellationToken);
+
             // Carry out any DLCS interactions (for paintedResources with _assets_) 
             var dlcsInteractionResult =
                 await dlcsManifestCoordinator.HandleDlcsInteractions(request, existingManifest.Id, existingManifest, cancellationToken);
             if (dlcsInteractionResult.Error != null) return dlcsInteractionResult.Error;
             
             var (error, dbManifest) =
-                await UpdateDatabaseRecord(request, parsedParentSlug!, existingManifest, dlcsInteractionResult, cancellationToken);
+                await UpdateDatabaseRecord(request, parsedParentSlug!, existingManifest, dlcsInteractionResult, recognizedItemsAssets, cancellationToken);
             if (error != null) return error;
             
             var hasAssets = PaintedResourcesHasAssets(request);
@@ -246,11 +256,12 @@ public class ManifestWriteService(
 
     private async Task<(PresUpdateResult?, DbManifest?)> CreateDatabaseRecord(WriteManifestRequest request,
         ParsedParentSlug parsedParentSlug, string manifestId, int? spaceId, DlcsInteractionResult dlcsInteractionResult,
+        Dictionary<IPaintable, AssetId> recognizedItemsAssets,
         CancellationToken cancellationToken)
     {
         var (canvasPaintingsError, canvasPaintings) =
             await canvasPaintingResolver.GenerateCanvasPaintings(request.CustomerId, request.PresentationManifest,
-                cancellationToken);
+                recognizedItemsAssets, cancellationToken);
         if (canvasPaintingsError != null) return (canvasPaintingsError, null);
 
         var timeStamp = DateTime.UtcNow;
@@ -294,11 +305,12 @@ public class ManifestWriteService(
 
     private async Task<(PresUpdateResult?, DbManifest?)> UpdateDatabaseRecord(WriteManifestRequest request,
         ParsedParentSlug parsedParentSlug, DbManifest existingManifest, DlcsInteractionResult dlcsInteractionResult,
+        Dictionary<IPaintable, AssetId> recognizedItemsAssets,
         CancellationToken cancellationToken)
     {
         var presentationManifest = request.PresentationManifest;
         var canvasPaintingsError = await canvasPaintingResolver.UpdateCanvasPaintings(request.CustomerId,
-            presentationManifest, existingManifest, cancellationToken);
+            presentationManifest, existingManifest, recognizedItemsAssets, cancellationToken);
         if (canvasPaintingsError != null) return (canvasPaintingsError, null);
         
         existingManifest.Label = presentationManifest.Label;

--- a/src/IIIFPresentation/API/Features/Manifest/PaintableAssetIdentifier.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/PaintableAssetIdentifier.cs
@@ -1,0 +1,108 @@
+﻿using System.Text.RegularExpressions;
+using API.Helpers;
+using Core.Exceptions;
+using Core.Web;
+using IIIF;
+using IIIF.ImageApi.V2;
+using IIIF.ImageApi.V3;
+using IIIF.Presentation.V3.Annotation;
+using IIIF.Presentation.V3.Content;
+using Microsoft.Extensions.Options;
+using Models.DLCS;
+
+namespace API.Features.Manifest;
+
+public partial class PaintableAssetIdentifier(IHttpContextAccessor httpContextAccessor, IOptionsMonitor<TypedPathTemplateOptions> templateOptionsMonitor, ILogger<PaintableAssetIdentifier> logger)
+{
+    private TypedPathTemplateOptions TemplateOptions => templateOptionsMonitor.CurrentValue;
+    
+    /// <summary>
+    /// Get <see cref="AssetId"/> from <see cref="IPaintable"/>, if it represents an asset managed by this instance, otherwise <c>null</c>
+    /// </summary>
+    /// <param name="paintable">Paintable resource, can be null</param>
+    /// <param name="customerId">Id of the customer making the current request</param>
+    /// <returns></returns>
+    public AssetId? ResolvePaintableAsset(IPaintable? paintable, int customerId)
+        => paintable switch
+        {
+            Image image => Resolve(image, customerId),
+            Sound sound => Resolve(sound, customerId),
+            Video video => Resolve(video, customerId),
+            // If there are multiple transcodes available the body may be a PaintingChoice in which case each choice can be checked.
+            PaintingChoice choice => choice.Items
+                ?.Select(choicePaintable => ResolvePaintableAsset(choicePaintable, customerId)).OfType<AssetId>()
+                .FirstOrDefault(),
+            _ => null
+        };
+
+    private AssetId? Resolve(ExternalResource av, int customerId)
+    {
+        // AV are identified from body id only.
+        return ParseId(CanonicalAvRegex(), av.Id, customerId);
+    }
+    
+    private AssetId? Resolve(Image image, int customerId)
+    {
+        var fromServices = ResolveFromImageServices(image.Service, customerId);
+        var fromBody = ParseId(CanonicalImageRegex(), image.Id, customerId);
+
+        // Explicit ban on ambiguity
+        if (fromServices is not null
+            && fromBody is not null
+            && fromServices != fromBody)
+            throw new PresentationException("Image body and services point to different managed assets");
+
+        return fromServices ?? fromBody;
+    }
+
+    private AssetId? ResolveFromImageServices(List<IService>? services, int customerId)
+    {
+        if (services is null) return null;
+
+        foreach (var service in services)
+            switch (service)
+            {
+                case ImageService3 service3:
+                    if (ParseId(CanonicalImageRegex(), service3.Id, customerId) is {} result3) return result3;
+                    break;
+                case ImageService2 service2:
+                    if (ParseId(CanonicalImageRegex(), service2.Id, customerId) is {} result2) return result2;
+                    break;
+                // default: break;
+            }
+
+        return null; // no recognizable asset id found
+    }
+    
+
+    private AssetId? ParseId(Regex regex, string? id, int customerId)
+    {
+        if (id is null) return null;
+        if (!Uri.TryCreate(id, UriKind.Absolute, out var uri)) return null;
+        if (!IsHostKnown(uri))
+            return null; // only assets from known domains (self or as-configured)
+
+        var canonicalMatch = regex.Match(uri.AbsolutePath);
+        if (!canonicalMatch.Success) return null;
+        if (int.Parse(canonicalMatch.Groups["customer"].Value) != customerId)
+        {
+            logger.LogTrace("Asset path '{Path}' does not belong to customer '{CustomerId}'", uri.AbsolutePath, customerId);
+            return null;
+        }
+        
+        return new AssetId(customerId, int.Parse(canonicalMatch.Groups["space"].Value), canonicalMatch.Groups["asset"].Value);
+    }
+
+    private bool IsHostKnown(Uri uri) =>
+        uri.Host.Equals(httpContextAccessor.SafeHttpContext().Request.Host.Host)
+        || TemplateOptions.Overrides.ContainsKey(uri.Host);
+    
+    // Canonical path: /iiif-img/{version?}/{customer}/{space}/{asset}/{image-request}
+    [GeneratedRegex("""\/?iiif-img/((v2|v3)\/)?(?<customer>\d+)\/(?<space>\d+)/(?<asset>[^\/\s]+)\/?""")]
+    private static partial Regex CanonicalImageRegex();
+    
+    // Audio: /iiif-av/{customer}/{space}/{asset}/full/max/default.{extension}
+    // Video: /iiif-av/{customer}/{space}/{asset}/full/full/max/max/0/default.{extension}
+    [GeneratedRegex("""\/?iiif-av/(?<customer>\d+)\/(?<space>\d+)/(?<asset>[^\/\s]+)\/?""")]
+    private static partial Regex CanonicalAvRegex();
+}

--- a/src/IIIFPresentation/API/Features/Manifest/Validators/PresentationManifestValidator.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/Validators/PresentationManifestValidator.cs
@@ -12,15 +12,6 @@ public class PresentationManifestValidator : AbstractValidator<PresentationManif
 {
     public PresentationManifestValidator(IOptions<ApiSettings> options)
     {
-        var settings = options.Value;
-        
-        if (!settings.IgnorePaintedResourcesWithItems)
-        {
-            RuleFor(m => m.Items).Empty()
-                .When(f => !f.PaintedResources.IsNullOrEmpty())
-                .WithMessage("The properties \"items\" and \"paintedResource\" cannot be used at the same time");
-        }
-
         When(m => !m.PaintedResources.IsNullOrEmpty(), PaintedResourcesValidation);
         RuleFor(c => c).SetValidator(new PresentationValidator());
     }

--- a/src/IIIFPresentation/API/Program.cs
+++ b/src/IIIFPresentation/API/Program.cs
@@ -68,6 +68,7 @@ builder.Services
     .AddScoped<IManifestRead, ManifestReadService>()
     .AddScoped<CanvasPaintingResolver>()
     .AddSingleton<ManifestItemsParser>()
+    .AddSingleton<PaintableAssetIdentifier>()
     .AddSingleton<ManifestPaintedResourceParser>()
     .AddSingleton<IPathGenerator, HttpRequestBasedPathGenerator>()
     .AddSingleton<IPathRewriteParser, PathRewriteParser>()

--- a/src/IIIFPresentation/API/Settings/ApiSettings.cs
+++ b/src/IIIFPresentation/API/Settings/ApiSettings.cs
@@ -18,11 +18,6 @@ public class ApiSettings
     
     public string? PathBase { get; set; }
     
-    /// <summary>
-    /// Whether painted resources should be ignored when there are also items
-    /// </summary>
-    public bool IgnorePaintedResourcesWithItems { get; set; }
-    
     public required AWSSettings AWS { get; set; }
 
     public required DlcsSettings DLCS { get; set; }

--- a/src/IIIFPresentation/Services.Tests/Manifests/ManifestItemsParserTests.cs
+++ b/src/IIIFPresentation/Services.Tests/Manifests/ManifestItemsParserTests.cs
@@ -6,6 +6,7 @@ using IIIF.Presentation.V3.Strings;
 using Microsoft.Extensions.Logging.Abstractions;
 using Models.API.Manifest;
 using Repository.Paths;
+using Models.DLCS;
 using Services.Manifests;
 using CanvasPainting = Models.Database.CanvasPainting;
 
@@ -15,21 +16,22 @@ public class ManifestItemsParserTests
 {
     private readonly ManifestItemsParser sut = new(A.Fake<IPresentationPathGenerator>(), new NullLogger<ManifestItemsParser>());
 
+    private static readonly Dictionary<IPaintable, AssetId> EmptyRecognizedDictionary = new();
     [Fact]
     public void Parse_ReturnsEmptyEnumerable_IfItemsNull()
-        => sut.ParseToCanvasPainting(new PresentationManifest(), 123).Should().BeEmpty();
+        => sut.ParseToCanvasPainting(new PresentationManifest(), 123, EmptyRecognizedDictionary).Should().BeEmpty();
 
     [Fact]
     public void Parse_ReturnsEmptyEnumerable_IfItemsEmpty()
-        => sut.ParseToCanvasPainting(new PresentationManifest { Items = [] }, 123).Should().BeEmpty();
+        => sut.ParseToCanvasPainting(new PresentationManifest { Items = [] }, 123, EmptyRecognizedDictionary).Should().BeEmpty();
 
     [Fact]
     public void Parse_ReturnsCanvasPainting_IfCanvasHasNoAnnotationPages()
-        => sut.ParseToCanvasPainting(new PresentationManifest { Items = [new Canvas { Items = [] }] }, 123).Should().HaveCount(1);
+        => sut.ParseToCanvasPainting(new PresentationManifest { Items = [new Canvas { Items = [] }] }, 123, EmptyRecognizedDictionary).Should().HaveCount(1);
 
     [Fact]
     public void Parse_ReturnsCanvasPainting_IfAnnotationPagesHaveNoAnnotations()
-        => sut.ParseToCanvasPainting(new PresentationManifest { Items = [new Canvas { Items = [new AnnotationPage()] }] }, 123)
+        => sut.ParseToCanvasPainting(new PresentationManifest { Items = [new Canvas { Items = [new AnnotationPage()] }] }, 123, EmptyRecognizedDictionary)
             .Should().HaveCount(1);
 
     [Fact]
@@ -37,53 +39,55 @@ public class ManifestItemsParserTests
         => sut.ParseToCanvasPainting(new PresentationManifest
             {
                 Items = [new Canvas { Items = [new AnnotationPage { Items = [new TypeClassifyingAnnotation()] }] }]
-            }, 123)
+            }, 123, EmptyRecognizedDictionary)
             .Should().HaveCount(1);
 
     [Fact]
     public async Task Parse_Throws_CanvasIdInvalidUri()
     {
         // Arrange
-        var manifest = @"
-{
-    ""@context"": ""http://iiif.io/api/presentation/3/context.json"",
-    ""id"": ""https://iiif.io/api/cookbook/recipe/0001-mvm-image/manifest.json"",
-    ""type"": ""Manifest"",
-    ""items"": [
-        {
-            ""id"": ""i-am-not-a-uri"",
-            ""type"": ""Canvas"",
-            ""height"": 1800,
-            ""width"": 1200,
-            ""items"": [
-                {
-                    ""id"": ""https://iiif.io/api/cookbook/recipe/0001-mvm-image/page/p1/1"",
-                    ""type"": ""AnnotationPage"",
-                    ""items"": [
-                        {
-                            ""id"": ""https://iiif.io/api/cookbook/recipe/0001-mvm-image/annotation/p0001-image"",
-                            ""type"": ""Annotation"",
-                            ""motivation"": ""painting"",
-                            ""body"": {
-                                ""id"": ""http://iiif.io/api/presentation/2.1/example/fixtures/resources/page1-full.png"",
-                                ""type"": ""Image"",
-                                ""format"": ""image/png"",
-                                ""height"": 1800,
-                                ""width"": 1200
-                            },
-                            ""target"": ""https://iiif.io/api/cookbook/recipe/0001-mvm-image/canvas/p1""
-                        }
-                    ]
-                }
-            ]
-        }
-    ]
-}";
+        var manifest = """
+
+                       {
+                           "@context": "http://iiif.io/api/presentation/3/context.json",
+                           "id": "https://iiif.io/api/cookbook/recipe/0001-mvm-image/manifest.json",
+                           "type": "Manifest",
+                           "items": [
+                               {
+                                   "id": "i-am-not-a-uri",
+                                   "type": "Canvas",
+                                   "height": 1800,
+                                   "width": 1200,
+                                   "items": [
+                                       {
+                                           "id": "https://iiif.io/api/cookbook/recipe/0001-mvm-image/page/p1/1",
+                                           "type": "AnnotationPage",
+                                           "items": [
+                                               {
+                                                   "id": "https://iiif.io/api/cookbook/recipe/0001-mvm-image/annotation/p0001-image",
+                                                   "type": "Annotation",
+                                                   "motivation": "painting",
+                                                   "body": {
+                                                       "id": "http://iiif.io/api/presentation/2.1/example/fixtures/resources/page1-full.png",
+                                                       "type": "Image",
+                                                       "format": "image/png",
+                                                       "height": 1800,
+                                                       "width": 1200
+                                                   },
+                                                   "target": "https://iiif.io/api/cookbook/recipe/0001-mvm-image/canvas/p1"
+                                               }
+                                           ]
+                                       }
+                                   ]
+                               }
+                           ]
+                       }
+                       """;
         
         var deserialised = await manifest.ToPresentation<PresentationManifest>();
          
         // Act
-        Action action = () => sut.ParseToCanvasPainting(deserialised, 123);
+        Action action = () => sut.ParseToCanvasPainting(deserialised, 123, EmptyRecognizedDictionary);
         
         // Assert
         action.Should().Throw<UriFormatException>();
@@ -93,39 +97,41 @@ public class ManifestItemsParserTests
     public async Task Parse_Throws_MissingBody()
     {
         // Arrange
-        var manifest = @"
-{
-    ""@context"": ""http://iiif.io/api/presentation/3/context.json"",
-    ""id"": ""https://iiif.io/api/cookbook/recipe/0001-mvm-image/manifest.json"",
-    ""type"": ""Manifest"",
-    ""items"": [
-        {
-            ""id"": ""i-am-not-a-uri"",
-            ""type"": ""Canvas"",
-            ""height"": 1800,
-            ""width"": 1200,
-            ""items"": [
-                {
-                    ""id"": ""https://iiif.io/api/cookbook/recipe/0001-mvm-image/page/p1/1"",
-                    ""type"": ""AnnotationPage"",
-                    ""items"": [
-                        {
-                            ""id"": ""https://iiif.io/api/cookbook/recipe/0001-mvm-image/annotation/p0001-image"",
-                            ""type"": ""Annotation"",
-                            ""motivation"": ""painting"",
-                            ""target"": ""https://iiif.io/api/cookbook/recipe/0001-mvm-image/canvas/p1""
-                        }
-                    ]
-                }
-            ]
-        }
-    ]
-}";
+        var manifest = """
+
+                       {
+                           "@context": "http://iiif.io/api/presentation/3/context.json",
+                           "id": "https://iiif.io/api/cookbook/recipe/0001-mvm-image/manifest.json",
+                           "type": "Manifest",
+                           "items": [
+                               {
+                                   "id": "i-am-not-a-uri",
+                                   "type": "Canvas",
+                                   "height": 1800,
+                                   "width": 1200,
+                                   "items": [
+                                       {
+                                           "id": "https://iiif.io/api/cookbook/recipe/0001-mvm-image/page/p1/1",
+                                           "type": "AnnotationPage",
+                                           "items": [
+                                               {
+                                                   "id": "https://iiif.io/api/cookbook/recipe/0001-mvm-image/annotation/p0001-image",
+                                                   "type": "Annotation",
+                                                   "motivation": "painting",
+                                                   "target": "https://iiif.io/api/cookbook/recipe/0001-mvm-image/canvas/p1"
+                                               }
+                                           ]
+                                       }
+                                   ]
+                               }
+                           ]
+                       }
+                       """;
         
         var deserialised = await manifest.ToPresentation<PresentationManifest>();
          
         // Act
-        Action action = () => sut.ParseToCanvasPainting(deserialised, 123);
+        Action action = () => sut.ParseToCanvasPainting(deserialised, 123, EmptyRecognizedDictionary);
         
         // Assert
         action.Should().Throw<InvalidOperationException>()
@@ -137,41 +143,43 @@ public class ManifestItemsParserTests
     {
         // https://iiif.io/api/cookbook/recipe/0001-mvm-image/manifest.json
         // Arrange
-        var manifest = @"
-{
-    ""@context"": ""http://iiif.io/api/presentation/3/context.json"",
-    ""id"": ""https://iiif.io/api/cookbook/recipe/0001-mvm-image/manifest.json"",
-    ""type"": ""Manifest"",
-    ""items"": [
-        {
-            ""id"": ""https://iiif.io/api/cookbook/recipe/0001-mvm-image/canvas/p1"",
-            ""type"": ""Canvas"",
-            ""height"": 1800,
-            ""width"": 1200,
-            ""items"": [
-                {
-                    ""id"": ""https://iiif.io/api/cookbook/recipe/0001-mvm-image/page/p1/1"",
-                    ""type"": ""AnnotationPage"",
-                    ""items"": [
-                        {
-                            ""id"": ""https://iiif.io/api/cookbook/recipe/0001-mvm-image/annotation/p0001-image"",
-                            ""type"": ""Annotation"",
-                            ""motivation"": ""painting"",
-                            ""body"": {
-                                ""id"": ""http://iiif.io/api/presentation/2.1/example/fixtures/resources/page1-full.png"",
-                                ""type"": ""Image"",
-                                ""format"": ""image/png"",
-                                ""height"": 1800,
-                                ""width"": 1200
-                            },
-                            ""target"": ""https://iiif.io/api/cookbook/recipe/0001-mvm-image/canvas/p1""
-                        }
-                    ]
-                }
-            ]
-        }
-    ]
-}";
+        var manifest = """
+
+                       {
+                           "@context": "http://iiif.io/api/presentation/3/context.json",
+                           "id": "https://iiif.io/api/cookbook/recipe/0001-mvm-image/manifest.json",
+                           "type": "Manifest",
+                           "items": [
+                               {
+                                   "id": "https://iiif.io/api/cookbook/recipe/0001-mvm-image/canvas/p1",
+                                   "type": "Canvas",
+                                   "height": 1800,
+                                   "width": 1200,
+                                   "items": [
+                                       {
+                                           "id": "https://iiif.io/api/cookbook/recipe/0001-mvm-image/page/p1/1",
+                                           "type": "AnnotationPage",
+                                           "items": [
+                                               {
+                                                   "id": "https://iiif.io/api/cookbook/recipe/0001-mvm-image/annotation/p0001-image",
+                                                   "type": "Annotation",
+                                                   "motivation": "painting",
+                                                   "body": {
+                                                       "id": "http://iiif.io/api/presentation/2.1/example/fixtures/resources/page1-full.png",
+                                                       "type": "Image",
+                                                       "format": "image/png",
+                                                       "height": 1800,
+                                                       "width": 1200
+                                                   },
+                                                   "target": "https://iiif.io/api/cookbook/recipe/0001-mvm-image/canvas/p1"
+                                               }
+                                           ]
+                                       }
+                                   ]
+                               }
+                           ]
+                       }
+                       """;
         var expected = new List<CanvasPainting>
         {
             new()
@@ -188,7 +196,7 @@ public class ManifestItemsParserTests
         var deserialised = await manifest.ToPresentation<PresentationManifest>();
          
         // Act
-        var canvasPaintings = sut.ParseToCanvasPainting(deserialised, 123);
+        var canvasPaintings = sut.ParseToCanvasPainting(deserialised, 123, EmptyRecognizedDictionary);
         
         // Assert
         canvasPaintings.Should().BeEquivalentTo(expected);
@@ -199,80 +207,82 @@ public class ManifestItemsParserTests
     {
         // https://iiif.io/api/cookbook/recipe/0001-mvm-image/manifest.json (with added thumbnail)
         // Arrange
-        var manifest = @"
-{
-    ""@context"": ""http://iiif.io/api/presentation/3/context.json"",
-        ""id"": ""https://iiif.io/api/cookbook/recipe/0001-mvm-image/manifest.json"",
-            ""type"": ""Manifest"",
-                ""label"": {
-        ""en"": [
-            ""Single Image Example""
-        ]
-    },
-    ""items"": [
-        {
-            ""id"": ""https://iiif.io/api/cookbook/recipe/0001-mvm-image/canvas/p1"",
-            ""type"": ""Canvas"",
-            ""height"": 1800,
-            ""width"": 1200,
-            ""thumbnail"": [
-                {
-                    ""id"": ""https://iiif.io/api/cookbook/recipe/0001-mvm-image/image-example/full/648,1024/0/default.jpg"",
-                    ""type"": ""Image"",
-                    ""format"": ""image/jpeg"",
-                    ""service"": [
-                        {
-                            ""@context"": ""http://iiif.io/api/image/3/context.json"",
-                            ""id"": ""https://dlc.services/thumbs/v3/6/1/5c084b27-cdd8-4c8d-b1b2-e3cc3f4155bb"",
-                            ""type"": ""ImageService3"",
-                            ""profile"": ""level0"",
-                            ""sizes"": [
-                                {
-                                    ""width"": 648,
-                                    ""height"": 1024
-                                },
-                                {
-                                    ""width"": 253,
-                                    ""height"": 400
-                                },
-                                {
-                                    ""width"": 127,
-                                    ""height"": 200
-                                },
-                                {
-                                    ""width"": 63,
-                                    ""height"": 100
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ],
-            ""items"": [
-                {
-                    ""id"": ""https://iiif.io/api/cookbook/recipe/0001-mvm-image/page/p1/1"",
-                    ""type"": ""AnnotationPage"",
-                    ""items"": [
-                        {
-                            ""id"": ""https://iiif.io/api/cookbook/recipe/0001-mvm-image/annotation/p0001-image"",
-                            ""type"": ""Annotation"",
-                            ""motivation"": ""painting"",
-                            ""body"": {
-                                ""id"": ""http://iiif.io/api/presentation/2.1/example/fixtures/resources/page1-full.png"",
-                                ""type"": ""Image"",
-                                ""format"": ""image/png"",
-                                ""height"": 1800,
-                                ""width"": 1200
-                            },
-                            ""target"": ""https://iiif.io/api/cookbook/recipe/0001-mvm-image/canvas/p1""
-                        }
-                    ]
-                }
-            ]
-        }
-    ]
-}
-";
+        var manifest = """
+
+                       {
+                           "@context": "http://iiif.io/api/presentation/3/context.json",
+                               "id": "https://iiif.io/api/cookbook/recipe/0001-mvm-image/manifest.json",
+                                   "type": "Manifest",
+                                       "label": {
+                               "en": [
+                                   "Single Image Example"
+                               ]
+                           },
+                           "items": [
+                               {
+                                   "id": "https://iiif.io/api/cookbook/recipe/0001-mvm-image/canvas/p1",
+                                   "type": "Canvas",
+                                   "height": 1800,
+                                   "width": 1200,
+                                   "thumbnail": [
+                                       {
+                                           "id": "https://iiif.io/api/cookbook/recipe/0001-mvm-image/image-example/full/648,1024/0/default.jpg",
+                                           "type": "Image",
+                                           "format": "image/jpeg",
+                                           "service": [
+                                               {
+                                                   "@context": "http://iiif.io/api/image/3/context.json",
+                                                   "id": "https://dlc.services/thumbs/v3/6/1/5c084b27-cdd8-4c8d-b1b2-e3cc3f4155bb",
+                                                   "type": "ImageService3",
+                                                   "profile": "level0",
+                                                   "sizes": [
+                                                       {
+                                                           "width": 648,
+                                                           "height": 1024
+                                                       },
+                                                       {
+                                                           "width": 253,
+                                                           "height": 400
+                                                       },
+                                                       {
+                                                           "width": 127,
+                                                           "height": 200
+                                                       },
+                                                       {
+                                                           "width": 63,
+                                                           "height": 100
+                                                       }
+                                                   ]
+                                               }
+                                           ]
+                                       }
+                                   ],
+                                   "items": [
+                                       {
+                                           "id": "https://iiif.io/api/cookbook/recipe/0001-mvm-image/page/p1/1",
+                                           "type": "AnnotationPage",
+                                           "items": [
+                                               {
+                                                   "id": "https://iiif.io/api/cookbook/recipe/0001-mvm-image/annotation/p0001-image",
+                                                   "type": "Annotation",
+                                                   "motivation": "painting",
+                                                   "body": {
+                                                       "id": "http://iiif.io/api/presentation/2.1/example/fixtures/resources/page1-full.png",
+                                                       "type": "Image",
+                                                       "format": "image/png",
+                                                       "height": 1800,
+                                                       "width": 1200
+                                                   },
+                                                   "target": "https://iiif.io/api/cookbook/recipe/0001-mvm-image/canvas/p1"
+                                               }
+                                           ]
+                                       }
+                                   ]
+                               }
+                           ]
+                       }
+
+                       """;
         var expected = new List<CanvasPainting>
         {
             new()
@@ -290,7 +300,7 @@ public class ManifestItemsParserTests
         var deserialised = await manifest.ToPresentation<PresentationManifest>();
          
         // Act
-        var canvasPaintings = sut.ParseToCanvasPainting(deserialised, 123);
+        var canvasPaintings = sut.ParseToCanvasPainting(deserialised, 123, EmptyRecognizedDictionary);
         
         // Assert
         canvasPaintings.Should().BeEquivalentTo(expected);
@@ -301,44 +311,46 @@ public class ManifestItemsParserTests
     {
         // https://iiif.io/api/cookbook/recipe/0002-mvm-audio/manifest.json
         // Arrange
-        var manifest = @"
-{
-    ""@context"": ""http://iiif.io/api/presentation/3/context.json"",
-    ""id"": ""https://iiif.io/api/cookbook/recipe/0002-mvm-audio/manifest.json"",
-    ""type"": ""Manifest"",
-    ""label"": {
-        ""en"": [
-            ""Simplest Audio Example 1""
-        ]
-    },
-    ""items"": [
-        {
-            ""id"": ""https://iiif.io/api/cookbook/recipe/0002-mvm-audio/canvas"",
-            ""type"": ""Canvas"",
-            ""duration"": 1985.024,
-            ""items"": [
-                {
-                    ""id"": ""https://iiif.io/api/cookbook/recipe/0002-mvm-audio/canvas/page"",
-                    ""type"": ""AnnotationPage"",
-                    ""items"": [
-                        {
-                            ""id"": ""https://iiif.io/api/cookbook/recipe/0002-mvm-audio/canvas/page/annotation"",
-                            ""type"": ""Annotation"",
-                            ""motivation"": ""painting"",
-                            ""body"": {
-                                ""id"": ""https://fixtures.iiif.io/audio/indiana/mahler-symphony-3/CD1/medium/128Kbps.mp4"",
-                                ""type"": ""Sound"",
-                                ""format"": ""audio/mp4"",
-                                ""duration"": 1985.024
-                            },
-                            ""target"": ""https://iiif.io/api/cookbook/recipe/0002-mvm-audio/canvas""
-                        }
-                    ]
-                }
-            ]
-        }
-    ]
-}";
+        var manifest = """
+
+                       {
+                           "@context": "http://iiif.io/api/presentation/3/context.json",
+                           "id": "https://iiif.io/api/cookbook/recipe/0002-mvm-audio/manifest.json",
+                           "type": "Manifest",
+                           "label": {
+                               "en": [
+                                   "Simplest Audio Example 1"
+                               ]
+                           },
+                           "items": [
+                               {
+                                   "id": "https://iiif.io/api/cookbook/recipe/0002-mvm-audio/canvas",
+                                   "type": "Canvas",
+                                   "duration": 1985.024,
+                                   "items": [
+                                       {
+                                           "id": "https://iiif.io/api/cookbook/recipe/0002-mvm-audio/canvas/page",
+                                           "type": "AnnotationPage",
+                                           "items": [
+                                               {
+                                                   "id": "https://iiif.io/api/cookbook/recipe/0002-mvm-audio/canvas/page/annotation",
+                                                   "type": "Annotation",
+                                                   "motivation": "painting",
+                                                   "body": {
+                                                       "id": "https://fixtures.iiif.io/audio/indiana/mahler-symphony-3/CD1/medium/128Kbps.mp4",
+                                                       "type": "Sound",
+                                                       "format": "audio/mp4",
+                                                       "duration": 1985.024
+                                                   },
+                                                   "target": "https://iiif.io/api/cookbook/recipe/0002-mvm-audio/canvas"
+                                               }
+                                           ]
+                                       }
+                                   ]
+                               }
+                           ]
+                       }
+                       """;
         var expected = new List<CanvasPainting>
         {
             new()
@@ -355,7 +367,7 @@ public class ManifestItemsParserTests
         var deserialised = await manifest.ToPresentation<PresentationManifest>();
          
         // Act
-        var canvasPaintings = sut.ParseToCanvasPainting(deserialised, 123);
+        var canvasPaintings = sut.ParseToCanvasPainting(deserialised, 123, EmptyRecognizedDictionary);
         
         // Assert
         canvasPaintings.Should().BeEquivalentTo(expected);
@@ -366,49 +378,51 @@ public class ManifestItemsParserTests
     {
         // https://iiif.io/api/cookbook/recipe/0002-mvm-audio/manifest.json
         // Arrange
-        var manifest = @"
-{
-    ""@context"": ""http://iiif.io/api/presentation/3/context.json"",
-    ""id"": ""https://iiif.io/api/cookbook/recipe/0003-mvm-video/manifest.json"",
-    ""type"": ""Manifest"",
-    ""label"": {
-        ""en"": [
-            ""Video Example 3""
-        ]
-    },
-    ""items"": [
-        {
-            ""id"": ""https://iiif.io/api/cookbook/recipe/0003-mvm-video/canvas"",
-            ""type"": ""Canvas"",
-            ""height"": 360,
-            ""width"": 480,
-            ""duration"": 572.034,
-            ""items"": [
-                {
-                    ""id"": ""https://iiif.io/api/cookbook/recipe/0003-mvm-video/canvas/page"",
-                    ""type"": ""AnnotationPage"",
-                    ""items"": [
-                        {
-                            ""id"": ""https://iiif.io/api/cookbook/recipe/0003-mvm-video/canvas/page/annotation"",
-                            ""type"": ""Annotation"",
-                            ""motivation"": ""painting"",
-                            ""body"": {
-                                ""id"": ""https://fixtures.iiif.io/video/indiana/lunchroom_manners/high/lunchroom_manners_1024kb.mp4"",
-                                ""type"": ""Video"",
-                                ""height"": 360,
-                                ""width"": 480,
-                                ""duration"": 572.034,
-                                ""format"": ""video/mp4""
-                            },
-                            ""target"": ""https://iiif.io/api/cookbook/recipe/0003-mvm-video/canvas""
-                        }
-                    ]
-                }
-            ]
-        }
-    ]
-}
-";
+        var manifest = """
+
+                       {
+                           "@context": "http://iiif.io/api/presentation/3/context.json",
+                           "id": "https://iiif.io/api/cookbook/recipe/0003-mvm-video/manifest.json",
+                           "type": "Manifest",
+                           "label": {
+                               "en": [
+                                   "Video Example 3"
+                               ]
+                           },
+                           "items": [
+                               {
+                                   "id": "https://iiif.io/api/cookbook/recipe/0003-mvm-video/canvas",
+                                   "type": "Canvas",
+                                   "height": 360,
+                                   "width": 480,
+                                   "duration": 572.034,
+                                   "items": [
+                                       {
+                                           "id": "https://iiif.io/api/cookbook/recipe/0003-mvm-video/canvas/page",
+                                           "type": "AnnotationPage",
+                                           "items": [
+                                               {
+                                                   "id": "https://iiif.io/api/cookbook/recipe/0003-mvm-video/canvas/page/annotation",
+                                                   "type": "Annotation",
+                                                   "motivation": "painting",
+                                                   "body": {
+                                                       "id": "https://fixtures.iiif.io/video/indiana/lunchroom_manners/high/lunchroom_manners_1024kb.mp4",
+                                                       "type": "Video",
+                                                       "height": 360,
+                                                       "width": 480,
+                                                       "duration": 572.034,
+                                                       "format": "video/mp4"
+                                                   },
+                                                   "target": "https://iiif.io/api/cookbook/recipe/0003-mvm-video/canvas"
+                                               }
+                                           ]
+                                       }
+                                   ]
+                               }
+                           ]
+                       }
+
+                       """;
         var expected = new List<CanvasPainting>
         {
             new()
@@ -425,7 +439,7 @@ public class ManifestItemsParserTests
         var deserialised = await manifest.ToPresentation<PresentationManifest>();
          
         // Act
-        var canvasPaintings = sut.ParseToCanvasPainting(deserialised, 123);
+        var canvasPaintings = sut.ParseToCanvasPainting(deserialised, 123, EmptyRecognizedDictionary);
         
         // Assert
         canvasPaintings.Should().BeEquivalentTo(expected);
@@ -436,83 +450,85 @@ public class ManifestItemsParserTests
     {
         // https://iiif.io/api/cookbook/recipe/0033-choice/manifest.json (with some small changes)
         // Arrange
-        var manifest = @"
-{
-    ""@context"": ""http://iiif.io/api/presentation/3/context.json"",
-    ""id"": ""https://iiif.io/api/cookbook/recipe/0033-choice/manifest.json"",
-    ""type"": ""Manifest"",
-    ""label"": {
-        ""en"": [
-            ""John Dee performing an experiment before Queen Elizabeth I.""
-        ]
-    },
-    ""items"": [
-        {
-            ""id"": ""https://iiif.io/api/cookbook/recipe/0033-choice/canvas/p1"",
-            ""type"": ""Canvas"",
-            ""height"": 1271,
-            ""width"": 2000,
-            ""items"": [
-                {
-                    ""id"": ""https://iiif.io/api/cookbook/recipe/0033-choice/page/p1/1"",
-                    ""type"": ""AnnotationPage"",
-                    ""items"": [
-                        {
-                            ""id"": ""https://iiif.io/api/cookbook/recipe/0033-choice/annotation/p0001-image"",
-                            ""type"": ""Annotation"",
-                            ""motivation"": ""painting"",
-                            ""body"": {
-                                ""type"": ""Choice"",
-                                ""items"": [
-                                    {
-                                        ""id"": ""https://iiif.io/api/image/3.0/example/reference/421e65be2ce95439b3ad6ef1f2ab87a9-dee-natural/full/max/0/default.jpg"",
-                                        ""type"": ""Image"",
-                                        ""format"": ""image/jpeg"",
-                                        ""width"": 2000,
-                                        ""height"": 1271,
-                                        ""label"": {
-                                            ""en"": [
-                                                ""Natural Light""
-                                            ]
-                                        },
-                                        ""service"": [
-                                            {
-                                                ""id"": ""https://iiif.io/api/image/3.0/example/reference/421e65be2ce95439b3ad6ef1f2ab87a9-dee-natural"",
-                                                ""type"": ""ImageService3"",
-                                                ""profile"": ""level1""
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        ""id"": ""https://iiif.io/api/image/3.0/example/reference/421e65be2ce95439b3ad6ef1f2ab87a9-dee-xray/full/max/0/default.jpg"",
-                                        ""type"": ""Image"",
-                                        ""format"": ""image/jpeg"",
-                                        ""width"": 2001,
-                                        ""height"": 1272,
-                                        ""label"": {
-                                            ""en"": [
-                                                ""X-Ray""
-                                            ]
-                                        },
-                                        ""service"": [
-                                            {
-                                                ""id"": ""https://iiif.io/api/image/3.0/example/reference/421e65be2ce95439b3ad6ef1f2ab87a9-dee-xray"",
-                                                ""type"": ""ImageService3"",
-                                                ""profile"": ""level1""
-                                            }
-                                        ]
-                                    }
-                                ]
-                            },
-                            ""target"": ""https://iiif.io/api/cookbook/recipe/0033-choice/canvas/p1""
-                        }
-                    ]
-                }
-            ]
-        }
-    ]
-}
-";
+        var manifest = """
+
+                       {
+                           "@context": "http://iiif.io/api/presentation/3/context.json",
+                           "id": "https://iiif.io/api/cookbook/recipe/0033-choice/manifest.json",
+                           "type": "Manifest",
+                           "label": {
+                               "en": [
+                                   "John Dee performing an experiment before Queen Elizabeth I."
+                               ]
+                           },
+                           "items": [
+                               {
+                                   "id": "https://iiif.io/api/cookbook/recipe/0033-choice/canvas/p1",
+                                   "type": "Canvas",
+                                   "height": 1271,
+                                   "width": 2000,
+                                   "items": [
+                                       {
+                                           "id": "https://iiif.io/api/cookbook/recipe/0033-choice/page/p1/1",
+                                           "type": "AnnotationPage",
+                                           "items": [
+                                               {
+                                                   "id": "https://iiif.io/api/cookbook/recipe/0033-choice/annotation/p0001-image",
+                                                   "type": "Annotation",
+                                                   "motivation": "painting",
+                                                   "body": {
+                                                       "type": "Choice",
+                                                       "items": [
+                                                           {
+                                                               "id": "https://iiif.io/api/image/3.0/example/reference/421e65be2ce95439b3ad6ef1f2ab87a9-dee-natural/full/max/0/default.jpg",
+                                                               "type": "Image",
+                                                               "format": "image/jpeg",
+                                                               "width": 2000,
+                                                               "height": 1271,
+                                                               "label": {
+                                                                   "en": [
+                                                                       "Natural Light"
+                                                                   ]
+                                                               },
+                                                               "service": [
+                                                                   {
+                                                                       "id": "https://iiif.io/api/image/3.0/example/reference/421e65be2ce95439b3ad6ef1f2ab87a9-dee-natural",
+                                                                       "type": "ImageService3",
+                                                                       "profile": "level1"
+                                                                   }
+                                                               ]
+                                                           },
+                                                           {
+                                                               "id": "https://iiif.io/api/image/3.0/example/reference/421e65be2ce95439b3ad6ef1f2ab87a9-dee-xray/full/max/0/default.jpg",
+                                                               "type": "Image",
+                                                               "format": "image/jpeg",
+                                                               "width": 2001,
+                                                               "height": 1272,
+                                                               "label": {
+                                                                   "en": [
+                                                                       "X-Ray"
+                                                                   ]
+                                                               },
+                                                               "service": [
+                                                                   {
+                                                                       "id": "https://iiif.io/api/image/3.0/example/reference/421e65be2ce95439b3ad6ef1f2ab87a9-dee-xray",
+                                                                       "type": "ImageService3",
+                                                                       "profile": "level1"
+                                                                   }
+                                                               ]
+                                                           }
+                                                       ]
+                                                   },
+                                                   "target": "https://iiif.io/api/cookbook/recipe/0033-choice/canvas/p1"
+                                               }
+                                           ]
+                                       }
+                                   ]
+                               }
+                           ]
+                       }
+
+                       """;
         var expected = new List<CanvasPainting>
         {
             new()
@@ -540,7 +556,7 @@ public class ManifestItemsParserTests
         var deserialised = await manifest.ToPresentation<PresentationManifest>();
          
         // Act
-        var canvasPaintings = sut.ParseToCanvasPainting(deserialised, 123);
+        var canvasPaintings = sut.ParseToCanvasPainting(deserialised, 123, EmptyRecognizedDictionary);
         
         // Assert
         canvasPaintings.Should().BeEquivalentTo(expected);
@@ -551,84 +567,86 @@ public class ManifestItemsParserTests
     {
         // https://iiif.io/api/cookbook/recipe/0036-composition-from-multiple-images/manifest.json
         // Arrange
-        var manifest = @"
-{
-    ""@context"": ""http://iiif.io/api/presentation/3/context.json"",
-    ""id"": ""https://iiif.io/api/cookbook/recipe/0036-composition-from-multiple-images/manifest.json"",
-    ""type"": ""Manifest"",
-    ""label"": {
-        ""en"": [
-            ""Folio from Grandes Chroniques de France, ca. 1460""
-        ]
-    },
-    ""items"": [
-        {
-            ""id"": ""https://iiif.io/api/cookbook/recipe/0036-composition-from-multiple-images/canvas/p1"",
-            ""type"": ""Canvas"",
-            ""label"": {
-                ""none"": [
-                    ""f. 033v-034r [Chilpéric Ier tue Galswinthe, se remarie et est assassiné]""
-                ]
-            },
-            ""height"": 5412,
-            ""width"": 7216,
-            ""items"": [
-                {
-                    ""id"": ""https://iiif.io/api/cookbook/recipe/0036-composition-from-multiple-images/page/p1/1"",
-                    ""type"": ""AnnotationPage"",
-                    ""items"": [
-                        {
-                            ""id"": ""https://iiif.io/api/cookbook/recipe/0036-composition-from-multiple-images/annotation/p0001-image"",
-                            ""type"": ""Annotation"",
-                            ""motivation"": ""painting"",
-                            ""body"": {
-                                ""id"": ""https://iiif.io/api/image/3.0/example/reference/899da506920824588764bc12b10fc800-bnf_chateauroux/full/max/0/default.jpg"",
-                                ""type"": ""Image"",
-                                ""format"": ""image/jpeg"",
-                                ""height"": 5412,
-                                ""width"": 7216,
-                                ""service"": [
-                                    {
-                                        ""id"": ""https://iiif.io/api/image/3.0/example/reference/899da506920824588764bc12b10fc800-bnf_chateauroux"",
-                                        ""type"": ""ImageService3"",
-                                        ""profile"": ""level1""
-                                    }
-                                ]
-                            },
-                            ""target"": ""https://iiif.io/api/cookbook/recipe/0036-composition-from-multiple-images/canvas/p1""
-                        },
-                        {
-                            ""id"": ""https://iiif.io/api/cookbook/recipe/0036-composition-from-multiple-images/annotation/p0002-image"",
-                            ""type"": ""Annotation"",
-                            ""motivation"": ""painting"",
-                            ""body"": {
-                                ""id"": ""https://iiif.io/api/image/3.0/example/reference/899da506920824588764bc12b10fc800-bnf_chateauroux_miniature/full/max/0/default.jpg"",
-                                ""type"": ""Image"",
-                                ""format"": ""image/jpeg"",
-                                ""label"": {
-                                    ""fr"": [
-                                        ""Miniature [Chilpéric Ier tue Galswinthe, se remarie et est assassiné]""
-                                    ]
-                                },
-                                ""width"": 2138,
-                                ""height"": 2414,
-                                ""service"": [
-                                    {
-                                        ""id"": ""https://iiif.io/api/image/3.0/example/reference/899da506920824588764bc12b10fc800-bnf_chateauroux_miniature"",
-                                        ""type"": ""ImageService3"",
-                                        ""profile"": ""level1""
-                                    }
-                                ]
-                            },
-                            ""target"": ""https://iiif.io/api/cookbook/recipe/0036-composition-from-multiple-images/canvas/p1#xywh=3949,994,1091,1232""
-                        }
-                    ]
-                }
-            ]
-        }
-    ]
-}
-";
+        var manifest = """
+
+                       {
+                           "@context": "http://iiif.io/api/presentation/3/context.json",
+                           "id": "https://iiif.io/api/cookbook/recipe/0036-composition-from-multiple-images/manifest.json",
+                           "type": "Manifest",
+                           "label": {
+                               "en": [
+                                   "Folio from Grandes Chroniques de France, ca. 1460"
+                               ]
+                           },
+                           "items": [
+                               {
+                                   "id": "https://iiif.io/api/cookbook/recipe/0036-composition-from-multiple-images/canvas/p1",
+                                   "type": "Canvas",
+                                   "label": {
+                                       "none": [
+                                           "f. 033v-034r [Chilpéric Ier tue Galswinthe, se remarie et est assassiné]"
+                                       ]
+                                   },
+                                   "height": 5412,
+                                   "width": 7216,
+                                   "items": [
+                                       {
+                                           "id": "https://iiif.io/api/cookbook/recipe/0036-composition-from-multiple-images/page/p1/1",
+                                           "type": "AnnotationPage",
+                                           "items": [
+                                               {
+                                                   "id": "https://iiif.io/api/cookbook/recipe/0036-composition-from-multiple-images/annotation/p0001-image",
+                                                   "type": "Annotation",
+                                                   "motivation": "painting",
+                                                   "body": {
+                                                       "id": "https://iiif.io/api/image/3.0/example/reference/899da506920824588764bc12b10fc800-bnf_chateauroux/full/max/0/default.jpg",
+                                                       "type": "Image",
+                                                       "format": "image/jpeg",
+                                                       "height": 5412,
+                                                       "width": 7216,
+                                                       "service": [
+                                                           {
+                                                               "id": "https://iiif.io/api/image/3.0/example/reference/899da506920824588764bc12b10fc800-bnf_chateauroux",
+                                                               "type": "ImageService3",
+                                                               "profile": "level1"
+                                                           }
+                                                       ]
+                                                   },
+                                                   "target": "https://iiif.io/api/cookbook/recipe/0036-composition-from-multiple-images/canvas/p1"
+                                               },
+                                               {
+                                                   "id": "https://iiif.io/api/cookbook/recipe/0036-composition-from-multiple-images/annotation/p0002-image",
+                                                   "type": "Annotation",
+                                                   "motivation": "painting",
+                                                   "body": {
+                                                       "id": "https://iiif.io/api/image/3.0/example/reference/899da506920824588764bc12b10fc800-bnf_chateauroux_miniature/full/max/0/default.jpg",
+                                                       "type": "Image",
+                                                       "format": "image/jpeg",
+                                                       "label": {
+                                                           "fr": [
+                                                               "Miniature [Chilpéric Ier tue Galswinthe, se remarie et est assassiné]"
+                                                           ]
+                                                       },
+                                                       "width": 2138,
+                                                       "height": 2414,
+                                                       "service": [
+                                                           {
+                                                               "id": "https://iiif.io/api/image/3.0/example/reference/899da506920824588764bc12b10fc800-bnf_chateauroux_miniature",
+                                                               "type": "ImageService3",
+                                                               "profile": "level1"
+                                                           }
+                                                       ]
+                                                   },
+                                                   "target": "https://iiif.io/api/cookbook/recipe/0036-composition-from-multiple-images/canvas/p1#xywh=3949,994,1091,1232"
+                                               }
+                                           ]
+                                       }
+                                   ]
+                               }
+                           ]
+                       }
+
+                       """;
         var expected = new List<CanvasPainting>
         {
             new()
@@ -657,7 +675,7 @@ public class ManifestItemsParserTests
         var deserialised = await manifest.ToPresentation<PresentationManifest>();
 
         // Act
-        var canvasPaintings = sut.ParseToCanvasPainting(deserialised, 123);
+        var canvasPaintings = sut.ParseToCanvasPainting(deserialised, 123, EmptyRecognizedDictionary);
 
         // Assert
         canvasPaintings.Should().BeEquivalentTo(expected);
@@ -668,62 +686,64 @@ public class ManifestItemsParserTests
     {
         // https://iiif.io/api/cookbook/recipe/0299-region/
         // Arrange
-        var manifest = @"
-{
-  ""@context"": ""http://iiif.io/api/presentation/3/context.json"",
-  ""id"": ""https://iiif.io/api/cookbook/recipe/0299-region/manifest.json"",
-  ""type"": ""Manifest"",
-  ""label"": {
-    ""en"": [
-      ""Berliner Tageblatt article, 'Ein neuer Sicherungsplan?'""
-    ]
-  },
-  ""items"": [
-    {
-      ""id"": ""https://iiif.io/api/cookbook/recipe/0299-region/canvas/p1"",
-      ""type"": ""Canvas"",
-      ""height"": 2080,
-      ""width"": 1768,
-      ""items"": [
-        {
-          ""id"": ""https://iiif.io/api/cookbook/recipe/0299-region/page/p1/1"",
-          ""type"": ""AnnotationPage"",
-          ""items"": [
-            {
-              ""id"": ""https://iiif.io/api/cookbook/recipe/0299-region/annotation/p0001-image"",
-              ""type"": ""Annotation"",
-              ""motivation"": ""painting"",
-              ""body"": {
-                ""id"": ""https://iiif.io/api/cookbook/recipe/0299-region/body/b1"",
-                ""type"": ""SpecificResource"",
-                ""source"": {
-                  ""id"": ""https://iiif.io/api/image/3.0/example/reference/4ce82cef49fb16798f4c2440307c3d6f-newspaper-p2/full/max/0/default.jpg"",
-                  ""type"": ""Image"",
-                  ""format"": ""image/jpeg"",
-                  ""height"": 4999,
-                  ""width"": 3536,
-                  ""service"": [
-                    {
-                      ""id"": ""https://iiif.io/api/image/3.0/example/reference/4ce82cef49fb16798f4c2440307c3d6f-newspaper-p2"",
-                      ""profile"": ""level1"",
-                      ""type"": ""ImageService3""
-                    }
-                  ]
-                },
-                ""selector"": {
-                  ""type"": ""ImageApiSelector"",
-                  ""region"": ""1768,2423,1768,2080""
-                }
-              },
-              ""target"": ""https://iiif.io/api/cookbook/recipe/0299-region/canvas/p1""
-            }
-          ]
-        }
-      ]
-    }
-  ]
-}
-";
+        var manifest = """
+
+                       {
+                         "@context": "http://iiif.io/api/presentation/3/context.json",
+                         "id": "https://iiif.io/api/cookbook/recipe/0299-region/manifest.json",
+                         "type": "Manifest",
+                         "label": {
+                           "en": [
+                             "Berliner Tageblatt article, 'Ein neuer Sicherungsplan?'"
+                           ]
+                         },
+                         "items": [
+                           {
+                             "id": "https://iiif.io/api/cookbook/recipe/0299-region/canvas/p1",
+                             "type": "Canvas",
+                             "height": 2080,
+                             "width": 1768,
+                             "items": [
+                               {
+                                 "id": "https://iiif.io/api/cookbook/recipe/0299-region/page/p1/1",
+                                 "type": "AnnotationPage",
+                                 "items": [
+                                   {
+                                     "id": "https://iiif.io/api/cookbook/recipe/0299-region/annotation/p0001-image",
+                                     "type": "Annotation",
+                                     "motivation": "painting",
+                                     "body": {
+                                       "id": "https://iiif.io/api/cookbook/recipe/0299-region/body/b1",
+                                       "type": "SpecificResource",
+                                       "source": {
+                                         "id": "https://iiif.io/api/image/3.0/example/reference/4ce82cef49fb16798f4c2440307c3d6f-newspaper-p2/full/max/0/default.jpg",
+                                         "type": "Image",
+                                         "format": "image/jpeg",
+                                         "height": 4999,
+                                         "width": 3536,
+                                         "service": [
+                                           {
+                                             "id": "https://iiif.io/api/image/3.0/example/reference/4ce82cef49fb16798f4c2440307c3d6f-newspaper-p2",
+                                             "profile": "level1",
+                                             "type": "ImageService3"
+                                           }
+                                         ]
+                                       },
+                                       "selector": {
+                                         "type": "ImageApiSelector",
+                                         "region": "1768,2423,1768,2080"
+                                       }
+                                     },
+                                     "target": "https://iiif.io/api/cookbook/recipe/0299-region/canvas/p1"
+                                   }
+                                 ]
+                               }
+                             ]
+                           }
+                         ]
+                       }
+
+                       """;
         var expected = new List<CanvasPainting>
         {
             new()
@@ -740,7 +760,7 @@ public class ManifestItemsParserTests
         var deserialised = await manifest.ToPresentation<PresentationManifest>();
 
         // Act
-        var canvasPaintings = sut.ParseToCanvasPainting(deserialised, 123);
+        var canvasPaintings = sut.ParseToCanvasPainting(deserialised, 123, EmptyRecognizedDictionary);
 
         // Assert
         canvasPaintings.Should().BeEquivalentTo(expected);
@@ -753,133 +773,135 @@ public class ManifestItemsParserTests
         // and https://iiif.io/api/cookbook/recipe/0033-choice/manifest.json
         
         // Arrange
-        var manifest = @"
-{
-    ""@context"": ""http://iiif.io/api/presentation/3/context.json"",
-    ""id"": ""https://iiif.io/api/cookbook/recipe/0036-composition-from-multiple-images/manifest.json"",
-    ""type"": ""Manifest"",
-    ""label"": {
-        ""en"": [
-            ""Folio from Grandes Chroniques de France, ca. 1460""
-        ]
-    },
-    ""items"": [
-        {
-            ""id"": ""https://iiif.io/api/cookbook/recipe/0036-composition-from-multiple-images/canvas/p1"",
-            ""type"": ""Canvas"",
-            ""label"": {
-                ""none"": [
-                    ""f. 033v-034r [Chilpéric Ier tue Galswinthe, se remarie et est assassiné]""
-                ]
-            },
-            ""height"": 5412,
-            ""width"": 7216,
-            ""items"": [
-                {
-                    ""id"": ""https://iiif.io/api/cookbook/recipe/0036-composition-from-multiple-images/page/p1/1"",
-                    ""type"": ""AnnotationPage"",
-                    ""items"": [
-                        {
-                            ""id"": ""https://iiif.io/api/cookbook/recipe/0036-composition-from-multiple-images/annotation/p0001-image"",
-                            ""type"": ""Annotation"",
-                            ""motivation"": ""painting"",
-                            ""body"": {
-                                ""id"": ""https://iiif.io/api/image/3.0/example/reference/899da506920824588764bc12b10fc800-bnf_chateauroux/full/max/0/default.jpg"",
-                                ""type"": ""Image"",
-                                ""format"": ""image/jpeg"",
-                                ""height"": 5412,
-                                ""width"": 7216,
-                                ""service"": [
-                                    {
-                                        ""id"": ""https://iiif.io/api/image/3.0/example/reference/899da506920824588764bc12b10fc800-bnf_chateauroux"",
-                                        ""type"": ""ImageService3"",
-                                        ""profile"": ""level1""
-                                    }
-                                ]
-                            },
-                            ""target"": ""https://iiif.io/api/cookbook/recipe/0036-composition-from-multiple-images/canvas/p1""
-                        },
-                        {
-                            ""id"": ""https://iiif.io/api/cookbook/recipe/0036-composition-from-multiple-images/annotation/p0002-image"",
-                            ""type"": ""Annotation"",
-                            ""motivation"": ""painting"",
-                            ""body"": {
-                                ""id"": ""https://iiif.io/api/image/3.0/example/reference/899da506920824588764bc12b10fc800-bnf_chateauroux_miniature/full/max/0/default.jpg"",
-                                ""type"": ""Image"",
-                                ""format"": ""image/jpeg"",
-                                ""label"": {
-                                    ""fr"": [
-                                        ""Miniature [Chilpéric Ier tue Galswinthe, se remarie et est assassiné]""
-                                    ]
-                                },
-                                ""width"": 2138,
-                                ""height"": 2414,
-                                ""service"": [
-                                    {
-                                        ""id"": ""https://iiif.io/api/image/3.0/example/reference/899da506920824588764bc12b10fc800-bnf_chateauroux_miniature"",
-                                        ""type"": ""ImageService3"",
-                                        ""profile"": ""level1""
-                                    }
-                                ]
-                            },
-                            ""target"": ""https://iiif.io/api/cookbook/recipe/0036-composition-from-multiple-images/canvas/p1#xywh=3949,994,1091,1232""
-                        },
-                        {
-                            ""id"": ""https://iiif.io/api/cookbook/recipe/0033-choice/annotation/p0001-image"",
-                            ""type"": ""Annotation"",
-                            ""motivation"": ""painting"",
-                            ""body"": {
-                                ""type"": ""Choice"",
-                                ""items"": [
-                                    {
-                                        ""id"": ""https://iiif.io/api/image/3.0/example/reference/421e65be2ce95439b3ad6ef1f2ab87a9-dee-natural/full/max/0/default.jpg"",
-                                        ""type"": ""Image"",
-                                        ""format"": ""image/jpeg"",
-                                        ""width"": 2000,
-                                        ""height"": 1271,
-                                        ""label"": {
-                                            ""en"": [
-                                                ""Natural Light""
-                                            ]
-                                        },
-                                        ""service"": [
-                                            {
-                                                ""id"": ""https://iiif.io/api/image/3.0/example/reference/421e65be2ce95439b3ad6ef1f2ab87a9-dee-natural"",
-                                                ""type"": ""ImageService3"",
-                                                ""profile"": ""level1""
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        ""id"": ""https://iiif.io/api/image/3.0/example/reference/421e65be2ce95439b3ad6ef1f2ab87a9-dee-xray/full/max/0/default.jpg"",
-                                        ""type"": ""Image"",
-                                        ""format"": ""image/jpeg"",
-                                        ""width"": 2001,
-                                        ""height"": 1272,
-                                        ""label"": {
-                                            ""en"": [
-                                                ""X-Ray""
-                                            ]
-                                        },
-                                        ""service"": [
-                                            {
-                                                ""id"": ""https://iiif.io/api/image/3.0/example/reference/421e65be2ce95439b3ad6ef1f2ab87a9-dee-xray"",
-                                                ""type"": ""ImageService3"",
-                                                ""profile"": ""level1""
-                                            }
-                                        ]
-                                    }
-                                ]
-                            },
-                            ""target"": ""https://iiif.io/api/cookbook/recipe/0036-composition-from-multiple-images/canvas/p1#xywh=0,0,1091,1232""
-                        }
-                    ]
-                }
-            ]
-        }
-    ]
-}
-";
+        var manifest = """
+
+                       {
+                           "@context": "http://iiif.io/api/presentation/3/context.json",
+                           "id": "https://iiif.io/api/cookbook/recipe/0036-composition-from-multiple-images/manifest.json",
+                           "type": "Manifest",
+                           "label": {
+                               "en": [
+                                   "Folio from Grandes Chroniques de France, ca. 1460"
+                               ]
+                           },
+                           "items": [
+                               {
+                                   "id": "https://iiif.io/api/cookbook/recipe/0036-composition-from-multiple-images/canvas/p1",
+                                   "type": "Canvas",
+                                   "label": {
+                                       "none": [
+                                           "f. 033v-034r [Chilpéric Ier tue Galswinthe, se remarie et est assassiné]"
+                                       ]
+                                   },
+                                   "height": 5412,
+                                   "width": 7216,
+                                   "items": [
+                                       {
+                                           "id": "https://iiif.io/api/cookbook/recipe/0036-composition-from-multiple-images/page/p1/1",
+                                           "type": "AnnotationPage",
+                                           "items": [
+                                               {
+                                                   "id": "https://iiif.io/api/cookbook/recipe/0036-composition-from-multiple-images/annotation/p0001-image",
+                                                   "type": "Annotation",
+                                                   "motivation": "painting",
+                                                   "body": {
+                                                       "id": "https://iiif.io/api/image/3.0/example/reference/899da506920824588764bc12b10fc800-bnf_chateauroux/full/max/0/default.jpg",
+                                                       "type": "Image",
+                                                       "format": "image/jpeg",
+                                                       "height": 5412,
+                                                       "width": 7216,
+                                                       "service": [
+                                                           {
+                                                               "id": "https://iiif.io/api/image/3.0/example/reference/899da506920824588764bc12b10fc800-bnf_chateauroux",
+                                                               "type": "ImageService3",
+                                                               "profile": "level1"
+                                                           }
+                                                       ]
+                                                   },
+                                                   "target": "https://iiif.io/api/cookbook/recipe/0036-composition-from-multiple-images/canvas/p1"
+                                               },
+                                               {
+                                                   "id": "https://iiif.io/api/cookbook/recipe/0036-composition-from-multiple-images/annotation/p0002-image",
+                                                   "type": "Annotation",
+                                                   "motivation": "painting",
+                                                   "body": {
+                                                       "id": "https://iiif.io/api/image/3.0/example/reference/899da506920824588764bc12b10fc800-bnf_chateauroux_miniature/full/max/0/default.jpg",
+                                                       "type": "Image",
+                                                       "format": "image/jpeg",
+                                                       "label": {
+                                                           "fr": [
+                                                               "Miniature [Chilpéric Ier tue Galswinthe, se remarie et est assassiné]"
+                                                           ]
+                                                       },
+                                                       "width": 2138,
+                                                       "height": 2414,
+                                                       "service": [
+                                                           {
+                                                               "id": "https://iiif.io/api/image/3.0/example/reference/899da506920824588764bc12b10fc800-bnf_chateauroux_miniature",
+                                                               "type": "ImageService3",
+                                                               "profile": "level1"
+                                                           }
+                                                       ]
+                                                   },
+                                                   "target": "https://iiif.io/api/cookbook/recipe/0036-composition-from-multiple-images/canvas/p1#xywh=3949,994,1091,1232"
+                                               },
+                                               {
+                                                   "id": "https://iiif.io/api/cookbook/recipe/0033-choice/annotation/p0001-image",
+                                                   "type": "Annotation",
+                                                   "motivation": "painting",
+                                                   "body": {
+                                                       "type": "Choice",
+                                                       "items": [
+                                                           {
+                                                               "id": "https://iiif.io/api/image/3.0/example/reference/421e65be2ce95439b3ad6ef1f2ab87a9-dee-natural/full/max/0/default.jpg",
+                                                               "type": "Image",
+                                                               "format": "image/jpeg",
+                                                               "width": 2000,
+                                                               "height": 1271,
+                                                               "label": {
+                                                                   "en": [
+                                                                       "Natural Light"
+                                                                   ]
+                                                               },
+                                                               "service": [
+                                                                   {
+                                                                       "id": "https://iiif.io/api/image/3.0/example/reference/421e65be2ce95439b3ad6ef1f2ab87a9-dee-natural",
+                                                                       "type": "ImageService3",
+                                                                       "profile": "level1"
+                                                                   }
+                                                               ]
+                                                           },
+                                                           {
+                                                               "id": "https://iiif.io/api/image/3.0/example/reference/421e65be2ce95439b3ad6ef1f2ab87a9-dee-xray/full/max/0/default.jpg",
+                                                               "type": "Image",
+                                                               "format": "image/jpeg",
+                                                               "width": 2001,
+                                                               "height": 1272,
+                                                               "label": {
+                                                                   "en": [
+                                                                       "X-Ray"
+                                                                   ]
+                                                               },
+                                                               "service": [
+                                                                   {
+                                                                       "id": "https://iiif.io/api/image/3.0/example/reference/421e65be2ce95439b3ad6ef1f2ab87a9-dee-xray",
+                                                                       "type": "ImageService3",
+                                                                       "profile": "level1"
+                                                                   }
+                                                               ]
+                                                           }
+                                                       ]
+                                                   },
+                                                   "target": "https://iiif.io/api/cookbook/recipe/0036-composition-from-multiple-images/canvas/p1#xywh=0,0,1091,1232"
+                                               }
+                                           ]
+                                       }
+                                   ]
+                               }
+                           ]
+                       }
+
+                       """;
         var expected = new List<CanvasPainting>
         {
             new()
@@ -928,7 +950,7 @@ public class ManifestItemsParserTests
         var deserialised = await manifest.ToPresentation<PresentationManifest>();
 
         // Act
-        var canvasPaintings = sut.ParseToCanvasPainting(deserialised, 123);
+        var canvasPaintings = sut.ParseToCanvasPainting(deserialised, 123, EmptyRecognizedDictionary);
 
         // Assert
         canvasPaintings.Should().BeEquivalentTo(expected);

--- a/src/IIIFPresentation/Services.Tests/Manifests/ManifestPaintedResourceParserTests.cs
+++ b/src/IIIFPresentation/Services.Tests/Manifests/ManifestPaintedResourceParserTests.cs
@@ -32,11 +32,11 @@ public class ManifestPaintedResourceParserTests
 
     [Fact]
     public void Parse_ReturnsEmptyEnumerable_IfItemsNull()
-        => sut.ParseToCanvasPainting(new PresentationManifest(), CustomerId).Should().BeEmpty();
+        => sut.ParseToCanvasPainting(new PresentationManifest(), CustomerId, null!).Should().BeEmpty();
 
     [Fact]
     public void Parse_ReturnsEmptyEnumerable_IfItemsEmpty()
-        => sut.ParseToCanvasPainting(new PresentationManifest(), CustomerId).Should().BeEmpty();
+        => sut.ParseToCanvasPainting(new PresentationManifest(), CustomerId, null!).Should().BeEmpty();
 
     [Theory]
     [InlineData("https://foo.com/example/1/canvases/canvas")]
@@ -60,7 +60,7 @@ public class ManifestPaintedResourceParserTests
             ]
         };
 
-        Action action = () => sut.ParseToCanvasPainting(manifest, CustomerId);
+        Action action = () => sut.ParseToCanvasPainting(manifest, CustomerId, null!);
         action.Should().Throw<InvalidCanvasIdException>();
     }
     
@@ -85,7 +85,7 @@ public class ManifestPaintedResourceParserTests
             ]
         };
 
-        var parsed = sut.ParseToCanvasPainting(manifest, CustomerId);
+        var parsed = sut.ParseToCanvasPainting(manifest, CustomerId, null!);
         
         parsed.First().Id.Should().Be("canvas");
     }
@@ -114,7 +114,7 @@ public class ManifestPaintedResourceParserTests
             },
         };
         
-        var canvasPaintings = sut.ParseToCanvasPainting(manifest, CustomerId);
+        var canvasPaintings = sut.ParseToCanvasPainting(manifest, CustomerId, null!);
 
         canvasPaintings.Should().BeEquivalentTo(expected);
     }
@@ -153,7 +153,7 @@ public class ManifestPaintedResourceParserTests
             },
         };
         
-        var canvasPaintings = sut.ParseToCanvasPainting(manifest, CustomerId);
+        var canvasPaintings = sut.ParseToCanvasPainting(manifest, CustomerId, null!);
 
         canvasPaintings.Should().BeEquivalentTo(expected);
     }
@@ -200,7 +200,7 @@ public class ManifestPaintedResourceParserTests
             },
         };
         
-        var canvasPaintings = sut.ParseToCanvasPainting(manifest, CustomerId);
+        var canvasPaintings = sut.ParseToCanvasPainting(manifest, CustomerId, null!);
 
         canvasPaintings.Should().BeEquivalentTo(expected);
     }
@@ -275,7 +275,7 @@ public class ManifestPaintedResourceParserTests
             },
         };
         
-        var canvasPaintings = sut.ParseToCanvasPainting(manifest, CustomerId);
+        var canvasPaintings = sut.ParseToCanvasPainting(manifest, CustomerId, null!);
 
         canvasPaintings.Should().BeEquivalentTo(expected);
     }
@@ -352,7 +352,7 @@ public class ManifestPaintedResourceParserTests
             },
         };
         
-        var canvasPaintings = sut.ParseToCanvasPainting(manifest, CustomerId);
+        var canvasPaintings = sut.ParseToCanvasPainting(manifest, CustomerId, null!);
         canvasPaintings.Should().BeEquivalentTo(expected);
     }
 
@@ -411,7 +411,7 @@ public class ManifestPaintedResourceParserTests
             },
         };
         
-        var canvasPaintings = sut.ParseToCanvasPainting(manifest, CustomerId);
+        var canvasPaintings = sut.ParseToCanvasPainting(manifest, CustomerId, null!);
         canvasPaintings.Should().BeEquivalentTo(expected);
     }
 
@@ -549,7 +549,7 @@ public class ManifestPaintedResourceParserTests
             },
         };
         
-        var canvasPaintings = sut.ParseToCanvasPainting(manifest, CustomerId);
+        var canvasPaintings = sut.ParseToCanvasPainting(manifest, CustomerId, null!);
         canvasPaintings.Should().BeEquivalentTo(expected);
     }
 

--- a/src/IIIFPresentation/Services/Manifests/ICanvasPaintingParser.cs
+++ b/src/IIIFPresentation/Services/Manifests/ICanvasPaintingParser.cs
@@ -1,4 +1,6 @@
-﻿using Models.API.Manifest;
+﻿using IIIF.Presentation.V3.Annotation;
+using Models.API.Manifest;
+using Models.DLCS;
 using CanvasPainting = Models.Database.CanvasPainting;
 
 namespace Services.Manifests;
@@ -8,5 +10,6 @@ namespace Services.Manifests;
 /// </summary>
 public interface ICanvasPaintingParser
 {
-    IEnumerable<CanvasPainting> ParseToCanvasPainting(PresentationManifest manifest, int customer);
+    IEnumerable<CanvasPainting> ParseToCanvasPainting(PresentationManifest manifest, int customer,
+        Dictionary<IPaintable, AssetId> recognizedItemsAssets);
 }

--- a/src/IIIFPresentation/Services/Manifests/ManifestItemsParser.cs
+++ b/src/IIIFPresentation/Services/Manifests/ManifestItemsParser.cs
@@ -6,6 +6,7 @@ using IIIF.Presentation.V3.Content;
 using IIIF.Serialisation;
 using Microsoft.Extensions.Logging;
 using Models.API.Manifest;
+using Models.DLCS;
 using Repository.Paths;
 using Services.Manifests.Helpers;
 using CanvasPainting = Models.Database.CanvasPainting;
@@ -19,7 +20,8 @@ public class ManifestItemsParser(
     IPresentationPathGenerator presentationPathGenerator,
     ILogger<ManifestItemsParser> logger) : ICanvasPaintingParser
 {
-    public IEnumerable<CanvasPainting> ParseToCanvasPainting(PresentationManifest manifest, int customer)
+    public IEnumerable<CanvasPainting> ParseToCanvasPainting(PresentationManifest manifest, int customer,
+        Dictionary<IPaintable, AssetId> recognizedItemsAssets)
     {
         if (manifest.Items.IsNullOrEmpty()) return [];
 
@@ -50,6 +52,8 @@ public class ManifestItemsParser(
                 var target = painting.Target;
 
                 var body = painting.Body;
+                var assetId = body is not null && recognizedItemsAssets.ContainsKey(body) ? recognizedItemsAssets[canvas] : null;
+                
                 if (body is PaintingChoice choice)
                 {
                     logger.LogTrace("Canvas {CanvasOrder}:'{CanvasId}' is a choice", canvasOrder, canvas.Id);
@@ -66,7 +70,7 @@ public class ManifestItemsParser(
                         if (resource is Image or Video or Sound)
                         {
                             var cp = CreatePartialCanvasPainting(resource, canvas.Id, choiceCanvasOrder, target,
-                                canvas, customer, choiceOrder);
+                                canvas, customer, choiceOrder, assetId);
 
                             choiceOrder++;
                             if (first)
@@ -107,7 +111,7 @@ public class ManifestItemsParser(
                             $"Body type '{body}' not supported as painting annotation body");
                     }
 
-                    var cp = CreatePartialCanvasPainting(resource, canvas.Id, canvasOrder, target, canvas, customer);
+                    var cp = CreatePartialCanvasPainting(resource, canvas.Id, canvasOrder, target, canvas, customer, assetId: assetId);
 
                     canvasOrder++;
                     cp.Label = resource.Label ?? painting.Label ?? canvas.Label;
@@ -141,7 +145,8 @@ public class ManifestItemsParser(
         ResourceBase? target,
         Canvas currentCanvas,
         int customerId,
-        int? choiceOrder = null)
+        int? choiceOrder = null,
+        AssetId? assetId = null)
     {
         // Create "partial" canvasPaintings that only contains values derived from manifest (no customer, manifest etc) 
         var cp = new CanvasPainting
@@ -151,6 +156,7 @@ public class ManifestItemsParser(
             ChoiceOrder = choiceOrder,
             Target = TargetAsString(target, currentCanvas),
             Thumbnail = TryGetThumbnail(currentCanvas),
+            AssetId = assetId
         };
         
         if (resource is ISpatial spatial)

--- a/src/IIIFPresentation/Services/Manifests/ManifestPaintedResourceParser.cs
+++ b/src/IIIFPresentation/Services/Manifests/ManifestPaintedResourceParser.cs
@@ -1,5 +1,6 @@
 ﻿using Core.Exceptions;
 using Core.Helpers;
+using IIIF.Presentation.V3.Annotation;
 using Microsoft.Extensions.Logging;
 using Models.API.Manifest;
 using Models.DLCS;
@@ -18,7 +19,8 @@ public class ManifestPaintedResourceParser(
     IPresentationPathGenerator presentationPathGenerator,
     ILogger<ManifestPaintedResourceParser> logger) : ICanvasPaintingParser
 {
-    public IEnumerable<CanvasPainting> ParseToCanvasPainting(PresentationManifest presentationManifest, int customerId)
+    public IEnumerable<CanvasPainting> ParseToCanvasPainting(PresentationManifest presentationManifest, int customerId,
+        Dictionary<IPaintable, AssetId> _)
     {
         if (presentationManifest.PaintedResources.IsNullOrEmpty()) return [];
         


### PR DESCRIPTION
- **Remove `IgnorePaintedResourcesWithItems` option as no longer needed**
- **Update PresentationManifestValidatorTests.cs**
- **Impl #424 - Recognize managed asset path in manifest items**
- **Adjust existing tests to new code**
- **Fix to previously expected functionality**
