### PR TITLE
Add canvas id parsing notes

### DIFF
--- a/docs/.vscode/settings.json
+++ b/docs/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "cSpell.customDictionaries": {
+
+    },
+    "cSpell.language": "en-GB"
+}

--- a/docs/.vscode/settings.json
+++ b/docs/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "cSpell.customDictionaries": {
-
-    },
-    "cSpell.language": "en-GB"
-}

--- a/docs/notes/canvas-id-parsing.md
+++ b/docs/notes/canvas-id-parsing.md
@@ -1,0 +1,71 @@
+# Canvas Id parsing
+
+When parsing payloads, the `canvasId` can be used to generate a `canvasPainting` `id` record.  This can be accepted either directly from a `canvasPainting` `canvasId` and also from `items` `id` of a canvas.  In addition to the 2 locations that we can generate a `canvasId` from, we can accept either a short form (i.e.: just the id itself) or alternatively from a recognized URI.  Finally, this `canvasId` can be used to join a `canvas` declared in `items` with a `canvasPainting` record in order to decorate an asset from the DLCS with additional IIIF.   This document is set to explain the various ways this `canvasId` can be parsed from a payload.
+
+## Accepted formats
+
+As mentioned above, there are a few formats that will be accepted 
+
+
+| Format      | Example     |
+| ------------- | ------------- |
+| short canvas | `someId` |
+| general API URL | `https://presentation-api.com/1/canvas/someId` |
+| customer specific API URL | `https:/customer-base.com/canvas/someId` |
+
+
+## Basic process
+
+When we receive a canvas id, a series of actions happen to see if we can work out the canvas id based on the given value.  This can be quite complex to follow the logic, so the below flowchart shows the steps taken:
+
+```mermaid
+flowchart TD
+    first[Canvas provided]
+    second{is the canvas id null}
+    third[generate the canvas id]
+    fourth{is the canvas id a URI}
+    fifth{any invalid characters}
+    sixth[use the provided canvas id]
+    seventh{where is this canvas id from?}
+    eighth{is this a recognized host}
+    ninth[parse path with rewrites]
+    tenth{is the path parsed}
+    eleventh{from items}
+    twelfth[throw an error]
+
+    first --> second
+    second -- yes --> third
+    second -- no --> fourth
+    fourth -- no --> fifth
+    fifth -- yes --> eleventh
+    fifth -- no --> sixth
+    fourth -- yes --> seventh
+    seventh -- items --> eighth
+    eighth -- no --> third
+    eighth -- yes --> ninth
+    seventh -- canvasPaintings --> ninth
+    ninth --> tenth
+    tenth -- no --> third
+    tenth -- yes --> fifth
+    eleventh -- yes --> third
+    eleventh -- no --> twelfth
+```
+
+There is a slight difference between the id being parsed from `items` versus `canvasPaintings`, in that `items` has an additional check for "is a recognized host".  This is because `items` needs to be slightly tighter than `canvasPaintings` as the `canvasId` will be _generated_ for the `canvasPainting` table, but the id in the `items`will be left alone, with a `canvasOriginalId` added to the `canvasPainting` record.  This ultimately helps to avoid rejecting payloads that are purely IIIF that have been copied around from another customer.  This check is essentially checking that the passed URL is either the general API URL or the customer specific URL.
+
+Additionally, in `items`, if the host is matched, but the resource is not, (for example, the API expects `https://presentation-api.com/{customer}/canvas/someId` and receives `https://presentation-api.com/someId`), the API will fallback to generating an id instead of throwing an error.
+
+> [!NOTE]
+> the only way for a `canvasPainting` to have a `canvasOriginalId` is if the `item` is __not__ matched with a `canvasPainting` from the payload
+
+> [!NOTE]
+> The currently invalid characters are `/`, `,` and `=`
+
+## Matching canvas painting records
+
+In addition to how the id is retrieved from the payload itself, `canvasPainting` is matched to a corresponding canvas in `items` when the `id` matches.  As this value in the database is _only_ the id and not a potential full URI, it does mean that the presentation API can match between slightly different values in the payload.  For example, if the canvas in `items` has an id of `https://presentation-api.com/1/canvas/someId`, it would match with a `canvasPainting` `canvasId` of `someId`.
+
+
+## Short canvas id
+
+When selecting from a short canvas id, there _must_ be a matching `paintedResource` if the canvas is set using a short canvas.  However, a painted resource can be specified with a short canvas without a matching canvas in `items.  

--- a/docs/notes/canvas-id-parsing.md
+++ b/docs/notes/canvas-id-parsing.md
@@ -34,6 +34,7 @@ flowchart TD
     twelfth[throw an error]
     thirteenth{from items}
     fourteenth{matches painted resource}
+    fifteenth{from items, <br> no painted resource match}
 
     first --> second
     second -- yes --> third
@@ -44,7 +45,9 @@ flowchart TD
     fourteenth -- no --> twelfth
     fourteenth -- yes --> fifth
     fifth -- yes --> eleventh
-    fifth -- no --> sixth
+    fifth -- no --> fifteenth
+    fifteenth -- yes --> third
+    fifteenth -- no --> sixth
     fourth -- yes --> seventh
     seventh -- items --> eighth
     eighth -- no --> third

--- a/docs/notes/canvas-id-parsing.md
+++ b/docs/notes/canvas-id-parsing.md
@@ -111,7 +111,6 @@ A set of worked examples to try and show the final result, based on the flowchar
 | items | `someId` | `someId`|  `someId` |
 | painted resource | `https://presentation-api.com/1/canvas/someId` | `https://presentation-api.com/1/canvas/someId` |  `someId`  |
 | items | `https://presentation-api.com/1/canvas/someId` | `https://presentation-api.com/1/canvas/someId` |  `someId`  |
-| items | `https:/customer-base.com/canvas/someId` | `https:/customer-base.com/canvas/someId` |  `someId`  |
 | painted resource | `https:/customer-base.com/canvas/someId` | `https:/customer-base.com/canvas/someId` |  `someId`  |
 | items | `https:/customer-base.com/canvas/someId` | `https:/customer-base.com/canvas/someId` |  `someId`  |
 | painted resource | `https://presentation-api.com/1/canvas/invalidCharacter=` | not matched |  throws error |
@@ -120,3 +119,9 @@ A set of worked examples to try and show the final result, based on the flowchar
 | items | `https://presentation-api.com/invalidCanvasId` | not matched |  generates id  |
 | painted resource | `https://random.co.uk/someCanvasId` | not matched |  throws error  |
 | items | `https://random.co.uk/someCanvasId` | not matched |  generates id  |
+| painted resource | `https:/customer-base.com/canvas/someId` | `https://presentation-api.com/1/canvas/someId` |  `someId`  |
+| painted resource | `someId` | `https://presentation-api.com/1/canvas/someId` |  `someId`  |
+| painted resource | `https://presentation-api.com/1/canvas/someId` | `https:/customer-base.com/canvas/someId` |  `someId`  |
+| items | `https:/customer-base.com/canvas/someId` | `https://presentation-api.com/1/canvas/someId` |  `someId`  |
+| items | `someId` | `https://presentation-api.com/1/canvas/someId` |  `someId`  |
+| items | `https://presentation-api.com/1/canvas/someId` | `https:/customer-base.com/canvas/someId` |  `someId`  |

--- a/docs/notes/canvas-id-parsing.md
+++ b/docs/notes/canvas-id-parsing.md
@@ -125,3 +125,4 @@ A set of worked examples to try and show the final result, based on the flowchar
 | items | `https:/customer-base.com/canvas/someId` | `https://presentation-api.com/1/canvas/someId` |  `someId`  |
 | items | `someId` | `https://presentation-api.com/1/canvas/someId` |  `someId`  |
 | items | `https://presentation-api.com/1/canvas/someId` | `https:/customer-base.com/canvas/someId` |  `someId`  |
+| items | `https://presentation-api.com/1/canvas/someId` | not matched | generates id |

--- a/docs/notes/canvas-id-parsing.md
+++ b/docs/notes/canvas-id-parsing.md
@@ -1,6 +1,6 @@
 # Canvas Id parsing
 
-When parsing payloads, the `canvasId` can be used to generate a `canvasPainting` `id` record.  This can be accepted either directly from a `canvasPainting` `canvasId` and also from `items` `id` of a canvas.  In addition to the 2 locations that we can generate a `canvasId` from, we can accept either a short form (i.e.: just the id itself) or alternatively from a recognized URI.  Finally, this `canvasId` can be used to join a `canvas` declared in `items` with a `canvasPainting` record in order to decorate an asset from the DLCS with additional IIIF.   This document is set to explain the various ways this `canvasId` can be parsed from a payload.
+When parsing payloads, the `canvasId` can be used to generate a `canvasPainting` `id` record.  This can be accepted either directly from a `canvasPainting` `canvasId` and also from `items` `id` of a canvas.  In addition to the 2 locations that we can generate a `canvasId` from, we can accept either a short form (i.e.: just the id itself) or alternatively from a recognised URI.  Finally, this `canvasId` can be used to join a `canvas` declared in `items` with a `canvasPainting` record in order to decorate an asset from the DLCS with additional IIIF.   This document is set to explain the various ways this `canvasId` can be parsed from a payload.
 
 ## Accepted formats
 
@@ -27,7 +27,7 @@ flowchart TD
     fifth{any invalid characters}
     sixth[use the provided canvas id]
     seventh{where is this canvas id from?}
-    eighth{is this a recognized host}
+    eighth{is this a recognised host}
     ninth[parse path with rewrites]
     tenth{is the path parsed}
     eleventh{from items}
@@ -45,13 +45,22 @@ flowchart TD
     eighth -- yes --> ninth
     seventh -- canvasPaintings --> ninth
     ninth --> tenth
-    tenth -- no --> third
+    tenth -- no --> eleventh
     tenth -- yes --> fifth
     eleventh -- yes --> third
     eleventh -- no --> twelfth
 ```
 
-There is a slight difference between the id being parsed from `items` versus `canvasPaintings`, in that `items` has an additional check for "is a recognized host".  This is because `items` needs to be slightly tighter than `canvasPaintings` as the `canvasId` will be _generated_ for the `canvasPainting` table, but the id in the `items`will be left alone, with a `canvasOriginalId` added to the `canvasPainting` record.  This ultimately helps to avoid rejecting payloads that are purely IIIF that have been copied around from another customer.  This check is essentially checking that the passed URL is either the general API URL or the customer specific URL.
+There is a slight difference between the id being parsed from `items` versus `canvasPaintings`, in that `items` has an additional check for "is a recognised host".  This is because `items` needs to be slightly tighter than `canvasPaintings` as the `canvasId` will be _generated_ for the `canvasPainting` table, but the id in the `items`will be left alone, with a `canvasOriginalId` added to the `canvasPainting` record.  This ultimately helps to avoid rejecting payloads that are purely IIIF that have been copied around from another customer.  This check is essentially checking that the passed URL is either the general API URL or the customer specific URL.
+
+The "is recognised host" check depends on the below settings to recognise a host:
+
+```json
+"PresentationApiUrl": "https://presentation-api.com/1/canvas/someId",
+    "CustomerPresentationApiUrl": {
+      "1": "https:/customer-base.com/canvas/someId", // this matches based on the customer id
+    }
+```
 
 Additionally, in `items`, if the host is matched, but the resource is not, (for example, the API expects `https://presentation-api.com/{customer}/canvas/someId` and receives `https://presentation-api.com/someId`), the API will fallback to generating an id instead of throwing an error.
 
@@ -68,4 +77,4 @@ In addition to how the id is retrieved from the payload itself, `canvasPainting`
 
 ## Short canvas id
 
-When selecting from a short canvas id, there _must_ be a matching `paintedResource` if the canvas is set using a short canvas.  However, a painted resource can be specified with a short canvas without a matching canvas in `items.  
+When selecting from a short canvas id, there _must_ be a matching `paintedResource` if the canvas is set using a short canvas.  However, a painted resource can be specified with a short canvas without a matching canvas in `items`.  

--- a/docs/notes/canvas-id-parsing.md
+++ b/docs/notes/canvas-id-parsing.md
@@ -1,6 +1,6 @@
 # Canvas Id parsing
 
-When parsing payloads, the `canvasId` can be used to generate a `canvasPainting` `id` record.  This can be accepted either directly from a `canvasPainting` `canvasId` and also from `items` `id` of a canvas.  In addition to the 2 locations that we can generate a `canvasId` from, we can accept either a short form (i.e.: just the id itself) or alternatively from a recognised URI.  Finally, this `canvasId` can be used to join a `canvas` declared in `items` with a `canvasPainting` record in order to decorate an asset from the DLCS with additional IIIF.   This document is set to explain the various ways this `canvasId` can be parsed from a payload.
+When parsing payloads, the `canvasId` can be used to generate a `paintedResource` `id` record.  This can be accepted either directly from a `paintedResource` `canvasId` and also from `items` `id` of a canvas.  In addition to the 2 locations that we can generate a `canvasId` from, we can accept either a short form (i.e.: just the id itself) or alternatively from a recognised URI.  Finally, this `canvasId` can be used to join a `canvas` declared in `items` with a `canvasPainting` record in order to decorate an asset from the DLCS with additional IIIF.   This document is set to explain the various ways this `canvasId` can be parsed from a payload.
 
 ## Accepted formats
 
@@ -10,8 +10,8 @@ As mentioned above, there are a few formats that will be accepted
 | Format      | Example     |
 | ------------- | ------------- |
 | short canvas | `someId` |
-| general API URL | `https://presentation-api.com/1/canvas/someId` |
-| customer specific API URL | `https:/customer-base.com/canvas/someId` |
+| general API URL | `https://presentation-api.com/1/canvases/someId` |
+| customer specific API URL | `https:/customer-base.com/canvases/someId` |
 
 
 ## Basic process
@@ -59,7 +59,7 @@ flowchart TD
 title: Painted Resources
 ---
 flowchart TD
-    first[Canvas provided]
+    first[PaintedResource CanvasPainting provided]
     second{is the canvas id null}
     third[generate the canvas id]
     fourth{is the canvas id a URI}
@@ -76,19 +76,22 @@ flowchart TD
     fifth -- no --> sixth
     fifth -- yes --> ninth
     fourth -- yes --> seventh
+    subgraph no check for recognised host
+        seventh 
+    end
     seventh --> eighth
     eighth -- yes --> fifth
     eighth -- no --> ninth
 ```
 
-There is a slight difference between the id being parsed from `items` versus `canvasPaintings`, in that `items` has an additional check for "is a recognised host".  This is because `items` needs to be slightly tighter than `canvasPaintings` as the `canvasId` will be _generated_ for the `canvasPainting` table, but the id in the `items`will be left alone, with a `canvasOriginalId` added to the `canvasPainting` record.  This ultimately helps to avoid rejecting payloads that are purely IIIF that have been copied around from another customer.  This check is essentially checking that the passed URL is either the general API URL or the customer specific URL.
+There is a slight difference between the id being parsed from `items` versus `paintedResource`, in that `items` has an additional check for "is a recognised host".  This is because `items` needs to be slightly tighter than `canvasPaintings` as the `canvasId` will be _generated_ for the `canvasPainting` table, but the id in the `items`will be left alone, with a `canvasOriginalId` added to the `canvasPainting` record.  This ultimately helps to avoid rejecting payloads that are purely IIIF that have been copied around from another customer.  This check is essentially checking that the passed URL is either the general API URL or the customer specific URL.
 
 The "is recognised host" check depends on the below settings to recognise a host:
 
 ```json
-"PresentationApiUrl": "https://presentation-api.com/1/canvas/someId",
+"PresentationApiUrl": "https://presentation-api.com",
     "CustomerPresentationApiUrl": {
-      "1": "https:/customer-base.com/canvas/someId", // this matches based on the customer id
+      "1": "https:/customer-base.com", // this matches based on the customer id
     }
 ```
 this is then combined with settings from `PathRules` to parse a URI:
@@ -96,27 +99,27 @@ this is then combined with settings from `PathRules` to parse a URI:
 ```json
 "PathRules": {
       "Defaults": {
-        "Canvas": "/{customerId}/canvas/{resourceId}"
+        "Canvas": "/{customerId}/canvases/{resourceId}"
       },
       "Overrides": {
         "https:/customer-base.com": {
-          "Canvas": "/canvas/{resourceId}"
+          "Canvas": "/canvases/{resourceId}"
         }
     }
 }
 ```
 
-Additionally, in `items`, if the host is matched, but the resource is not, (for example, the API expects `https://presentation-api.com/{customer}/canvas/someId` and receives `https://presentation-api.com/someId`), the API will fallback to generating an id instead of throwing an error.
+Additionally, in `items`, if the host is matched, but the resource is not, (for example, the API expects `https://presentation-api.com/{customer}/canvases/someId` and receives `https://presentation-api.com/someId`), the API will fallback to generating an id instead of throwing an error.
 
 > [!NOTE]
-> the only way for a `canvasPainting` to have a `canvasOriginalId` is if the `item` is __not__ matched with a `canvasPainting` from the payload
+> the only way for a `canvasPainting` to have a `canvasOriginalId` is if the `item` is __not__ matched with a `paintedResource` from the payload
 
 > [!NOTE]
 > The currently invalid characters are `/`, `,` and `=`
 
 ## Matching canvas painting records
 
-In addition to how the id is retrieved from the payload itself, `canvasPainting` is matched to a corresponding canvas in `items` when the `id` matches.  As this value in the database is _only_ the id and not a potential full URI, it does mean that the presentation API can match between slightly different values in the payload.  For example, if the canvas in `items` has an id of `https://presentation-api.com/1/canvas/someId`, it would match with a `canvasPainting` `canvasId` of `someId`.
+In addition to how the id is retrieved from the payload itself, `paintedResource` is matched to a corresponding canvas in `items` when the `id` matches.  As this value in the database is _only_ the id and not a potential full URI, it does mean that the presentation API can match between slightly different values in the payload.  For example, if the canvas in `items` has an id of `https://presentation-api.com/1/canvases/someId`, it would match with a `paintedResource` `canvasId` of `someId`.
 
 
 ## Short canvas id
@@ -133,23 +136,23 @@ A set of worked examples to try and show the final result, based on the flowchar
 | items | `someId` | not matched | throws error |
 | painted resource | `someId` | `someId` | `some id` |
 | items | `someId` | `someId`|  `someId` |
-| painted resource | `https://presentation-api.com/1/canvas/someId` | `https://presentation-api.com/1/canvas/someId` |  `someId`  |
-| items | `https://presentation-api.com/1/canvas/someId` | `https://presentation-api.com/1/canvas/someId` |  `someId`  |
-| painted resource | `https:/customer-base.com/canvas/someId` | `https:/customer-base.com/canvas/someId` |  `someId`  |
-| items | `https:/customer-base.com/canvas/someId` | `https:/customer-base.com/canvas/someId` |  `someId`  |
-| painted resource | `https://presentation-api.com/1/canvas/invalidCharacter=` | not matched |  throws error |
-| items | `https://presentation-api.com/1/canvas/invalidCharacter=` | not matched |  generates id |
+| painted resource | `https://presentation-api.com/1/canvases/someId` | `https://presentation-api.com/1/canvases/someId` |  `someId`  |
+| items | `https://presentation-api.com/1/canvases/someId` | `https://presentation-api.com/1/canvases/someId` |  `someId`  |
+| painted resource | `https:/customer-base.com/canvases/someId` | `https:/customer-base.com/canvases/someId` |  `someId`  |
+| items | `https:/customer-base.com/canvases/someId` | `https:/customer-base.com/canvases/someId` |  `someId`  |
+| painted resource | `https://presentation-api.com/1/canvases/invalidCharacter=` | not matched |  throws error |
+| items | `https://presentation-api.com/1/canvases/invalidCharacter=` | not matched |  generates id |
 | painted resource | `https://presentation-api.com/invalidCanvasId` | not matched |  throws error  |
 | items | `https://presentation-api.com/invalidCanvasId` | not matched |  generates id  |
 | painted resource | `https://random.co.uk/someCanvasId` | not matched |  throws error  |
 | items | `https://random.co.uk/someCanvasId` | not matched |  generates id  |
-| painted resource | `https:/customer-base.com/canvas/someId` | `https://presentation-api.com/1/canvas/someId` |  `someId`  |
-| painted resource | `someId` | `https://presentation-api.com/1/canvas/someId` |  `someId`  |
-| painted resource | `https://presentation-api.com/1/canvas/someId` | `https:/customer-base.com/canvas/someId` |  `someId`  |
-| items | `https:/customer-base.com/canvas/someId` | `https://presentation-api.com/1/canvas/someId` |  `someId`  |
-| items | `someId` | `https://presentation-api.com/1/canvas/someId` |  `someId`  |
-| items | `https://presentation-api.com/1/canvas/someId` | `https:/customer-base.com/canvas/someId` |  `someId`  |
-| items | `https://presentation-api.com/1/canvas/someId` | not matched | generates id |
+| painted resource | `https:/customer-base.com/canvases/someId` | `https://presentation-api.com/1/canvases/someId` |  `someId`  |
+| painted resource | `someId` | `https://presentation-api.com/1/canvases/someId` |  `someId`  |
+| painted resource | `https://presentation-api.com/1/canvases/someId` | `https:/customer-base.com/canvases/someId` |  `someId`  |
+| items | `https:/customer-base.com/canvas/someId` | `https://presentation-api.com/1/canvases/someId` |  `someId`  |
+| items | `someId` | `https://presentation-api.com/1/canvases/someId` |  `someId`  |
+| items | `https://presentation-api.com/1/canvases/someId` | `https:/customer-base.com/canvases/someId` |  `someId`  |
+| items | `https://presentation-api.com/1/canvases/someId` | not matched | generates id |
 
 ## Combined flowchart
 

--- a/docs/notes/canvas-id-parsing.md
+++ b/docs/notes/canvas-id-parsing.md
@@ -141,7 +141,7 @@ A set of worked examples to try and show the final result, based on the flowchar
 | `someId` | `someId` | `someId` | |
 | null | `someId` | throws error | must match a PR record  |
 | `https://presentation-api.com/1/canvases/someId` | null | `someId` | |
-| null | `https://presentation-api.com/1/canvases/someId` | generates id | must match a PR record |
+| null | `https://presentation-api.com/1/canvases/someId` | generates id | doesn't match a PR record, so we generate |
 | `https://presentation-api.com/1/canvases/someId` | `https://presentation-api.com/1/canvases/someId` |  `someId`  | |
 | `https:/customer-base.com/canvases/someId` | `https:/customer-base.com/canvases/someId` |  `someId`  | |
 | `https://presentation-api.com/1/canvases/invalidCharacter=` | null |  throws error | |

--- a/docs/notes/canvas-id-parsing.md
+++ b/docs/notes/canvas-id-parsing.md
@@ -135,29 +135,26 @@ When using a short canvas id from `items`, there _must_ be a matching `paintedRe
 
 A set of worked examples to try and show the final result, based on the flowchart above
 
-| From      | id     | matched opposite value | final result|
-| ------------- | ------------- | ---- | ---- |
-| painted resource | `someId` | not matched |`someId`|
-| items | `someId` | not matched | throws error |
-| painted resource | `someId` | `someId` | `someId` |
-| items | `someId` | `someId`|  `someId` |
-| painted resource | `https://presentation-api.com/1/canvases/someId` | `https://presentation-api.com/1/canvases/someId` |  `someId`  |
-| items | `https://presentation-api.com/1/canvases/someId` | `https://presentation-api.com/1/canvases/someId` |  `someId`  |
-| painted resource | `https:/customer-base.com/canvases/someId` | `https:/customer-base.com/canvases/someId` |  `someId`  |
-| items | `https:/customer-base.com/canvases/someId` | `https:/customer-base.com/canvases/someId` |  `someId`  |
-| painted resource | `https://presentation-api.com/1/canvases/invalidCharacter=` | not matched |  throws error |
-| items | `https://presentation-api.com/1/canvases/invalidCharacter=` | not matched |  generates id |
-| painted resource | `https://presentation-api.com/invalidCanvasId` | not matched |  throws error  |
-| items | `https://presentation-api.com/invalidCanvasId` | not matched |  generates id  |
-| painted resource | `https://random.co.uk/someCanvasId` | not matched |  throws error  |
-| items | `https://random.co.uk/someCanvasId` | not matched |  generates id  |
-| painted resource | `https:/customer-base.com/canvases/someId` | `https://presentation-api.com/1/canvases/someId` |  `someId`  |
-| painted resource | `someId` | `https://presentation-api.com/1/canvases/someId` |  `someId`  |
-| painted resource | `https://presentation-api.com/1/canvases/someId` | `https:/customer-base.com/canvases/someId` |  `someId`  |
-| items | `https:/customer-base.com/canvas/someId` | `https://presentation-api.com/1/canvases/someId` |  `someId`  |
-| items | `someId` | `https://presentation-api.com/1/canvases/someId` |  `someId`  |
-| items | `https://presentation-api.com/1/canvases/someId` | `https:/customer-base.com/canvases/someId` |  `someId`  |
-| items | `https://presentation-api.com/1/canvases/someId` | not matched | generates id |
+| Painted Resource | Item | Result | Additional Information |
+| ---------------- | ---- | ------ | ---------------------- |
+| `someId` | null | `someId` | |
+| `someId` | `someId` | `someId` | |
+| null | `someId` | throws error | must match a PR record  |
+| `https://presentation-api.com/1/canvases/someId` | null | `someId` | |
+| null | `https://presentation-api.com/1/canvases/someId` | generates id | must match a PR record |
+| `https://presentation-api.com/1/canvases/someId` | `https://presentation-api.com/1/canvases/someId` |  `someId`  | |
+| `https:/customer-base.com/canvases/someId` | `https:/customer-base.com/canvases/someId` |  `someId`  | |
+| `https://presentation-api.com/1/canvases/invalidCharacter=` | null |  throws error | |
+| null | `https://presentation-api.com/1/canvases/invalidCharacter=` |  generates id | |
+| `https://presentation-api.com/invalidCanvasId` | null |  throws error  | |
+| null | `https://presentation-api.com/invalidCanvasId` | generates id  | |
+|  `https://random.co.uk/someCanvasId` | null |  throws error  | |
+| null |  `https://random.co.uk/someCanvasId` |  generates id  | |
+| `https:/customer-base.com/canvases/someId` | `https://presentation-api.com/1/canvases/someId` |  `someId`  | |
+| `https://presentation-api.com/1/canvases/someId` | `https:/customer-base.com/canvases/someId` |  `someId`  | |
+| `someId` | `https://presentation-api.com/1/canvases/someId` |  `someId`  | |
+| `https://presentation-api.com/1/canvases/someId` | `someId` |  `someId`  | |
+
 
 ## Combined flowchart
 
@@ -168,7 +165,7 @@ flowchart TD
     first[Canvas provided]
     second{is the canvas id null}
     third[generate the canvas id]
-    fourth{is the canvas id a URI}
+    fourth{is the canvas id a URI}   
     fifth{any invalid characters}
     sixth[use the provided canvas id]
     seventh{where is this canvas id from?}

--- a/docs/notes/canvas-id-parsing.md
+++ b/docs/notes/canvas-id-parsing.md
@@ -2,6 +2,11 @@
 
 When parsing payloads, the `canvasId` can be used to generate a `paintedResource` `id` record.  This can be accepted either directly from a `paintedResource` `canvasId` and also from `items` `id` of a canvas.  In addition to the 2 locations that we can generate a `canvasId` from, we can accept either a short form (i.e.: just the id itself) or alternatively from a recognised URI.  Finally, this `canvasId` can be used to join a `canvas` declared in `items` with a `canvasPainting` record in order to decorate an asset from the DLCS with additional IIIF.   This document is set to explain the various ways this `canvasId` can be parsed from a payload.
 
+> [!NOTE]
+> - when talking about `canvas`, `items` is also used to mean "a group of canvases"
+> - `paintedResource` means taken from the payload
+> - `canvasPainting` means the database record
+
 ## Accepted formats
 
 As mentioned above, there are a few formats that will be accepted 
@@ -124,7 +129,7 @@ In addition to how the id is retrieved from the payload itself, `paintedResource
 
 ## Short canvas id
 
-When selecting from a short canvas id, there _must_ be a matching `paintedResource` if the canvas is set using a short canvas.  However, a painted resource can be specified with a short canvas without a matching canvas in `items`.  
+When using a short canvas id from `items`, there _must_ be a matching `paintedResource` if the canvas is set using a short canvas.  However, a painted resource can be specified with a short canvas without a matching canvas in `items`.  
 
 ## Matching examples
 
@@ -134,7 +139,7 @@ A set of worked examples to try and show the final result, based on the flowchar
 | ------------- | ------------- | ---- | ---- |
 | painted resource | `someId` | not matched |`someId`|
 | items | `someId` | not matched | throws error |
-| painted resource | `someId` | `someId` | `some id` |
+| painted resource | `someId` | `someId` | `someId` |
 | items | `someId` | `someId`|  `someId` |
 | painted resource | `https://presentation-api.com/1/canvases/someId` | `https://presentation-api.com/1/canvases/someId` |  `someId`  |
 | items | `https://presentation-api.com/1/canvases/someId` | `https://presentation-api.com/1/canvases/someId` |  `someId`  |

--- a/docs/notes/readme.md
+++ b/docs/notes/readme.md
@@ -9,3 +9,5 @@
   * Outline of how `paintedResources` are rendered on Manifest
 * [Reingest Property](reingest-property.md)
   * Details of how the reingest property works
+* [Canvas Id Parsing](canvas-id-parsing.md)
+  * Shows how the canvas id can be parsed from a payload


### PR DESCRIPTION
This PR adds some notes on how a canvas id is parsed from the payload.  It contains information from #456, so will not be fully accurate until that PR is merged