### PR TITLE
Hotfix to support rewritten paths in the API

### DIFF
--- a/src/IIIFPresentation/API.Tests/Integration/GetManifestTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/GetManifestTests.cs
@@ -53,7 +53,7 @@ public class GetManifestTests : IClassFixture<PresentationAppFactory<Program>>
             """
             {
                    "@context": "https://localhost/contexts/Image.jsonld",
-                   "@id": "https://localhost:7230/customers/1/spaces/2/images/foo-paintedResource",
+                   "@id": "https://localhost:6000/customers/1/spaces/2/images/foo-paintedResource",
                    "@type": "vocab:Image",
                    "id": "foo-paintedResource",
                    "ingesting": false,
@@ -66,7 +66,7 @@ public class GetManifestTests : IClassFixture<PresentationAppFactory<Program>>
             """
             {
                    "@context": "https://localhost/contexts/Image.jsonld",
-                   "@id": "https://localhost:7230/customers/1/spaces/2/images/errorPaintedResource",
+                   "@id": "https://localhost:6000/customers/1/spaces/2/images/errorPaintedResource",
                    "@type": "vocab:Image",
                    "id": "errorPaintedResource",
                    "error": "random error",
@@ -79,7 +79,7 @@ public class GetManifestTests : IClassFixture<PresentationAppFactory<Program>>
             """
             {
                    "@context": "https://localhost/contexts/Image.jsonld",
-                   "@id": "https://localhost:7230/customers/1/spaces/2/images/foo-paintedResource",
+                   "@id": "https://localhost:6000/customers/1/spaces/2/images/foo-paintedResource",
                    "@type": "vocab:Image",
                    "id": "ingestingPaintedResource",
                    "ingesting": true,

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
@@ -345,7 +345,7 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
               [
                   JObject.Parse($$"""
                                   {
-                                      "@id": "https://localhost:7230/customers/1/spaces/999/images/{{assetId}}",
+                                      "@id": "https://localhost:6000/customers/1/spaces/999/images/{{assetId}}",
                                       "id": "{{assetId}}",
                                       "space": 999,
                                       "batch": "https://localhost/customers/1/queue/batches/2137"

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestCreateTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestCreateTests.cs
@@ -22,7 +22,6 @@ using Repository;
 using Test.Helpers;
 using Test.Helpers.Helpers;
 using Test.Helpers.Integration;
-using Xunit.Abstractions;
 using Collection = Models.Database.Collections.Collection;
 using Manifest = Models.Database.Collections.Manifest;
 
@@ -572,7 +571,7 @@ public class ModifyManifestCreateTests : IClassFixture<PresentationAppFactory<Pr
         response.StatusCode.Should().Be(HttpStatusCode.Created);
         
         var responseManifest = await response.ReadAsPresentationResponseAsync<PresentationManifest>();
-        responseManifest.Space.Should().Be("https://localhost:7230/customers/1/spaces/999");
+        responseManifest.Space.Should().Be("https://localhost:6000/customers/1/spaces/999");
     }
     
     [Fact]
@@ -1369,7 +1368,7 @@ public class ModifyManifestCreateTests : IClassFixture<PresentationAppFactory<Pr
         response.StatusCode.Should().Be(HttpStatusCode.Created);
         
         var responseManifest = await response.ReadAsPresentationResponseAsync<PresentationManifest>();
-        responseManifest.Space.Should().Be("https://localhost:7230/customers/1/spaces/999");
+        responseManifest.Space.Should().Be("https://localhost:6000/customers/1/spaces/999");
     }
     
     [Fact]

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyRewrittenPathTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyRewrittenPathTests.cs
@@ -357,6 +357,7 @@ public class ModifyRewrittenPathTests : IClassFixture<PresentationAppFactory<Pro
         responseManifest.Slug.Should().Be(slug);
         responseManifest.Parent.Should().Be($"http://example.com/foo/1/collections/{RootCollection.Id}");
         responseManifest.PaintedResources[0].CanvasPainting.CanvasId.Should().Be("http://example.com/example/1/canvases/someId");
+        responseManifest.Items[0].Id.Should().Be("https://localhost:7230/1/canvases/someId", "uses the settings based path parser");
     }
     
     [Fact]
@@ -400,6 +401,7 @@ public class ModifyRewrittenPathTests : IClassFixture<PresentationAppFactory<Pro
         responseManifest.Slug.Should().Be(slug);
         responseManifest.Parent.Should().Be($"http://localhost/1/collections/{RootCollection.Id}");
         responseManifest.PaintedResources[0].CanvasPainting.CanvasId.Should().Be("http://localhost/1/canvases/someId");
+        responseManifest.Items[0].Id.Should().Be("https://localhost:7230/1/canvases/someId", "uses the settings based path parser");
     }
 
     [Fact]

--- a/src/IIIFPresentation/API.Tests/appsettings.Testing.json
+++ b/src/IIIFPresentation/API.Tests/appsettings.Testing.json
@@ -10,28 +10,31 @@
     }
   },
   "DLCS": {
-    "ApiUri": "https://localhost:7230",
+    "ApiUri": "https://localhost:6000",
     "MaxBatchSize": 2
   },
-  "PathRules": {
-    "Defaults": {
-      "ResourcePublic": "/{customerId}/{hierarchyPath}",
-      "ManifestPrivate": "/{customerId}/manifests/{resourceId}",
-      "CollectionPrivate": "/{customerId}/collections/{resourceId}",
-      "Canvas": "/{customerId}/canvases/{resourceId}"
-    },
-    "Overrides": {
-      "example.com": {
-        "ResourcePublic": "/example/{customerId}/{hierarchyPath}",
-        "ManifestPrivate": "/example/{customerId}/manifests/{resourceId}",
-        "CollectionPrivate": "/foo/{customerId}/collections/{resourceId}",
-        "Canvas": "/example/{customerId}/canvases/{resourceId}"
+  "PathSettings": {
+    "PresentationApiUrl": "https://localhost:7230/",
+    "PathRules": {
+      "Defaults": {
+        "ResourcePublic": "/{customerId}/{hierarchyPath}",
+        "ManifestPrivate": "/{customerId}/manifests/{resourceId}",
+        "CollectionPrivate": "/{customerId}/collections/{resourceId}",
+        "Canvas": "/{customerId}/canvases/{resourceId}"
       },
-      "no-customer.com": {
-        "ResourcePublic": "/{hierarchyPath}",
-        "ManifestPrivate": "/manifests/{resourceId}",
-        "CollectionPrivate": "/collections/{resourceId}",
-        "Canvas": "/canvases/{resourceId}"
+      "Overrides": {
+        "example.com": {
+          "ResourcePublic": "/example/{customerId}/{hierarchyPath}",
+          "ManifestPrivate": "/example/{customerId}/manifests/{resourceId}",
+          "CollectionPrivate": "/foo/{customerId}/collections/{resourceId}",
+          "Canvas": "/example/{customerId}/canvases/{resourceId}"
+        },
+        "no-customer.com": {
+          "ResourcePublic": "/{hierarchyPath}",
+          "ManifestPrivate": "/manifests/{resourceId}",
+          "CollectionPrivate": "/collections/{resourceId}",
+          "Canvas": "/canvases/{resourceId}"
+        }
       }
     }
   }

--- a/src/IIIFPresentation/API/Converters/ManifestConverter.cs
+++ b/src/IIIFPresentation/API/Converters/ManifestConverter.cs
@@ -72,7 +72,7 @@ public static class ManifestConverter
     /// Generate provisional <see cref="Canvas"/> items from provided <see cref="CanvasPainting"/> collection. These
     /// provisional canvases have the structure of the final canvases without the full content-resource details
     /// </summary>
-    private static List<Canvas> GenerateProvisionalItems(this IList<CanvasPainting> canvasPaintings,
+    public static List<Canvas> GenerateProvisionalItems(this IList<CanvasPainting> canvasPaintings,
         IPathGenerator pathGenerator)
     {
         // ToLookup, rather than GroupBy - the former maintains order of input. The latter orders by key.

--- a/src/IIIFPresentation/API/Program.cs
+++ b/src/IIIFPresentation/API/Program.cs
@@ -3,7 +3,6 @@ using API.Auth;
 using API.Features.Manifest;
 using API.Helpers;
 using API.Infrastructure;
-using API.Infrastructure.Helpers;
 using API.Infrastructure.Http;
 using API.Infrastructure.Http.CorrelationId;
 using API.Infrastructure.Http.Redirect;
@@ -19,6 +18,8 @@ using Repository.Paths;
 using Serilog;
 using Services.Manifests;
 using Services.Manifests.AWS;
+using Services.Manifests.Helpers;
+using Services.Manifests.Settings;
 
 const string corsPolicyName = "CorsPolicy";
 
@@ -47,7 +48,9 @@ builder.Services.AddOptions<CacheSettings>()
     .BindConfiguration(nameof(CacheSettings));
 var dlcsSettings = builder.Configuration.GetSection(DlcsSettings.SettingsName);
 builder.Services.Configure<DlcsSettings>(dlcsSettings);
-var typedPathTemplateOptions = builder.Configuration.GetSection(TypedPathTemplateOptions.SettingsName);
+var pathSettings = builder.Configuration.GetSection(PathSettings.SettingsName);
+builder.Services.Configure<PathSettings>(pathSettings);
+var typedPathTemplateOptions = pathSettings.GetSection(TypedPathTemplateOptions.SettingsName);
 builder.Services.Configure<TypedPathTemplateOptions>(typedPathTemplateOptions);
 
 var cacheSettings = builder.Configuration.GetSection(nameof(CacheSettings)).Get<CacheSettings>() ?? new CacheSettings();
@@ -72,6 +75,8 @@ builder.Services
     .AddSingleton<IPathGenerator, HttpRequestBasedPathGenerator>()
     .AddSingleton<IPathRewriteParser, PathRewriteParser>()
     .AddSingleton<IPresentationPathGenerator, ConfigDrivenPresentationPathGenerator>()
+    .AddSingleton<SettingsDrivenPresentationConfigGenerator>()
+    .AddSingleton<SettingsBasedPathGenerator>()
     .AddSingleton<IManifestMerger, ManifestMerger>()
     .AddSingleton<IManifestStorageManager, ManifestS3Manager>()
     .AddScoped<IParentSlugParser, ParentSlugParser>()

--- a/src/IIIFPresentation/API/Settings/ApiSettings.cs
+++ b/src/IIIFPresentation/API/Settings/ApiSettings.cs
@@ -1,6 +1,6 @@
 ﻿using AWS.Settings;
-using Core.Web;
 using DLCS;
+using Services.Manifests.Settings;
 
 namespace API.Settings;
 
@@ -27,5 +27,5 @@ public class ApiSettings
 
     public required DlcsSettings DLCS { get; set; }
     
-    public TypedPathTemplateOptions PathRules { get; set; } = new ();
+    public PathSettings? PathSettings { get; set; }
 }

--- a/src/IIIFPresentation/BackgroundHandler/Program.cs
+++ b/src/IIIFPresentation/BackgroundHandler/Program.cs
@@ -1,13 +1,12 @@
 ﻿using AWS.Settings;
-using BackgroundHandler.Helpers;
 using BackgroundHandler.Infrastructure;
 using BackgroundHandler.Settings;
-using Core.Web;
 using DLCS;
-using Repository.Paths;
 using Serilog;
 using Services.Manifests;
 using Services.Manifests.AWS;
+using Services.Manifests.Helpers;
+using Services.Manifests.Settings;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -24,8 +23,8 @@ builder.Host.UseSerilog((hostContext, loggerConfig) =>
 
 builder.Services.AddOptions<BackgroundHandlerSettings>()
     .BindConfiguration(string.Empty);
-var typedPathTemplateOptions = builder.Configuration.GetSection(TypedPathTemplateOptions.SettingsName);
-builder.Services.Configure<TypedPathTemplateOptions>(typedPathTemplateOptions);
+var pathSettings = builder.Configuration.GetSection(PathSettings.SettingsName);
+builder.Services.Configure<PathSettings>(pathSettings);
 
 var aws = builder.Configuration.GetSection(AWSSettings.SettingsName).Get<AWSSettings>() ?? new AWSSettings();
 var dlcsSettings = builder.Configuration.GetSection(DlcsSettings.SettingsName);
@@ -35,8 +34,8 @@ builder.Services.AddAws(builder.Configuration, builder.Environment)
     .AddDataAccess(builder.Configuration)
     .AddDlcsOrchestratorClient(dlcs)
     .AddBackgroundServices(aws)
-    .AddSingleton<IPathGenerator, SettingsBasedPathGenerator>()
-    .AddSingleton<IPresentationPathGenerator, SettingsDrivenPresentationConfigGenerator>()
+    .AddSingleton<SettingsBasedPathGenerator>()
+    .AddSingleton<SettingsDrivenPresentationConfigGenerator>()
     .AddSingleton<IManifestMerger, ManifestMerger>()
     .AddSingleton<IManifestStorageManager, ManifestS3Manager>()
     .Configure<DlcsSettings>(dlcsSettings);

--- a/src/IIIFPresentation/BackgroundHandler/Settings/BackgroundHandlerSettings.cs
+++ b/src/IIIFPresentation/BackgroundHandler/Settings/BackgroundHandlerSettings.cs
@@ -1,5 +1,5 @@
 ﻿using AWS.Settings;
-using Core.Web;
+using Services.Manifests.Settings;
 
 namespace BackgroundHandler.Settings;
 
@@ -7,19 +7,5 @@ public class BackgroundHandlerSettings
 {
     public required AWSSettings AWS { get; set; }
     
-    public Uri PresentationApiUrl { get; set; }
-    
-    public Dictionary<int, Uri> CustomerPresentationApiUrl { get; set; } = new();
-    
-    /// <summary>
-    /// Get CustomerSpecificUrls, if found. 
-    /// </summary>
-    /// <param name="customerId">CustomerId to get settings for.</param>
-    /// <returns>Customer specific overrides, or default if not found.</returns>
-    public Uri GetCustomerSpecificPresentationUrl(int customerId)
-        => CustomerPresentationApiUrl.TryGetValue(customerId, out var customerPresentationApiUrl)
-            ? customerPresentationApiUrl
-            : PresentationApiUrl;
-    
-    public TypedPathTemplateOptions PathRules { get; set; } = new ();
+    public required PathSettings PathSettings { get; set; }
 }

--- a/src/IIIFPresentation/Services.Tests/Manifests/Helpers/ManifestMergerMixedContentTests.cs
+++ b/src/IIIFPresentation/Services.Tests/Manifests/Helpers/ManifestMergerMixedContentTests.cs
@@ -1,10 +1,12 @@
-﻿using Core.Web;
+﻿using DLCS;
 using IIIF.Presentation.V3;
 using IIIF.Presentation.V3.Annotation;
 using IIIF.Presentation.V3.Content;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Services.Manifests;
 using Services.Manifests.Helpers;
+using Services.Manifests.Settings;
 using Test.Helpers;
 using Test.Helpers.Helpers;
 
@@ -16,11 +18,16 @@ public class ManifestMergerMixedContentTests
 
     public ManifestMergerMixedContentTests()
     {
-        var presentationGenerator =
-            new TestPresentationConfigGenerator("https://localhost:5000", new TypedPathTemplateOptions());
-        var pathGenerator = new TestPathGenerator(presentationGenerator);
+        var settingsBasedPathGenerator = new SettingsBasedPathGenerator(Options.Create(new DlcsSettings
+        {
+            ApiUri = new Uri("https://dlcs.api")
+        }), new SettingsDrivenPresentationConfigGenerator(Options.Create(new PathSettings()
+        {
+            PresentationApiUrl = new Uri("https://localhost:5000"),
+            PathRules = PathRewriteOptions.Default
+        })));
         
-        sut = new ManifestMerger(pathGenerator, new NullLogger<ManifestMerger>());
+        sut = new ManifestMerger(settingsBasedPathGenerator, new NullLogger<ManifestMerger>());
     }
     
     [Fact]

--- a/src/IIIFPresentation/Services.Tests/Manifests/Helpers/ManifestMergerTests.cs
+++ b/src/IIIFPresentation/Services.Tests/Manifests/Helpers/ManifestMergerTests.cs
@@ -1,12 +1,15 @@
 ﻿using Core.Web;
+using DLCS;
 using IIIF;
 using IIIF.Presentation.V3;
 using IIIF.Presentation.V3.Annotation;
 using IIIF.Presentation.V3.Content;
 using IIIF.Presentation.V3.Strings;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Services.Manifests;
 using Services.Manifests.Helpers;
+using Services.Manifests.Settings;
 using Test.Helpers;
 using Test.Helpers.Helpers;
 using Canvas = IIIF.Presentation.V3.Canvas;
@@ -20,11 +23,16 @@ public class ManifestMergerTests
 
     public ManifestMergerTests()
     {
-        var presentationGenerator =
-            new TestPresentationConfigGenerator("https://localhost:5000", new TypedPathTemplateOptions());
-        var pathGenerator = new TestPathGenerator(presentationGenerator);
+        var settingsBasedPathGenerator = new SettingsBasedPathGenerator(Options.Create(new DlcsSettings
+        {
+            ApiUri = new Uri("https://dlcs.api")
+        }), new SettingsDrivenPresentationConfigGenerator(Options.Create(new PathSettings()
+        {
+            PresentationApiUrl = new Uri("https://localhost:5000"),
+            PathRules = PathRewriteOptions.Default
+        })));
         
-        sut = new ManifestMerger(pathGenerator, new NullLogger<ManifestMerger>());
+        sut = new ManifestMerger(settingsBasedPathGenerator, new NullLogger<ManifestMerger>());
     }
     
     [Fact]

--- a/src/IIIFPresentation/Services/Manifests/Helpers/SettingsBasedPathGenerator.cs
+++ b/src/IIIFPresentation/Services/Manifests/Helpers/SettingsBasedPathGenerator.cs
@@ -2,13 +2,13 @@
 using Microsoft.Extensions.Options;
 using Repository.Paths;
 
-namespace BackgroundHandler.Helpers;
+namespace Services.Manifests.Helpers;
 
 /// <summary>
 /// Implementation of <see cref="PathGeneratorBase"/> using settings for base urls
 /// </summary>
 public class SettingsBasedPathGenerator(
-    IOptions<DlcsSettings> dlcsOptions, IPresentationPathGenerator presentationPathGenerator) 
+    IOptions<DlcsSettings> dlcsOptions, SettingsDrivenPresentationConfigGenerator presentationPathGenerator) 
     : PathGeneratorBase(presentationPathGenerator)
 {
     protected override Uri DlcsApiUrl { get; } = dlcsOptions.Value.ApiUri;

--- a/src/IIIFPresentation/Services/Manifests/Helpers/SettingsDrivenPresentationConfigGenerator.cs
+++ b/src/IIIFPresentation/Services/Manifests/Helpers/SettingsDrivenPresentationConfigGenerator.cs
@@ -1,14 +1,14 @@
-﻿using BackgroundHandler.Settings;
-using Core.Paths;
+﻿using Core.Paths;
 using Microsoft.Extensions.Options;
 using Repository.Paths;
+using Services.Manifests.Settings;
 
-namespace BackgroundHandler.Helpers;
+namespace Services.Manifests.Helpers;
 
-public class SettingsDrivenPresentationConfigGenerator(IOptions<BackgroundHandlerSettings> settings)
+public class SettingsDrivenPresentationConfigGenerator(IOptions<PathSettings> settings)
     : IPresentationPathGenerator
 {
-    private readonly BackgroundHandlerSettings settings = settings.Value;
+    private readonly PathSettings settings = settings.Value;
 
     public string GetHierarchyPresentationPathForRequest(string presentationServiceType, int customerId, string hierarchyPath)
     {

--- a/src/IIIFPresentation/Services/Manifests/ManifestMerger.cs
+++ b/src/IIIFPresentation/Services/Manifests/ManifestMerger.cs
@@ -31,7 +31,7 @@ public interface IManifestMerger
         List<CanvasPainting>? canvasPaintings);
 }
 
-public class ManifestMerger(IPathGenerator pathGenerator, ILogger<ManifestMerger> logger) : IManifestMerger
+public class ManifestMerger(SettingsBasedPathGenerator pathGenerator, ILogger<ManifestMerger> logger) : IManifestMerger
 {
     /// <summary>
     /// Process specified <see cref="CanvasPainting"/> objects to project contents from namedQueryManifest onto the

--- a/src/IIIFPresentation/Services/Manifests/Settings/PathSettings.cs
+++ b/src/IIIFPresentation/Services/Manifests/Settings/PathSettings.cs
@@ -1,0 +1,22 @@
+﻿using Core.Web;
+
+namespace Services.Manifests.Settings;
+
+public class PathSettings
+{
+    public const string SettingsName = "PathSettings";
+
+    public required Uri PresentationApiUrl { get; set; }
+
+    public Dictionary<int, Uri> CustomerPresentationApiUrl { get; set; } = new();
+
+    /// <summary>
+    /// Get CustomerSpecificUrls, if found. 
+    /// </summary>
+    /// <param name="customerId">CustomerId to get settings for.</param>
+    /// <returns>Customer specific overrides, or default if not found.</returns>
+    public Uri GetCustomerSpecificPresentationUrl(int customerId)
+        => CustomerPresentationApiUrl.GetValueOrDefault(customerId, PresentationApiUrl);
+
+    public TypedPathTemplateOptions PathRules { get; set; } = new ();
+}


### PR DESCRIPTION
This pulls out the work done in #442 to ONLY include the section on rewritten paths so that v0.7 can fully rewrite paths

There is essentially 3 parts to the fix:
1. Modify `ManifestWriteService` to use the `SettingsBasedPathGenerator` in the `ManifestConverter`, so that it returns provisional canvases with the correctly rewritten path
2. Modify the `ManifestMerger` to only use the settings based path generator (this is shared between API and background handler)
3. Move the now duplicate settings between API and background handler to a combined settings class called `PathSettings`

> [!NOTE]
> Merging this PR would mean that the `develop` branch will conflict with `main`