### PR TITLE
Fix database not being saved when all assets are tracked

### DIFF
--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetUpdateTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetUpdateTests.cs
@@ -2185,6 +2185,13 @@ public class ModifyManifestAssetUpdateTests : IClassFixture<PresentationAppFacto
             .Include(m => m.Batches)
             .First(x => x.Id == id);
         dbManifest.CanvasPaintings.Should().HaveCount(2);
+        var firstCanvasPainting = dbManifest.CanvasPaintings.First();
+        firstCanvasPainting.StaticHeight.Should().Be(100, "maintained value");
+        firstCanvasPainting.StaticWidth.Should().Be(100, "maintained value");
+        firstCanvasPainting.Thumbnail.Should()
+            .Be($"https://dlcs.test/iiif-img/{Customer}/{NewlyCreatedSpace}/{assetId}_1/canvas/c/_CanvasThumbnail",
+                "maintained value");
+        
         dbManifest.Batches.Should().HaveCount(1, "Only the initial batch is created");
         
         var savedS3 =

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
@@ -363,6 +363,7 @@ public class ManifestWriteService(
         if (canBeBuiltUpfront)
         {
             var manifest = await manifestStorageManager.UpsertManifestInStorage(iiifManifest, dbManifest, cancellationToken);
+            await dbContext.SaveChangesAsync(cancellationToken);
             request.PresentationManifest.Items = manifest.Items;
         }
         else


### PR DESCRIPTION
Resolves #454 

This PR fixes an issue where the database is not saved when all assets are tracked