### PR TITLE
Allow multiple composite and choice canvases to work

### DIFF
--- a/src/IIIFPresentation/API.Tests/Features/Manifest/CanvasPaintingMergerTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Manifest/CanvasPaintingMergerTests.cs
@@ -690,4 +690,128 @@ public class CanvasPaintingMergerTests
         action.Should().ThrowExactly<CanvasPaintingMergerException>()
             .WithMessage("Canvas with id paintedResource_1 has a mismatched case with matched canvas painting(s) PaintedResource_1,painteDResource_1.  Canvases and canvas paintings cannot differ by case");
     }
+    
+    [Fact]
+    public void CombinePaintedResources_CreatesMultipleCompositeCanvases_WhenItemsTrackedByPaintedResourcesWithMultipleCompositeCanvases()
+    {
+        var canvasPaintingItems = ManifestTestCreator.CanvasPaintings()
+            .WithCanvasPainting($"paintedResource_1", cp =>
+            {
+                cp.CanvasOrder = 0;
+                cp.CanvasOriginalId = new Uri($"https://localhost/1/paintedResource_1");
+            }).WithCanvasPainting($"paintedResource_2", cp =>
+            {
+                cp.CanvasOrder = 1;
+                cp.CanvasOriginalId = new Uri($"https://localhost/1/paintedResource_2");
+            }).BuildInterim();
+        
+        var canvasPaintingPaintedResources = ManifestTestCreator.CanvasPaintings()
+            .WithCanvasPainting($"paintedResource_1", cp =>
+            {
+                cp.CanvasOrder = 0;
+            })
+            .WithCanvasPainting($"paintedResource_1", cp =>
+            {
+                cp.CanvasOrder = 1;
+            }).WithCanvasPainting($"paintedResource_2", cp =>
+            {
+                cp.CanvasOrder = 2;
+            })
+            .WithCanvasPainting($"paintedResource_2", cp =>
+            {
+                cp.CanvasOrder = 3;
+            }).BuildInterim();
+
+        // Act
+        var merged = sut.CombinePaintedResources(canvasPaintingItems, canvasPaintingPaintedResources, []);
+
+        // Assert
+        merged.Count.Should().Be(4);
+        var first = merged.First();
+        first.Id.Should().Be($"paintedResource_1");
+        first.CanvasOrder.Should().Be(0);
+        
+        first.CanvasPaintingType.Should().Be(CanvasPaintingType.Mixed);
+        
+        var second = merged[1];
+        second.Id.Should().Be($"paintedResource_1");
+        second.CanvasOrder.Should().Be(1);
+        second.CanvasPaintingType.Should().Be(CanvasPaintingType.Mixed);
+        
+        var third = merged[2];
+        third.Id.Should().Be($"paintedResource_2");
+        third.CanvasOrder.Should().Be(2);
+        third.CanvasPaintingType.Should().Be(CanvasPaintingType.Mixed);
+        
+        var last = merged.Last();
+        last.Id.Should().Be($"paintedResource_2");
+        last.CanvasOrder.Should().Be(3);
+        last.CanvasPaintingType.Should().Be(CanvasPaintingType.Mixed);
+    }
+    
+    [Fact]
+    public void CombinePaintedResources_CreatesMultipleChoiceCanvases_WhenItemsTrackedByPaintedResourcesWithMultipleChoiceCanvases()
+    {
+        var canvasPaintingItems = ManifestTestCreator.CanvasPaintings()
+            .WithCanvasPainting($"paintedResource_1", cp =>
+            {
+                cp.CanvasOrder = 0;
+                cp.CanvasOriginalId = new Uri($"https://localhost/1/paintedResource_1");
+            }).WithCanvasPainting($"paintedResource_2", cp =>
+            {
+                cp.CanvasOrder = 1;
+                cp.CanvasOriginalId = new Uri($"https://localhost/1/paintedResource_2");
+            }).BuildInterim();
+        
+        var canvasPaintingPaintedResources = ManifestTestCreator.CanvasPaintings()
+            .WithCanvasPainting($"paintedResource_1", cp =>
+            {
+                cp.CanvasOrder = 0;
+                cp.ChoiceOrder = 1;
+            })
+            .WithCanvasPainting($"paintedResource_1", cp =>
+            {
+                cp.CanvasOrder = 0;
+                cp.ChoiceOrder = 2;
+            }).WithCanvasPainting($"paintedResource_2", cp =>
+            {
+                cp.CanvasOrder = 1;
+                cp.ChoiceOrder = 1;
+            })
+            .WithCanvasPainting($"paintedResource_2", cp =>
+            {
+                cp.CanvasOrder = 1;
+                cp.ChoiceOrder = 2;
+            }).BuildInterim();
+
+        // Act
+        var merged = sut.CombinePaintedResources(canvasPaintingItems, canvasPaintingPaintedResources, []);
+
+        // Assert
+        merged.Count.Should().Be(4);
+        var first = merged.First();
+        first.Id.Should().Be($"paintedResource_1");
+        first.CanvasOrder.Should().Be(0);
+        first.ChoiceOrder.Should().Be(1);
+        
+        first.CanvasPaintingType.Should().Be(CanvasPaintingType.Mixed);
+        
+        var second = merged[1];
+        second.Id.Should().Be($"paintedResource_1");
+        second.CanvasOrder.Should().Be(0);
+        second.ChoiceOrder.Should().Be(2);
+        second.CanvasPaintingType.Should().Be(CanvasPaintingType.Mixed);
+        
+        var third = merged[2];
+        third.Id.Should().Be($"paintedResource_2");
+        third.CanvasOrder.Should().Be(1);
+        third.ChoiceOrder.Should().Be(1);
+        third.CanvasPaintingType.Should().Be(CanvasPaintingType.Mixed);
+        
+        var last = merged.Last();
+        last.Id.Should().Be($"paintedResource_2");
+        last.CanvasOrder.Should().Be(1);
+        last.ChoiceOrder.Should().Be(2);
+        last.CanvasPaintingType.Should().Be(CanvasPaintingType.Mixed);
+    }
 }

--- a/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingMerger.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingMerger.cs
@@ -117,7 +117,7 @@ public class CanvasPaintingMerger(IPathRewriteParser pathRewriteParser) : ICanva
             {
                 orderedCanvasPainting =
                     matchedPaintedResourceCanvasPaintings.FirstOrDefault(cp =>
-                        cp.CanvasOrder == itemsCanvasPainting.CanvasOrder) ?? throw new CanvasPaintingMergerException(
+                        cp.CanvasOrder == currentCanvasOrder) ?? throw new CanvasPaintingMergerException(
                         $"Canvas with id {itemsCanvasPainting.CanvasOriginalId} refers to multiple canvases, and the matching canvas order cannot be found");
                 
                 // Going through all the multi-item canvases to find the first specified canvas label, as the first found
@@ -138,7 +138,8 @@ public class CanvasPaintingMerger(IPathRewriteParser pathRewriteParser) : ICanva
             MatchImplicitItemsToCanvasOrder(itemsCanvasPainting, matchedPaintedResourceCanvasPaintings);
 
             itemsCanvasPaintings.Remove(itemsCanvasPainting);
-            currentCanvasOrder += matchedPaintedResourceCanvasPaintings.Count;
+            // group by allows counts to work correctly with choice and composite canvases
+            currentCanvasOrder += matchedPaintedResourceCanvasPaintings.GroupBy(pr => pr.CanvasOrder).Count();
         }
     }
 


### PR DESCRIPTION
Resolves #541 

This PR allows composite and choice canvases to work after the first item.

This is actually 2 separate issues, which broke similar functionality, though both related to `currentCanvasOrder`:
- The `currentCanvasOrder` value was not correctly tracking retrieval of `matchedPaintedResources` in choice constructs
- `currentCanvasOrder` was tracking composite canvases as different canvases, causing the count to get out of sync