### PR TITLE
Reenable the validator for requiring all canvases to have an explicit order if one does

### DIFF
--- a/src/IIIFPresentation/API.Tests/Features/Manifest/Validators/PresentationManifestValidatorTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Manifest/Validators/PresentationManifestValidatorTests.cs
@@ -294,6 +294,61 @@ public class PresentationManifestValidatorTests
     }
     
     [Fact]
+    public void CanvasPaintingAndItems_Manifest_ErrorWhenNotEveryItemHasCanvasOrder()
+    {
+        var manifest = new PresentationManifest
+        {
+            PaintedResources =
+            [
+                new PaintedResource
+                {
+                    CanvasPainting = new CanvasPainting
+                    {
+                        CanvasId = "someCanvasId-1",
+                        CanvasOrder = 1
+                    }
+                },
+
+                new PaintedResource
+                {
+                    CanvasPainting = new CanvasPainting
+                    {
+                        CanvasId = "someCanvasId-2",
+                    }
+                }
+            ],
+        };
+        
+        var result = sut.TestValidate(manifest);
+        result.ShouldHaveValidationErrorFor(m => m.PaintedResources)
+            .WithErrorMessage("'canvasOrder' is required on all resources when used in at least one");
+    }
+    
+    [Fact]
+    public void CanvasPaintingAndItems_Manifest_ErrorWhenNotEveryItemHasCanvasOrder_DueToMissingCanvasPainting()
+    {
+        var manifest = new PresentationManifest
+        {
+            PaintedResources =
+            [
+                new PaintedResource
+                {
+                    CanvasPainting = new CanvasPainting
+                    {
+                        CanvasId = "someCanvasId-1",
+                        CanvasOrder = 1
+                    }
+                },
+                new PaintedResource()
+            ],
+        };
+        
+        var result = sut.TestValidate(manifest);
+        result.ShouldHaveValidationErrorFor(m => m.PaintedResources)
+            .WithErrorMessage("'canvasOrder' is required on all resources when used in at least one");
+    }
+    
+    [Fact]
     public void PaintedResource_Manifest_NoErrorWhenChoiceOfOne()
     {
         var manifest = new PresentationManifest

--- a/src/IIIFPresentation/API/Features/Manifest/Validators/PresentationManifestValidator.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/Validators/PresentationManifestValidator.cs
@@ -19,6 +19,11 @@ public class PresentationManifestValidator : AbstractValidator<PresentationManif
     // Validation rules specific to PaintedResources only
     private void PaintedResourcesValidation()
     {
+        RuleForEach(m => m.PaintedResources)
+            .Must(pr => pr.CanvasPainting?.CanvasOrder != null)
+            .When(m => m.PaintedResources != null && m.PaintedResources.Any(pr => pr.CanvasPainting is { CanvasOrder: not null }))
+            .WithMessage("'canvasOrder' is required on all resources when used in at least one");
+        
         RuleForEach(a => a.PaintedResources)
             .Where(pr => pr.CanvasPainting?.ChoiceOrder != null)
             .Must(pr => pr.CanvasPainting?.ChoiceOrder > 0)


### PR DESCRIPTION
Links #532

This PR reenables a validator removed in #471 

This is because there are issues with implicit ordering around the initial explicit items not being validated against implicit ordering, creating situations where choices were created, instead of the payload being rejected as invalid. i.e.:

```json
{
    "type": "Manifest",
    "parent": "https://presentation.dlcs/499/collections/parent",
    "slug": "test",
    "paintedResources": [
        {
            "canvasPainting": { // explicit order=1
                "canvasId": "https://presentation.dlcs/499/canvases/two",
                "canvasOrder": 1
            },
            "asset": { ... }
        },
        {
            "canvasPainting": { // implicit order=1
                "canvasId": "https://presentation.dlcs/499/canvases/one"
            },
            "asset": { ... }
        }
    ]
}
```

This PR is a fix to disallow this to happen in order to allow mixed-manifest work to be released.  However, this isn't closing the initial ticket as a full fix is to share some validation logic after the point that implicit/explicit order are worked out