### PR TITLE
Make PATCH /allImages distinct

### DIFF
--- a/src/IIIFPresentation/DLCS/API/DlcsApiClient.cs
+++ b/src/IIIFPresentation/DLCS/API/DlcsApiClient.cs
@@ -177,9 +177,9 @@ internal class DlcsApiClient(
         logger.LogTrace("Updating assets for customer {CustomerId} to {OperationType} manifests",
             customerId, operationType.ToString());
 
-        assets = assets.Distinct().ToList();
+        var distinctAssets = assets.Distinct().ToList();
         
-        var chunkedAssetList = assets.Chunk(settings.MaxBatchSize);
+        var chunkedAssetList = distinctAssets.Chunk(settings.MaxBatchSize);
         var assetsResponse = new ConcurrentBag<Asset>();
         var endpoint = $"/customers/{customerId}/allImages";
 
@@ -209,7 +209,7 @@ internal class DlcsApiClient(
         await Task.WhenAll(tasks);
         
         // this is extremely unlikely to happen, as the DLCS should have already been checked at this point
-        if (assetsResponse.Count != assets.Count)
+        if (assetsResponse.Count != distinctAssets.Count)
         {
             var missingAssets = assets.Where(a => assetsResponse.All(ar => a != $"{customerId}/{ar.Space}/{ar.Id}")).ToList();
 

--- a/src/IIIFPresentation/DLCS/Models/BulkPatchAssets.cs
+++ b/src/IIIFPresentation/DLCS/Models/BulkPatchAssets.cs
@@ -32,5 +32,6 @@ public enum OperationType
 
 public class IdentifierOnly(string id)
 {
+    [JsonPropertyName("id")]
     public string Id { get; set; } = id;
 }


### PR DESCRIPTION
Resolves #486 

Makes it so that `PATCH /allImages` calls are made to be distinct - this then avoids issues where the DLCS returns errors over being asked to update the same asset multiple times in the same payload