### PR TITLE
Make delete requests require an Etag

### DIFF
--- a/src/IIIFPresentation/API.Tests/Integration/DeleteCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/DeleteCollectionTests.cs
@@ -148,7 +148,7 @@ public class DeleteCollectionTests : IClassFixture<PresentationAppFactory<Progra
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         errorResponse!.ErrorTypeUri.Should()
-            .Be("http://localhost/errors/DeleteResourceType/CannotDeleteRootCollection");
+            .Be("http://localhost/errors/DeleteResourceErrorType/CannotDeleteRootCollection");
         errorResponse.Detail.Should().Be("Cannot delete a root collection");
     }
 
@@ -168,7 +168,7 @@ public class DeleteCollectionTests : IClassFixture<PresentationAppFactory<Progra
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-        errorResponse!.ErrorTypeUri.Should().Be("http://localhost/errors/DeleteResourceType/CollectionNotEmpty");
+        errorResponse!.ErrorTypeUri.Should().Be("http://localhost/errors/DeleteResourceErrorType/CollectionNotEmpty");
         errorResponse.Detail.Should().Be("Cannot delete a collection with child items");
     }
     
@@ -188,7 +188,7 @@ public class DeleteCollectionTests : IClassFixture<PresentationAppFactory<Progra
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.PreconditionFailed);
-        errorResponse!.ErrorTypeUri.Should().Be("http://localhost/errors/DeleteResourceType/EtagNotMatching");
+        errorResponse!.ErrorTypeUri.Should().Be("http://localhost/errors/DeleteResourceErrorType/EtagNotMatching");
         errorResponse.Detail.Should().Be("Etag does not match");
     }
     

--- a/src/IIIFPresentation/API.Tests/Integration/DeleteCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/DeleteCollectionTests.cs
@@ -5,9 +5,12 @@ using Core.Helpers;
 using Core.Infrastructure;
 using Core.Response;
 using IIIF.Serialisation;
+using Microsoft.EntityFrameworkCore;
 using Models.API.Collection;
 using Models.API.General;
+using Models.Database.General;
 using Repository;
+using Repository.Helpers;
 using Test.Helpers.Helpers;
 using Test.Helpers.Integration;
 
@@ -78,7 +81,7 @@ public class DeleteCollectionTests : IClassFixture<PresentationAppFactory<Progra
        await dbContext.SaveChangesAsync();
 
         var deleteRequestMessage = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Delete,
-            $"{Customer}/collections/{dbCollection.Id}");
+            $"{Customer}/collections/{dbCollection.Id}", dbContext.GetETag(dbCollection));
 
         // Act
         var response = await httpClient.AsCustomer().SendAsync(deleteRequestMessage);
@@ -102,7 +105,7 @@ public class DeleteCollectionTests : IClassFixture<PresentationAppFactory<Progra
         await dbContext.SaveChangesAsync();
 
         var deleteRequestMessage = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Delete,
-            $"{Customer}/collections/{dbCollection.Id}/");
+            $"{Customer}/collections/{dbCollection.Id}/", dbContext.GetETag(dbCollection));
 
         // Act
         var response = await httpClient.AsCustomer().SendAsync(deleteRequestMessage);
@@ -145,7 +148,7 @@ public class DeleteCollectionTests : IClassFixture<PresentationAppFactory<Progra
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         errorResponse!.ErrorTypeUri.Should()
-            .Be("http://localhost/errors/DeleteCollectionType/CannotDeleteRootCollection");
+            .Be("http://localhost/errors/DeleteResourceType/CannotDeleteRootCollection");
         errorResponse.Detail.Should().Be("Cannot delete a root collection");
     }
 
@@ -153,8 +156,10 @@ public class DeleteCollectionTests : IClassFixture<PresentationAppFactory<Progra
     public async Task DeleteCollection_FailsToDeleteCollection_WhenAttemptingToDeleteCollectionWithItems()
     {
         // Arrange
+        var id = "FirstChildCollection";
+        
         var deleteRequestMessage = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Delete,
-            $"{Customer}/collections/FirstChildCollection");
+            $"{Customer}/collections/{id}", dbContext.GetETag(id, Customer, ResourceType.IIIFCollection));
 
         // Act
         var response = await httpClient.AsCustomer().SendAsync(deleteRequestMessage);
@@ -163,8 +168,28 @@ public class DeleteCollectionTests : IClassFixture<PresentationAppFactory<Progra
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-        errorResponse!.ErrorTypeUri.Should().Be("http://localhost/errors/DeleteCollectionType/CollectionNotEmpty");
+        errorResponse!.ErrorTypeUri.Should().Be("http://localhost/errors/DeleteResourceType/CollectionNotEmpty");
         errorResponse.Detail.Should().Be("Cannot delete a collection with child items");
+    }
+    
+    [Fact]
+    public async Task DeleteCollection_FailsToDeleteCollection_WhenAttemptingToDeleteCollectionWithNonMatchingEtag()
+    {
+        // Arrange
+        var id = "IiifCollection";
+        
+        var deleteRequestMessage = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Delete,
+            $"{Customer}/collections/{id}");
+
+        // Act
+        var response = await httpClient.AsCustomer().SendAsync(deleteRequestMessage);
+
+        var errorResponse = await response.ReadAsPresentationResponseAsync<Error>();
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.PreconditionFailed);
+        errorResponse!.ErrorTypeUri.Should().Be("http://localhost/errors/DeleteResourceType/EtagNotMatching");
+        errorResponse.Detail.Should().Be("Etag does not match");
     }
     
     [Fact]
@@ -190,13 +215,13 @@ public class DeleteCollectionTests : IClassFixture<PresentationAppFactory<Progra
         response.StatusCode.Should().Be(HttpStatusCode.Created);
         var responseCollection = await response.ReadAsPresentationResponseAsync<PresentationCollection>();
         var id = responseCollection!.Id.GetLastPathElement();
-        
+
         var objectInS3 = await amazonS3.GetObjectAsync(LocalStackFixture.StorageBucketName,
             $"{Customer}/collections/{id}");
         objectInS3.Should().NotBeNull();
 
-        requestMessage =
-            HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Delete, $"{Customer}/collections/{id}");
+        requestMessage = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Delete, $"{Customer}/collections/{id}",
+            dbContext.GetETag(id, Customer, ResourceType.IIIFCollection));
 
 
         // Act

--- a/src/IIIFPresentation/API.Tests/Integration/DeleteManifestTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/DeleteManifestTests.cs
@@ -1,13 +1,13 @@
 ﻿using System.Net;
 using Amazon.S3;
-using API.Infrastructure.Helpers;
 using API.Tests.Integration.Infrastructure;
 using Core.Helpers;
 using Core.Response;
 using IIIF.Serialisation;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.DependencyInjection;
+using Models.API.General;
 using Models.API.Manifest;
+using Models.Database.General;
 using Repository;
 using Test.Helpers.Helpers;
 using Test.Helpers.Integration;
@@ -41,8 +41,8 @@ public class DeleteManifestTests : IClassFixture<PresentationAppFactory<Program>
         var dbManifest = (await dbContext.Manifests.AddTestManifest()).Entity;
         await dbContext.SaveChangesAsync();
 
-        var requestMessage =
-            HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Delete, $"{Customer}/manifests/{dbManifest.Id}");
+        var requestMessage = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Delete,
+            $"{Customer}/manifests/{dbManifest.Id}", dbContext.GetETag(dbManifest));
 
         // Act
         var response = await httpClient.AsCustomer().SendAsync(requestMessage);
@@ -87,6 +87,25 @@ public class DeleteManifestTests : IClassFixture<PresentationAppFactory<Program>
         dbContext.Manifests.Remove(dbManifest);
         await dbContext.SaveChangesAsync();
     }
+    
+    [Fact]
+    public async Task DeleteManifest_FailsToDeleteManifest_WhenEtagDoesNotMatch()
+    {
+        // Arrange
+        var requestMessage =
+            HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Delete,
+                $"{Customer}/manifests/FirstChildManifest");
+
+        // Act
+        var response = await httpClient.AsCustomer().SendAsync(requestMessage);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.PreconditionFailed);
+        
+        var errorResponse = await response.ReadAsPresentationResponseAsync<Error>();
+        errorResponse!.ErrorTypeUri.Should().Be("http://localhost/errors/DeleteResourceType/EtagNotMatching");
+        errorResponse.Detail.Should().Be("Etag does not match");
+    }
 
     [Fact]
     public async Task DeleteManifest_DeletesInS3()
@@ -107,8 +126,8 @@ public class DeleteManifestTests : IClassFixture<PresentationAppFactory<Program>
         var responseCollection = await response.ReadAsPresentationResponseAsync<PresentationManifest>();
         var id = responseCollection!.Id.GetLastPathElement();
 
-        requestMessage =
-            HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Delete, $"{Customer}/manifests/{id}");
+        requestMessage = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Delete, $"{Customer}/manifests/{id}",
+            dbContext.GetETag(id, Customer, ResourceType.IIIFManifest));
 
 
         // Act

--- a/src/IIIFPresentation/API.Tests/Integration/DeleteManifestTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/DeleteManifestTests.cs
@@ -103,7 +103,7 @@ public class DeleteManifestTests : IClassFixture<PresentationAppFactory<Program>
         response.StatusCode.Should().Be(HttpStatusCode.PreconditionFailed);
         
         var errorResponse = await response.ReadAsPresentationResponseAsync<Error>();
-        errorResponse!.ErrorTypeUri.Should().Be("http://localhost/errors/DeleteResourceType/EtagNotMatching");
+        errorResponse!.ErrorTypeUri.Should().Be("http://localhost/errors/DeleteResourceErrorType/EtagNotMatching");
         errorResponse.Detail.Should().Be("Etag does not match");
     }
 

--- a/src/IIIFPresentation/API/Features/Common/Helpers/DeleteErrorHelper.cs
+++ b/src/IIIFPresentation/API/Features/Common/Helpers/DeleteErrorHelper.cs
@@ -8,4 +8,15 @@ public class DeleteErrorHelper
     public static ResultMessage<DeleteResult, DeleteResourceErrorType> EtagNotMatching()
         => new(DeleteResult.PreconditionFailed, DeleteResourceErrorType.EtagNotMatching,
             "Etag does not match");
+    
+    public static ResultMessage<DeleteResult, DeleteResourceErrorType> NotFound()
+        => new(DeleteResult.NotFound, DeleteResourceErrorType.NotFound);
+
+    public static ResultMessage<DeleteResult, DeleteResourceErrorType> CannotDeleteRootCollection()
+        => new(DeleteResult.BadRequest, DeleteResourceErrorType.CannotDeleteRootCollection,
+            "Cannot delete a root collection");
+    
+    public static ResultMessage<DeleteResult, DeleteResourceErrorType> UnknownError(string resourceType)
+        => new(DeleteResult.BadRequest, DeleteResourceErrorType.Unknown,
+            $"Error deleting {resourceType}");
 }

--- a/src/IIIFPresentation/API/Features/Common/Helpers/DeleteErrorHelper.cs
+++ b/src/IIIFPresentation/API/Features/Common/Helpers/DeleteErrorHelper.cs
@@ -5,7 +5,7 @@ namespace API.Features.Common.Helpers;
 
 public class DeleteErrorHelper
 {
-    public static ResultMessage<DeleteResult, DeleteResourceType> EtagNotMatching()
-        => new(DeleteResult.PreConditionFailed, DeleteResourceType.EtagNotMatching,
+    public static ResultMessage<DeleteResult, DeleteResourceErrorType> EtagNotMatching()
+        => new(DeleteResult.PreconditionFailed, DeleteResourceErrorType.EtagNotMatching,
             "Etag does not match");
 }

--- a/src/IIIFPresentation/API/Features/Common/Helpers/DeleteErrorHelper.cs
+++ b/src/IIIFPresentation/API/Features/Common/Helpers/DeleteErrorHelper.cs
@@ -1,0 +1,11 @@
+﻿using Core;
+using Models.API.General;
+
+namespace API.Features.Common.Helpers;
+
+public class DeleteErrorHelper
+{
+    public static ResultMessage<DeleteResult, DeleteResourceType> EtagNotMatching()
+        => new(DeleteResult.PreConditionFailed, DeleteResourceType.EtagNotMatching,
+            "Etag does not match");
+}

--- a/src/IIIFPresentation/API/Features/Common/Helpers/HierarchyResourceDeleter.cs
+++ b/src/IIIFPresentation/API/Features/Common/Helpers/HierarchyResourceDeleter.cs
@@ -1,0 +1,83 @@
+﻿using API.Infrastructure.Helpers;
+using AWS.Helpers;
+using Core;
+using Microsoft.EntityFrameworkCore;
+using Models.API.General;
+using Models.Database.Collections;
+using Repository;
+using Repository.Helpers;
+
+namespace API.Features.Common.Helpers;
+
+public class HierarchyResourceDeleter(
+    PresentationContext dbContext,
+    IIIIFS3Service iiifS3,
+    ILogger<HierarchyResourceDeleter> logger)
+{
+    public async Task<ResultMessage<DeleteResult, DeleteResourceErrorType>> DeleteResource(string? etagFromRequest, 
+        IHierarchyResource? resource, CancellationToken cancellationToken)
+    {
+        if (resource is null) return DeleteErrorHelper.NotFound();
+
+        if (!EtagComparer.IsMatch(resource.Etag, etagFromRequest)) return DeleteErrorHelper.EtagNotMatching();
+        
+        switch (resource)
+        {
+            case Collection collection:
+            {
+                var error = await DeleteCollection(resource, collection, cancellationToken);
+                if (error != null) return error;
+                break;
+            }
+            case Models.Database.Collections.Manifest manifest:
+                await DeleteManifest(resource, manifest);
+                break;
+        }
+
+        try
+        {
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateConcurrencyException ex)
+        {
+            var hierarchy = resource.Hierarchy.GetCanonical();
+            var resourceType = hierarchy.CollectionId != null ? "collection" : "manifest";
+            
+            logger.LogError(ex, "Error attempting to delete {ResourceType} {ResourceId} for customer {CustomerId}",
+                resourceType, hierarchy.CollectionId ?? hierarchy.ManifestId, hierarchy.CustomerId);
+            return DeleteErrorHelper.UnknownError(resourceType);
+        }
+
+        return new ResultMessage<DeleteResult, DeleteResourceErrorType>(DeleteResult.Deleted);
+    }
+    
+    private async Task<ResultMessage<DeleteResult, DeleteResourceErrorType>?> DeleteCollection(IHierarchyResource resource, 
+        Collection collection, CancellationToken cancellationToken)
+    {
+        var hasItems = await dbContext.Hierarchy.AnyAsync(
+            c => c.CustomerId == collection.CustomerId && c.Parent == collection.Id,
+            cancellationToken: cancellationToken);
+
+        if (hasItems)
+        {
+            return new ResultMessage<DeleteResult, DeleteResourceErrorType>(DeleteResult.BadRequest,
+                DeleteResourceErrorType.CollectionNotEmpty, "Cannot delete a collection with child items");
+        }
+        
+        dbContext.Collections.Remove(collection);
+
+        if (!collection.IsStorageCollection)
+        {
+            await iiifS3.DeleteIIIFFromS3(resource);
+        }
+
+        return null;
+    }
+    
+    private async Task DeleteManifest(IHierarchyResource resource, Models.Database.Collections.Manifest manifest)
+    {
+        dbContext.Manifests.Remove(manifest);
+        await iiifS3.DeleteIIIFFromS3(resource);
+    }
+
+}

--- a/src/IIIFPresentation/API/Features/Common/Helpers/ParentValidator.cs
+++ b/src/IIIFPresentation/API/Features/Common/Helpers/ParentValidator.cs
@@ -17,8 +17,8 @@ public static class ParentValidator
     public static ModifyEntityResult<TCollection, ModifyCollectionType>? ValidateParentCollection<TCollection>(Collection? parentCollection) 
         where TCollection : JsonLdBase
     {
-        if (parentCollection == null) return ErrorHelper.NullParentResponse<TCollection>();
+        if (parentCollection == null) return UpsertErrorHelper.NullParentResponse<TCollection>();
         
-        return !parentCollection.IsStorageCollection ? ErrorHelper.ParentMustBeStorageCollection<TCollection>() : null;
+        return !parentCollection.IsStorageCollection ? UpsertErrorHelper.ParentMustBeStorageCollection<TCollection>() : null;
     }
 }

--- a/src/IIIFPresentation/API/Features/Common/Helpers/UpsertErrorHelper.cs
+++ b/src/IIIFPresentation/API/Features/Common/Helpers/UpsertErrorHelper.cs
@@ -3,9 +3,9 @@ using Core;
 using IIIF;
 using Models.API.General;
 
-namespace API.Features.Storage.Helpers;
+namespace API.Features.Common.Helpers;
 
-public static class ErrorHelper
+public static class UpsertErrorHelper
 {
     public static ModifyEntityResult<TCollection, ModifyCollectionType> NullParentResponse<TCollection>() 
         where TCollection : JsonLdBase

--- a/src/IIIFPresentation/API/Features/Common/Helpers/UpsertErrorHelper.cs
+++ b/src/IIIFPresentation/API/Features/Common/Helpers/UpsertErrorHelper.cs
@@ -43,14 +43,14 @@ public static class UpsertErrorHelper
     {
         return ModifyEntityResult<T, ModifyCollectionType>.Failure(
             "ETag should not be included in request when inserting via PUT", ModifyCollectionType.ETagNotAllowed,
-            WriteResult.PreConditionFailed);
+            WriteResult.PreconditionFailed);
     }
     
     public static ModifyEntityResult<T, ModifyCollectionType> EtagNonMatching<T>()
         where T : JsonLdBase
     {
         return ModifyEntityResult<T, ModifyCollectionType>.Failure(
-            "ETag does not match", ModifyCollectionType.ETagNotMatched, WriteResult.PreConditionFailed);
+            "ETag does not match", ModifyCollectionType.ETagNotMatched, WriteResult.PreconditionFailed);
     }
     
     public static ModifyEntityResult<T, ModifyCollectionType> DlcsError<T>(string message)

--- a/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingResolver.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingResolver.cs
@@ -1,5 +1,6 @@
 ﻿using System.Data;
 using System.Diagnostics;
+using API.Features.Common.Helpers;
 using API.Features.Manifest.Exceptions;
 using API.Features.Storage.Helpers;
 using API.Infrastructure.IdGenerator;
@@ -47,13 +48,13 @@ public class CanvasPaintingResolver(
         {
             logger.LogDebug(cpId, "InvalidCanvasId '{CanvasId}' encountered in {ManifestId}", cpId.CanvasId,
                 presentationManifest.Id);
-            return CanvasPaintingRecords.Failure(ErrorHelper.InvalidCanvasId<PresentationManifest>(cpId.CanvasId, cpId.Message));
+            return CanvasPaintingRecords.Failure(UpsertErrorHelper.InvalidCanvasId<PresentationManifest>(cpId.CanvasId, cpId.Message));
         }
         catch (PaintableAssetException paintableAssetException)
         {
             logger.LogError(paintableAssetException,
                 "Error retrieving details of an asset from items when generating canvas paintings");
-            return CanvasPaintingRecords.Failure(ErrorHelper.PaintableAssetError<PresentationManifest>(paintableAssetException.Message));
+            return CanvasPaintingRecords.Failure(UpsertErrorHelper.PaintableAssetError<PresentationManifest>(paintableAssetException.Message));
         }
     }
 
@@ -197,7 +198,7 @@ public class CanvasPaintingResolver(
         logger.LogTrace("Adding {CanvasCounts} to Manifest", canvasPaintings.Count);
         var requiredIds = canvasPaintings.GetRequiredNumberOfCanvasIds();
         var canvasPaintingIds = await GenerateUniqueCanvasPaintingIds(requiredIds, customerId, cancellationToken);
-        if (canvasPaintingIds == null) return ErrorHelper.CannotGenerateUniqueId<PresentationManifest>();
+        if (canvasPaintingIds == null) return UpsertErrorHelper.CannotGenerateUniqueId<PresentationManifest>();
 
         // Build a dictionary of canvas_grouping:canvas_id, this is populated as we iterate over canvas paintings.
         // We will also seed it with any 'new' items that are on the same canvas as these will have been prepopulated
@@ -264,14 +265,14 @@ public class CanvasPaintingResolver(
         catch (InvalidCanvasIdException cpId)
         {
             logger.LogDebug(cpId, "InvalidCanvasId encountered in {ManifestId}", presentationManifest.Id);
-            return new ManifestParseResult(ErrorHelper.InvalidCanvasId<PresentationManifest>(cpId.CanvasId, cpId.Message), null, null);
+            return new ManifestParseResult(UpsertErrorHelper.InvalidCanvasId<PresentationManifest>(cpId.CanvasId, cpId.Message), null, null);
         }
         catch (CanvasPaintingMergerException cpMergeError)
         {
             logger.LogDebug(cpMergeError,
                 "Canvas painting merge exception encountered in {ManifestId} for id {Id} - expected: {Expected}, actual: {Actual}",
                 presentationManifest.Id, cpMergeError.Id, cpMergeError.Expected, cpMergeError.Actual);
-            return new ManifestParseResult(ErrorHelper.ErrorMergingPaintedResourcesWithItems<PresentationManifest>(cpMergeError.Message),
+            return new ManifestParseResult(UpsertErrorHelper.ErrorMergingPaintedResourcesWithItems<PresentationManifest>(cpMergeError.Message),
                 null, null);
         }
         catch (InvalidOperationException formatException)
@@ -279,13 +280,13 @@ public class CanvasPaintingResolver(
             logger.LogDebug(formatException,
                 "Canvas painting exception encountered in {ManifestId}, could not retrieve an asset id",
                 presentationManifest.Id);
-            return new ManifestParseResult(ErrorHelper.CouldNotRetrieveAssetId<PresentationManifest>(), null, null);
+            return new ManifestParseResult(UpsertErrorHelper.CouldNotRetrieveAssetId<PresentationManifest>(), null, null);
         }
         catch (PaintableAssetException paintableAssetException)
         {
             logger.LogDebug(paintableAssetException,
                 "Error retrieving paintable assets from items");
-            return new ManifestParseResult(ErrorHelper.PaintableAssetError<PresentationManifest>(paintableAssetException.Message), null, null);
+            return new ManifestParseResult(UpsertErrorHelper.PaintableAssetError<PresentationManifest>(paintableAssetException.Message), null, null);
         }
     }
 

--- a/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using API.Features.Common.Helpers;
 using API.Features.Storage.Helpers;
 using API.Helpers;
 using API.Infrastructure.Helpers;
@@ -111,7 +112,7 @@ public class DlcsManifestCoordinator(
         {
             logger.LogError(presentationException, "Error checking for the existence of assets");
 
-            return DlcsInteractionResult.Fail(ErrorHelper.PaintableAssetError<PresentationManifest>(presentationException.Message));
+            return DlcsInteractionResult.Fail(UpsertErrorHelper.PaintableAssetError<PresentationManifest>(presentationException.Message));
         }
 
         return null;
@@ -150,7 +151,7 @@ public class DlcsManifestCoordinator(
                 if (!spaceId.HasValue)
                 {
                     return DlcsInteractionResult.Fail(
-                        ErrorHelper.DlcsError<PresentationManifest>("Error creating DLCS space"));
+                        UpsertErrorHelper.DlcsError<PresentationManifest>("Error creating DLCS space"));
                 }
 
                 // you wanted a space, and there are no assets, so no further work required

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestController.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestController.cs
@@ -100,7 +100,7 @@ public class ManifestController(
     {
         if (!Request.HasShowExtraHeader()) return this.Forbidden();
 
-        return await HandleDelete(new DeleteManifest(customerId, id));
+        return await HandleDelete(new DeleteManifest(customerId, id, Request.Headers.IfMatch));
     }
 
     private async Task<IActionResult> ManifestUpsert<T, TEnum>(

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
@@ -1,6 +1,7 @@
 using System.Data;
 using System.Diagnostics;
 using API.Converters;
+using API.Features.Common.Helpers;
 using API.Features.Storage.Helpers;
 using API.Helpers;
 using API.Infrastructure.Helpers;
@@ -109,7 +110,7 @@ public class ManifestWriteService(
 
             if (existingManifest == null)
             {
-                if (!string.IsNullOrEmpty(request.Etag)) return ErrorHelper.EtagNotRequired<PresentationManifest>();
+                if (!string.IsNullOrEmpty(request.Etag)) return UpsertErrorHelper.EtagNotRequired<PresentationManifest>();
 
                 logger.LogDebug("Manifest {ManifestId} for Customer {CustomerId} doesn't exist, creating",
                     request.ManifestId, request.CustomerId);
@@ -120,7 +121,7 @@ public class ManifestWriteService(
         }
         catch (DlcsException ex)
         {
-            return ErrorHelper.DlcsError<PresentationManifest>(ex.Message);
+            return UpsertErrorHelper.DlcsError<PresentationManifest>(ex.Message);
         }
         catch (Exception ex)
         {
@@ -142,7 +143,7 @@ public class ManifestWriteService(
         }
         catch (DlcsException ex)
         {
-            return ErrorHelper.DlcsError<PresentationManifest>(ex.Message);
+            return UpsertErrorHelper.DlcsError<PresentationManifest>(ex.Message);
         }
         catch (Exception ex)
         {
@@ -172,7 +173,7 @@ public class ManifestWriteService(
 
             // Ensure we have a manifestId
             manifestId ??= await GenerateUniqueManifestId(request, cancellationToken);
-            if (manifestId == null) return ErrorHelper.CannotGenerateUniqueId<PresentationManifest>();
+            if (manifestId == null) return UpsertErrorHelper.CannotGenerateUniqueId<PresentationManifest>();
 
             // Carry out any DLCS interactions (for paintedResources with _assets_) 
             var dlcsInteractionResult = await dlcsManifestCoordinator.HandleDlcsInteractions(request, manifestId,
@@ -205,7 +206,7 @@ public class ManifestWriteService(
     {
         if (!EtagComparer.IsMatch(existingManifest.Etag, request.Etag))
         {
-            return ErrorHelper.EtagNonMatching<PresentationManifest>();
+            return UpsertErrorHelper.EtagNonMatching<PresentationManifest>();
         }
 
         using (logger.BeginScope("Updating Manifest {ManifestId} for Customer {CustomerId}",

--- a/src/IIIFPresentation/API/Features/Manifest/Requests/DeleteManifest.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/Requests/DeleteManifest.cs
@@ -10,8 +10,8 @@ using Repository;
 
 namespace API.Features.Manifest.Requests;
 
-public class DeleteManifest(int customerId, string manifestId, string etag)
-    : IRequest<ResultMessage<DeleteResult, DeleteResourceType>>
+public class DeleteManifest(int customerId, string manifestId, string? etag)
+    : IRequest<ResultMessage<DeleteResult, DeleteResourceErrorType>>
 {
     public int CustomerId { get; } = customerId;
     public string ManifestId { get; } = manifestId;
@@ -22,9 +22,9 @@ public class DeleteManifestHandler(
     PresentationContext dbContext,
     IIIIFS3Service iiifS3,
     ILogger<DeleteManifestHandler> logger)
-    : IRequestHandler<DeleteManifest, ResultMessage<DeleteResult, DeleteResourceType>>
+    : IRequestHandler<DeleteManifest, ResultMessage<DeleteResult, DeleteResourceErrorType>>
 {
-    public async Task<ResultMessage<DeleteResult, DeleteResourceType>> Handle(DeleteManifest request,
+    public async Task<ResultMessage<DeleteResult, DeleteResourceErrorType>> Handle(DeleteManifest request,
         CancellationToken cancellationToken)
     {
         logger.LogDebug("Deleting manifest {ManifestId} for customer {CustomerId}", request.ManifestId,
@@ -51,7 +51,7 @@ public class DeleteManifestHandler(
             logger.LogError(ex, "Error attempting to delete manifest {ManifestId} for customer {CustomerId}",
                 request.ManifestId, request.CustomerId);
             return new(DeleteResult.Error,
-                DeleteResourceType.Unknown, "Error deleting manifest");
+                DeleteResourceErrorType.Unknown, "Error deleting manifest");
         }
         
         return new(DeleteResult.Deleted);

--- a/src/IIIFPresentation/API/Features/Manifest/Requests/DeleteManifest.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/Requests/DeleteManifest.cs
@@ -16,7 +16,6 @@ public class DeleteManifest(int customerId, string manifestId, string? etag)
 }
 
 public class DeleteManifestHandler(
-    PresentationContext dbContext,
     HierarchyResourceDeleter hierarchyResourceDeleter,
     ILogger<DeleteManifestHandler> logger)
     : IRequestHandler<DeleteManifest, ResultMessage<DeleteResult, DeleteResourceErrorType>>
@@ -27,10 +26,7 @@ public class DeleteManifestHandler(
         logger.LogDebug("Deleting manifest {ManifestId} for customer {CustomerId}", request.ManifestId,
             request.CustomerId);
 
-        var manifest =
-            await dbContext.RetrieveManifestAsync(request.CustomerId, request.ManifestId, true,
-                withCanvasPaintings: false, cancellationToken: cancellationToken);
-        
-        return await hierarchyResourceDeleter.DeleteResource(request.Etag, manifest, cancellationToken);
+        return await hierarchyResourceDeleter.DeleteResource<Models.Database.Collections.Manifest>(request.Etag,
+            request.CustomerId, request.ManifestId, cancellationToken);
     }
 }

--- a/src/IIIFPresentation/API/Features/Storage/CollectionController.cs
+++ b/src/IIIFPresentation/API/Features/Storage/CollectionController.cs
@@ -128,7 +128,7 @@ public class CollectionController(
     {
         if (!Request.HasShowExtraHeader()) return this.Forbidden();
 
-        return await HandleDelete(new DeleteCollection(customerId, id));
+        return await HandleDelete(new DeleteCollection(customerId, id, Request.Headers.IfMatch));
     }
 
     /// <summary> 

--- a/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
@@ -1,5 +1,6 @@
 using System.Data;
 using API.Converters;
+using API.Features.Common.Helpers;
 using API.Features.Storage.Helpers;
 using API.Features.Storage.Models;
 using API.Helpers;
@@ -57,7 +58,7 @@ public class CreateCollectionHandler(
         if (!isStorageCollection)
         {
             iiifCollection = request.RawRequestBody.ConvertCollectionToIIIF<IIIF.Presentation.V3.Collection>(logger);
-            if (iiifCollection.Error) return ErrorHelper.CannotValidateIIIF<PresentationCollection>();
+            if (iiifCollection.Error) return UpsertErrorHelper.CannotValidateIIIF<PresentationCollection>();
         }
         
         var parsedParentSlugResult =
@@ -74,7 +75,7 @@ public class CreateCollectionHandler(
         catch (ConstraintException ex)
         {
             logger.LogError(ex, "An exception occured while generating a unique id");
-            return ErrorHelper.CannotGenerateUniqueId<PresentationCollection>();
+            return UpsertErrorHelper.CannotGenerateUniqueId<PresentationCollection>();
         }
 
         var dateCreated = DateTime.UtcNow;

--- a/src/IIIFPresentation/API/Features/Storage/Requests/DeleteCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/DeleteCollection.cs
@@ -1,10 +1,7 @@
 ﻿using API.Features.Common.Helpers;
 using API.Features.Storage.Helpers;
-using API.Infrastructure.Helpers;
-using AWS.Helpers;
 using Core;
 using MediatR;
-using Microsoft.EntityFrameworkCore;
 using Models;
 using Models.API.General;
 using Repository;
@@ -22,7 +19,7 @@ public class DeleteCollection (int customerId, string collectionId, string? etag
 
 public class DeleteCollectionHandler(
     PresentationContext dbContext,
-    IIIIFS3Service iiifS3,
+    HierarchyResourceDeleter hierarchyResourceDeleter,
     ILogger<DeleteCollectionHandler> logger)
     : IRequestHandler<DeleteCollection, ResultMessage<DeleteResult, DeleteResourceErrorType>>
 {
@@ -33,46 +30,12 @@ public class DeleteCollectionHandler(
         
         if (request.CollectionId.Equals(KnownCollections.RootCollection, StringComparison.OrdinalIgnoreCase))
         {
-            return new ResultMessage<DeleteResult, DeleteResourceErrorType>(DeleteResult.BadRequest,
-                DeleteResourceErrorType.CannotDeleteRootCollection, "Cannot delete a root collection");
+            return DeleteErrorHelper.CannotDeleteRootCollection();
         }
 
         var collection =
             await dbContext.RetrieveCollectionAsync(request.CustomerId, request.CollectionId, true, cancellationToken);
         
-        if (collection is null) return new ResultMessage<DeleteResult, DeleteResourceErrorType>(DeleteResult.NotFound);
-
-        if (!EtagComparer.IsMatch(collection.Etag, request.Etag)) return DeleteErrorHelper.EtagNotMatching();
-        
-        var hasItems = await dbContext.Hierarchy.AnyAsync(
-            c => c.CustomerId == request.CustomerId && c.Parent == collection.Id,
-            cancellationToken: cancellationToken);
-
-        if (hasItems)
-        {
-            return new ResultMessage<DeleteResult, DeleteResourceErrorType>(DeleteResult.BadRequest,
-                DeleteResourceErrorType.CollectionNotEmpty, "Cannot delete a collection with child items");
-        }
-
-        dbContext.Collections.Remove(collection);
-
-        if (!collection.IsStorageCollection)
-        {
-            await iiifS3.DeleteIIIFFromS3(collection);
-        }
-
-        try
-        {
-            await dbContext.SaveChangesAsync(cancellationToken);
-        }
-        catch (DbUpdateConcurrencyException ex)
-        {
-            logger.LogError(ex, "Error attempting to delete collection {CollectionId} for customer {CustomerId}",
-                request.CollectionId, request.CustomerId);
-            return new ResultMessage<DeleteResult, DeleteResourceErrorType>(DeleteResult.Error,
-                DeleteResourceErrorType.Unknown, "Error deleting collection");
-        }
-
-        return new ResultMessage<DeleteResult, DeleteResourceErrorType>(DeleteResult.Deleted);
+        return await hierarchyResourceDeleter.DeleteResource(request.Etag, collection, cancellationToken);
     }
 }

--- a/src/IIIFPresentation/API/Features/Storage/Requests/DeleteCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/DeleteCollection.cs
@@ -4,6 +4,7 @@ using Core;
 using MediatR;
 using Models;
 using Models.API.General;
+using Models.Database.Collections;
 using Repository;
 
 namespace API.Features.Storage.Requests;
@@ -18,7 +19,6 @@ public class DeleteCollection (int customerId, string collectionId, string? etag
 }
 
 public class DeleteCollectionHandler(
-    PresentationContext dbContext,
     HierarchyResourceDeleter hierarchyResourceDeleter,
     ILogger<DeleteCollectionHandler> logger)
     : IRequestHandler<DeleteCollection, ResultMessage<DeleteResult, DeleteResourceErrorType>>
@@ -32,10 +32,8 @@ public class DeleteCollectionHandler(
         {
             return DeleteErrorHelper.CannotDeleteRootCollection();
         }
-
-        var collection =
-            await dbContext.RetrieveCollectionAsync(request.CustomerId, request.CollectionId, true, cancellationToken);
         
-        return await hierarchyResourceDeleter.DeleteResource(request.Etag, collection, cancellationToken);
+        return await hierarchyResourceDeleter.DeleteResource<Collection>(request.Etag,
+            request.CustomerId, request.CollectionId, cancellationToken);
     }
 }

--- a/src/IIIFPresentation/API/Features/Storage/Requests/PostHierarchicalCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/PostHierarchicalCollection.cs
@@ -44,7 +44,7 @@ public class PostHierarchicalCollectionHandler(
         CancellationToken cancellationToken)
     {
         var convertResult = request.RawRequestBody.ConvertCollectionToIIIF<Collection>(logger);
-        if (convertResult.Error) return ErrorHelper.CannotValidateIIIF<Collection>();
+        if (convertResult.Error) return UpsertErrorHelper.CannotValidateIIIF<Collection>();
         var collectionFromBody = convertResult.ConvertedIIIF!;
         
         var splitSlug = request.Slug.Split('/');
@@ -58,7 +58,7 @@ public class PostHierarchicalCollectionHandler(
         if (parentValidationError != null) return parentValidationError;
         
         var id = await GenerateUniqueId(request, cancellationToken);
-        if (id == null) return ErrorHelper.CannotGenerateUniqueId<Collection>();
+        if (id == null) return UpsertErrorHelper.CannotGenerateUniqueId<Collection>();
 
         var collection = CreateDatabaseCollection(request, collectionFromBody, id, parentCollection, splitSlug);
         dbContext.Collections.Add(collection);

--- a/src/IIIFPresentation/API/Features/Storage/Requests/UpsertCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/UpsertCollection.cs
@@ -62,7 +62,7 @@ public class UpsertCollectionHandler(
         if (!isStorageCollection)
         {
             iiifCollection = request.RawRequestBody.ConvertCollectionToIIIF<IIIF.Presentation.V3.Collection>(logger);
-            if (iiifCollection.Error) return ErrorHelper.CannotValidateIIIF<PresentationCollection>();
+            if (iiifCollection.Error) return UpsertErrorHelper.CannotValidateIIIF<PresentationCollection>();
         }
         var databaseCollection =
             await dbContext.RetrieveCollectionWithParentAsync(request.CustomerId, request.CollectionId, true, cancellationToken);
@@ -77,7 +77,7 @@ public class UpsertCollectionHandler(
         if (databaseCollection == null)
         {
             // No existing collection = create
-            if (!string.IsNullOrEmpty(request.ETag)) return ErrorHelper.EtagNotRequired<PresentationCollection>();
+            if (!string.IsNullOrEmpty(request.ETag)) return UpsertErrorHelper.EtagNotRequired<PresentationCollection>();
 
             var createdDate = DateTime.UtcNow;
 
@@ -109,14 +109,14 @@ public class UpsertCollectionHandler(
         else
         {
             if (!EtagComparer.IsMatch(databaseCollection.Etag, request.ETag))
-                return ErrorHelper.EtagNonMatching<PresentationCollection>();
+                return UpsertErrorHelper.EtagNonMatching<PresentationCollection>();
             
             if (isStorageCollection != databaseCollection.IsStorageCollection)
             {
                 logger.LogError(
                     "Customer {CustomerId} attempted to convert collection {CollectionId} to {CollectionType}",
                     request.CustomerId, request.CollectionId, isStorageCollection ? "storage" : "iiif");
-                return ErrorHelper.CannotChangeCollectionType<PresentationCollection>(isStorageCollection);
+                return UpsertErrorHelper.CannotChangeCollectionType<PresentationCollection>(isStorageCollection);
             }
 
             var existingHierarchy = databaseCollection.Hierarchy!.Single(c => c.Canonical);

--- a/src/IIIFPresentation/API/Helpers/ParentSlugParser.cs
+++ b/src/IIIFPresentation/API/Helpers/ParentSlugParser.cs
@@ -73,7 +73,7 @@ public class ParentSlugParser(PresentationContext dbContext,
         where T : JsonLdBase
         => string.IsNullOrEmpty(presentation.PublicId) || presentation.PublicIdIsRoot(GetBaseUrl(), customer)
             ? null
-            : ErrorHelper.IncorrectPublicId<T>();
+            : UpsertErrorHelper.IncorrectPublicId<T>();
 
     private (ModifyEntityResult<T, ModifyCollectionType>? errors, string? slug)
         TryGetSlug<T>(IPresentation presentation) where T : JsonLdBase
@@ -88,7 +88,7 @@ public class ParentSlugParser(PresentationContext dbContext,
         {
             logger.LogDebug("PublicId slug '{PublicIdSlug}' and explicit slug {Slug} do not match",
                 presentation.PublicId, presentation.Slug);
-            return (ErrorHelper.SlugMustMatchPublicId<T>(), null);
+            return (UpsertErrorHelper.SlugMustMatchPublicId<T>(), null);
         }
 
         return (null, slug);
@@ -129,7 +129,7 @@ public class ParentSlugParser(PresentationContext dbContext,
         {
             logger.LogDebug("PublicId parent '{PublicIdParent}' and explicit parent {Parent} do not match",
                 presentation.PublicId, presentation.Parent);
-            return (ErrorHelper.ParentMustMatchPublicId<T>(), null);
+            return (UpsertErrorHelper.ParentMustMatchPublicId<T>(), null);
         }
 
         return (null, parent);

--- a/src/IIIFPresentation/API/Infrastructure/ControllerBaseX.cs
+++ b/src/IIIFPresentation/API/Infrastructure/ControllerBaseX.cs
@@ -87,7 +87,7 @@ public static class ControllerBaseX
             WriteResult.StorageLimitExceeded => controller.PresentationProblem(entityResult.Error, instance,
                 (int)HttpStatusCode.InsufficientStorage,
                 $"{errorTitle}: Storage limit exceeded"),
-            WriteResult.PreConditionFailed => controller.PresentationProblem(entityResult.Error, instance,
+            WriteResult.PreconditionFailed => controller.PresentationProblem(entityResult.Error, instance,
                 (int)HttpStatusCode.PreconditionFailed,
                 $"{errorTitle}: Pre-condition failed", controller.GetErrorType(entityResult.ErrorType)),
             _ => controller.PresentationProblem(entityResult.Error, instance, (int)HttpStatusCode.InternalServerError,

--- a/src/IIIFPresentation/API/Infrastructure/PresentationController.cs
+++ b/src/IIIFPresentation/API/Infrastructure/PresentationController.cs
@@ -131,6 +131,7 @@ public abstract class PresentationController : Controller
             DeleteResult.Conflict => this.PresentationProblem(detail: message, type: GetErrorType(type), statusCode: (int)HttpStatusCode.Conflict, title: "Conflict"),
             DeleteResult.Error => this.PresentationProblem(detail: message, type: GetErrorType(type), statusCode: (int)HttpStatusCode.InternalServerError, title: "Internal Server Error"),
             DeleteResult.BadRequest => this.PresentationProblem(detail: message, type: GetErrorType(type), statusCode: (int)HttpStatusCode.BadRequest, title: "Bad Request"),
+            DeleteResult.PreConditionFailed => this.PresentationProblem(detail: message, type: GetErrorType(type), statusCode: (int)HttpStatusCode.PreconditionFailed, title: "Pre-condition failed"),
             DeleteResult.Deleted => NoContent(),
             _ => throw new ArgumentOutOfRangeException(nameof(DeleteResult), $"No deletion value of {result}")
         };

--- a/src/IIIFPresentation/API/Infrastructure/PresentationController.cs
+++ b/src/IIIFPresentation/API/Infrastructure/PresentationController.cs
@@ -131,7 +131,7 @@ public abstract class PresentationController : Controller
             DeleteResult.Conflict => this.PresentationProblem(detail: message, type: GetErrorType(type), statusCode: (int)HttpStatusCode.Conflict, title: "Conflict"),
             DeleteResult.Error => this.PresentationProblem(detail: message, type: GetErrorType(type), statusCode: (int)HttpStatusCode.InternalServerError, title: "Internal Server Error"),
             DeleteResult.BadRequest => this.PresentationProblem(detail: message, type: GetErrorType(type), statusCode: (int)HttpStatusCode.BadRequest, title: "Bad Request"),
-            DeleteResult.PreconditionFailed => this.PresentationProblem(detail: message, type: GetErrorType(type), statusCode: (int)HttpStatusCode.PreconditionFailed, title: "Pre-condition Failed"),
+            DeleteResult.PreconditionFailed => this.PresentationProblem(detail: message, type: GetErrorType(type), statusCode: (int)HttpStatusCode.PreconditionFailed, title: "Precondition Failed"),
             DeleteResult.Deleted => NoContent(),
             _ => throw new ArgumentOutOfRangeException(nameof(DeleteResult), $"No deletion value of {result}")
         };

--- a/src/IIIFPresentation/API/Infrastructure/PresentationController.cs
+++ b/src/IIIFPresentation/API/Infrastructure/PresentationController.cs
@@ -131,7 +131,7 @@ public abstract class PresentationController : Controller
             DeleteResult.Conflict => this.PresentationProblem(detail: message, type: GetErrorType(type), statusCode: (int)HttpStatusCode.Conflict, title: "Conflict"),
             DeleteResult.Error => this.PresentationProblem(detail: message, type: GetErrorType(type), statusCode: (int)HttpStatusCode.InternalServerError, title: "Internal Server Error"),
             DeleteResult.BadRequest => this.PresentationProblem(detail: message, type: GetErrorType(type), statusCode: (int)HttpStatusCode.BadRequest, title: "Bad Request"),
-            DeleteResult.PreConditionFailed => this.PresentationProblem(detail: message, type: GetErrorType(type), statusCode: (int)HttpStatusCode.PreconditionFailed, title: "Pre-condition failed"),
+            DeleteResult.PreconditionFailed => this.PresentationProblem(detail: message, type: GetErrorType(type), statusCode: (int)HttpStatusCode.PreconditionFailed, title: "Pre-condition Failed"),
             DeleteResult.Deleted => NoContent(),
             _ => throw new ArgumentOutOfRangeException(nameof(DeleteResult), $"No deletion value of {result}")
         };

--- a/src/IIIFPresentation/API/Program.cs
+++ b/src/IIIFPresentation/API/Program.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Serialization;
 using API.Auth;
+using API.Features.Common.Helpers;
 using API.Features.Manifest;
 using API.Helpers;
 using API.Infrastructure;
@@ -8,7 +9,6 @@ using API.Infrastructure.Http.CorrelationId;
 using API.Infrastructure.Http.Redirect;
 using API.Paths;
 using API.Settings;
-using Core.Web;
 using DLCS;
 using FluentValidation;
 using Microsoft.AspNetCore.HttpOverrides;
@@ -20,7 +20,6 @@ using Services;
 using Services.Manifests;
 using Services.Manifests.AWS;
 using Services.Manifests.Helpers;
-using Services.Manifests.Settings;
 
 const string corsPolicyName = "CorsPolicy";
 
@@ -81,6 +80,7 @@ builder.Services
     .AddSingleton<IManifestStorageManager, ManifestS3Manager>()
     .AddScoped<IParentSlugParser, ParentSlugParser>()
     .AddScoped<IETagCache, ETagCache>()
+    .AddScoped<HierarchyResourceDeleter>()
     .AddHttpContextAccessor()
     .AddOutgoingHeaders();
 builder.Services.ConfigureMediatR();

--- a/src/IIIFPresentation/Core/DeleteResult.cs
+++ b/src/IIIFPresentation/Core/DeleteResult.cs
@@ -1,32 +1,37 @@
 ﻿namespace Core;
 
 /// <summary>
-///     Represents the result of a delete operation
+/// Represents the result of a delete operation
 /// </summary>
 public enum DeleteResult
 {
     /// <summary>
-    ///     Item not deleted as it could not be found
+    /// Item not deleted as it could not be found
     /// </summary>
     NotFound,
 
     /// <summary>
-    ///     Item was successfully deleted
+    /// Item was successfully deleted
     /// </summary>
     Deleted,
 
     /// <summary>
-    ///     There is a user addressable error while deleting
+    /// There is a user addressable error while deleting
     /// </summary>
     Conflict,
 
     /// <summary>
-    ///     There was an internal error deleting
+    /// There was an internal error deleting
     /// </summary>
     Error,
     
     /// <summary>
-    ///     There was an error deleting
+    /// There was an error deleting
     /// </summary>
-    BadRequest
+    BadRequest,
+    
+    /// <summary>
+    /// Request failed a precondition
+    /// </summary>
+    PreConditionFailed
 }

--- a/src/IIIFPresentation/Core/DeleteResult.cs
+++ b/src/IIIFPresentation/Core/DeleteResult.cs
@@ -33,5 +33,5 @@ public enum DeleteResult
     /// <summary>
     /// Request failed a precondition
     /// </summary>
-    PreConditionFailed
+    PreconditionFailed
 }

--- a/src/IIIFPresentation/Core/WriteResult.cs
+++ b/src/IIIFPresentation/Core/WriteResult.cs
@@ -58,5 +58,5 @@ public enum WriteResult
     /// <summary>
     /// Request failed a precondition
     /// </summary>
-    PreConditionFailed
+    PreconditionFailed
 }

--- a/src/IIIFPresentation/Models/API/General/DeleteCollectionType.cs
+++ b/src/IIIFPresentation/Models/API/General/DeleteCollectionType.cs
@@ -1,8 +1,9 @@
 ﻿namespace Models.API.General;
 
-public enum DeleteCollectionType
+public enum DeleteResourceType
 {
     CannotDeleteRootCollection = 1,
     CollectionNotEmpty = 2,
+    EtagNotMatching = 3,
     Unknown = 3
 }

--- a/src/IIIFPresentation/Models/API/General/DeleteManifestType.cs
+++ b/src/IIIFPresentation/Models/API/General/DeleteManifestType.cs
@@ -1,6 +1,0 @@
-﻿namespace Models.API.General;
-
-public enum DeleteManifestType
-{
-    Unknown = 0
-}

--- a/src/IIIFPresentation/Models/API/General/DeleteResourceErrorType.cs
+++ b/src/IIIFPresentation/Models/API/General/DeleteResourceErrorType.cs
@@ -1,9 +1,9 @@
 ﻿namespace Models.API.General;
 
-public enum DeleteResourceType
+public enum DeleteResourceErrorType
 {
     CannotDeleteRootCollection = 1,
     CollectionNotEmpty = 2,
     EtagNotMatching = 3,
-    Unknown = 3
+    Unknown = 4
 }

--- a/src/IIIFPresentation/Models/API/General/DeleteResourceErrorType.cs
+++ b/src/IIIFPresentation/Models/API/General/DeleteResourceErrorType.cs
@@ -5,5 +5,6 @@ public enum DeleteResourceErrorType
     CannotDeleteRootCollection = 1,
     CollectionNotEmpty = 2,
     EtagNotMatching = 3,
-    Unknown = 4
+    NotFound = 4,
+    Unknown = 5
 }

--- a/src/IIIFPresentation/Models/Database/Collections/IHierarchyResource.cs
+++ b/src/IIIFPresentation/Models/Database/Collections/IHierarchyResource.cs
@@ -9,5 +9,7 @@ public interface IHierarchyResource : IIdentifiable
 {
     List<Hierarchy>? Hierarchy { get; }
     
+    public Guid Etag { get; set; }
+    
     public DateTime Created { get; set; }
 }

--- a/src/IIIFPresentation/Test.Helpers/Integration/PresentationContextX.cs
+++ b/src/IIIFPresentation/Test.Helpers/Integration/PresentationContextX.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Models.Database.Collections;
+using Models.Database.General;
 using Repository;
 
 namespace Test.Helpers.Integration;
@@ -15,5 +16,12 @@ public static class PresentationContextX
             Manifest m => db.Manifests.AsNoTracking().FirstOrDefault(x => x.Id == m.Id && x.CustomerId == m.CustomerId)?.Etag,
             EntityEntry<Manifest> c => db.GetETag(c.Entity),
             _ => null
+        };
+    
+    public static Guid? GetETag(this PresentationContext db, string id, int customerId, ResourceType resourceType)
+        => resourceType switch
+        {
+            ResourceType.IIIFManifest => db.Manifests.AsNoTracking().FirstOrDefault(x => x.Id == id && x.CustomerId == customerId)?.Etag,
+            _ => db.Collections.AsNoTracking().FirstOrDefault(x => x.Id == id && x.CustomerId == customerId)?.Etag
         };
 }


### PR DESCRIPTION
Resolves #531

This PR makes it so that an Etag is required when calling `DELETE` for manifests and collections.  This shares the logic of `PUT` using the `EtagComparer`


Additionally, there's a small amount of refactoring around the naming of classes to make it clear which is for delete and upsert 