### PR TITLE
Allow reingest property to be deserialized, but not serialized

### DIFF
--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetReingestion.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetReingestion.cs
@@ -94,6 +94,9 @@ public class ModifyManifestAssetReingestion: IClassFixture<PresentationAppFactor
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Accepted);
 
+        var content = await response.Content.ReadAsStringAsync();
+        content.Should().NotContain("\"reingest\"");
+
         var canvasPaintings = await dbContext.CanvasPaintings.Where(cp => cp.ManifestId == id).ToListAsync();
         canvasPaintings.Should().HaveCount(1);
         canvasPaintings.First().Ingesting.Should().BeTrue();

--- a/src/IIIFPresentation/API/Features/Manifest/ManagedAssetResultFinder.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManagedAssetResultFinder.cs
@@ -46,7 +46,7 @@ public class ManagedAssetResultFinder(
                 if (dbManifest.CanvasPaintings?.Any(cp => cp.AssetId == assetId) ?? false)
                 {
                     // set the asset to reingest, otherwise ignore the asset
-                    if (paintedResource.Reingest)
+                    if (paintedResource.Reingest ?? false)
                     {
                         // ingest without the manifest id, then don't patch the manifest id
                         logger.LogTrace("Asset {AssetId} found within existing manifest - reingest", assetId);
@@ -75,7 +75,7 @@ public class ManagedAssetResultFinder(
             {
                 IngestType ingestType;
                 
-                if (assetNotFoundInSameManifest.paintedResource.Reingest)
+                if (assetNotFoundInSameManifest.paintedResource.Reingest ?? false)
                 {
                     // reingest - ingest with no manifest id, then patch afterwards
                     logger.LogTrace("Asset {AssetId} found within another manifest - reingest", assetNotFoundInSameManifest.assetId);
@@ -94,7 +94,7 @@ public class ManagedAssetResultFinder(
             }
 
             // check in the DLCS (unless reingest where we treat it as an unmanaged asset)
-            if (assetNotFoundInSameManifest.paintedResource.Reingest)
+            if (assetNotFoundInSameManifest.paintedResource.Reingest ?? false)
             {
                 // ingest with the manifest id, then don't patch the manifest id
                 logger.LogTrace("Asset {AssetId} not found within another manifest, but set to reingest", assetNotFoundInSameManifest.assetId);

--- a/src/IIIFPresentation/Models/API/Manifest/PresentationManifest.cs
+++ b/src/IIIFPresentation/Models/API/Manifest/PresentationManifest.cs
@@ -50,13 +50,7 @@ public class PaintedResource
     [JsonProperty(Order = 3)]
     public JObject? Asset { get; set; }
     
-    public bool Reingest { get; set; }
-    
-    // Newtonsoft method to stop serialization, but allow deserialization of the reingest property
-    public bool ShouldSerializeReingest()
-    {
-        return false;
-    }
+    public bool? Reingest { get; set; }
 }
 
 public class CanvasPainting

--- a/src/IIIFPresentation/Models/API/Manifest/PresentationManifest.cs
+++ b/src/IIIFPresentation/Models/API/Manifest/PresentationManifest.cs
@@ -51,6 +51,12 @@ public class PaintedResource
     public JObject? Asset { get; set; }
     
     public bool Reingest { get; set; }
+    
+    // Newtonsoft method to stop serialization, but allow deserialization of the reingest property
+    public bool ShouldSerializeReingest()
+    {
+        return false;
+    }
 }
 
 public class CanvasPainting


### PR DESCRIPTION
Resolves #446 

This PR makes it so that the `reingest` property will still be accepted, but won't show up on the response body. 