### PR TITLE
Add order to canvas order conflict error message

### DIFF
--- a/src/IIIFPresentation/API.Tests/Features/Manifest/CanvasPaintingMergerTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Manifest/CanvasPaintingMergerTests.cs
@@ -565,7 +565,7 @@ public class CanvasPaintingMergerTests
         // Assert
         action.Should().ThrowExactly<CanvasPaintingMergerException>()
             .WithMessage(
-                $"The following canvas painting records conflict with the order from items - {{id: {paintedResourceId}_1, canvasOrder: 0}},{{id: {paintedResourceId}_2, canvasOrder: 0}}");
+                $"The following canvas painting records conflict with the order from items - (id: {paintedResourceId}_1, canvasOrder: 0),(id: {paintedResourceId}_2, canvasOrder: 0)");
     }
     
     [Fact]

--- a/src/IIIFPresentation/API.Tests/Features/Manifest/ManifestWriteServiceTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Manifest/ManifestWriteServiceTests.cs
@@ -274,7 +274,7 @@ public class ManifestWriteServiceTests
         
         // Assert
         ingestedManifest.Should().NotBeNull();
-        ingestedManifest.Error.Should().Be($"The following canvas painting records conflict with the order from items - {{id: {canvasId}, canvasOrder: 0}}");
+        ingestedManifest.Error.Should().Be($"The following canvas painting records conflict with the order from items - (id: {canvasId}, canvasOrder: 0)");
     }
     
     [Fact]
@@ -318,7 +318,7 @@ public class ManifestWriteServiceTests
         ingestedManifest.Should().NotBeNull();
         ingestedManifest.Error.Should()
             .Be(
-                "The following canvas painting records conflict with the order from items - {canvasOrder: 0}");
+                "The following canvas painting records conflict with the order from items - (canvasOrder: 0)");
     }
     
     [Fact]

--- a/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingMerger.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingMerger.cs
@@ -78,7 +78,7 @@ public class CanvasPaintingMerger(IPathRewriteParser pathRewriteParser) : ICanva
             throw new CanvasPaintingMergerException(
                 "The following canvas painting records conflict with the order from items - " +
                 $"{string.Join(',', 
-                    matchedCanvasPainting.Select(m => $"{{{(m.Id != null ? $"id: {m.Id}, " : "")}canvasOrder: {m.CanvasOrder}}}"))}");
+                    matchedCanvasPainting.Select(m => $"({(m.Id != null ? $"id: {m.Id}, " : "")}canvasOrder: {m.CanvasOrder})"))}");
         }
     }
     


### PR DESCRIPTION
Resolves #457 

Updates the error message when a canvas order in painted resources conflicts with the order from items to include the canvas order.  This is so there's some additional information around which canvas is an issue when the canvas id is not specified