### PR TITLE
Stop persisting the space id between the asset when removing the space

### DIFF
--- a/src/IIIFPresentation/API.Tests/Features/Manifest/ManifestWriteServiceTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Manifest/ManifestWriteServiceTests.cs
@@ -102,7 +102,7 @@ public class ManifestWriteServiceTests
             PathRules = PathRewriteOptions.Default
         })));
 
-        sut = new ManifestWriteService(presentationContext, identityManager, iiifS3Service, canvasPaintingResolver,
+        sut = new ManifestWriteService(presentationContext, identityManager, canvasPaintingResolver,
             new TestPathGenerator(presentationGenerator), settingsBasedPathGenerator, dlcsManifestCoordinator, parentSlugParser,
             manifestStorageManager, pathRewriteParser, new NullLogger<ManifestWriteService>());
 

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetUpdateTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetUpdateTests.cs
@@ -2767,4 +2767,71 @@ public class ModifyManifestAssetUpdateTests : IClassFixture<PresentationAppFacto
         dbManifest.Entity.Etag.Should().NotBeEmpty();
         dbManifest.Entity.LastProcessed.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(2));
     }
+    
+    [Fact]
+    public async Task UpdateManifest_CorrectlyUpdatesAssetRequests_WhenSpaceChangesButAssetIdStaysTheSame()
+    {
+        // Arrange
+        var (slug, id, assetId) = TestIdentifiers.SlugResourceAsset();
+        var initialSpace = 25;
+
+        var initialCanvasPaintings = new List<CanvasPainting>
+        {
+            new()
+            {
+                Id = "first",
+                CanvasOrder = 1,
+                AssetId = new AssetId(Customer, initialSpace, assetId)
+            }
+        };
+
+        var testManifest = await dbContext.Manifests.AddTestManifest(id: id, slug: slug, canvasPaintings: initialCanvasPaintings,
+            batchId: TestIdentifiers.BatchId(), ingested: true);
+        await dbContext.SaveChangesAsync();
+
+        var batchId = TestIdentifiers.BatchId();
+        var payload = $$"""
+                         {
+                             "type": "Manifest",
+                             "slug": "{{slug}}",
+                             "parent": "http://localhost/{{Customer}}/collections/root",
+                             "paintedResources": [
+                                 {
+                                    "canvasPainting":{
+                                        "canvasId": "first"
+                                    },
+                                     "asset": {
+                                         "id": "{{assetId}}",
+                                         "batch": "{{batchId}}",
+                                         "mediaType": "image/jpg"
+                                     }
+                                 }
+                             ] 
+                         }
+                         """;
+
+        var requestMessage =
+            HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Put, $"{Customer}/manifests/{id}",
+                payload, dbContext.GetETag(testManifest));
+        
+        // Act
+        var response = await httpClient.AsCustomer().SendAsync(requestMessage);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+        var dbManifest = dbContext.Manifests
+            .Include(m => m.CanvasPaintings)
+            .Include(m => m.Batches)
+            .First(x => x.Id == id);
+
+        dbManifest.SpaceId.Should().Be(NewlyCreatedSpace, "space updated from null by the DLCS");
+        dbManifest.CanvasPaintings.Should().HaveCount(1);
+        var canvasPainting = dbManifest.CanvasPaintings.First();
+        
+        canvasPainting.Id.Should().Be("first");
+        // space added using the DLCS space
+        canvasPainting.AssetId!.ToString().Should()
+            .Be($"{Customer}/{NewlyCreatedSpace}/{assetId}", "asset id updated to point at new space");
+    }
 }

--- a/src/IIIFPresentation/API/Features/Common/Helpers/UpsertErrorHelper.cs
+++ b/src/IIIFPresentation/API/Features/Common/Helpers/UpsertErrorHelper.cs
@@ -110,6 +110,11 @@ public static class UpsertErrorHelper
         => ModifyEntityResult<TCollection, ModifyCollectionType>.Failure(error,
             ModifyCollectionType.PaintableAssetError, WriteResult.BadRequest);
     
+    public static ModifyEntityResult<TCollection, ModifyCollectionType> AssetError<TCollection>(string error)
+        where TCollection : JsonLdBase
+        => ModifyEntityResult<TCollection, ModifyCollectionType>.Failure(error,
+            ModifyCollectionType.AssetError, WriteResult.BadRequest);
+    
     private static string CollectionType(bool isStorageCollection)
     {
         return isStorageCollection ? "Storage" : "IIIF";

--- a/src/IIIFPresentation/API/Features/Common/Helpers/UpsertErrorHelper.cs
+++ b/src/IIIFPresentation/API/Features/Common/Helpers/UpsertErrorHelper.cs
@@ -2,6 +2,7 @@
 using Core;
 using IIIF;
 using Models.API.General;
+using Services.Manifests.Exceptions;
 
 namespace API.Features.Common.Helpers;
 
@@ -110,9 +111,9 @@ public static class UpsertErrorHelper
         => ModifyEntityResult<TCollection, ModifyCollectionType>.Failure(error,
             ModifyCollectionType.PaintableAssetError, WriteResult.BadRequest);
     
-    public static ModifyEntityResult<TCollection, ModifyCollectionType> AssetError<TCollection>(string error)
+    public static ModifyEntityResult<TCollection, ModifyCollectionType> AssetError<TCollection>(AssetException exception)
         where TCollection : JsonLdBase
-        => ModifyEntityResult<TCollection, ModifyCollectionType>.Failure(error,
+        => ModifyEntityResult<TCollection, ModifyCollectionType>.Failure(exception.Message,
             ModifyCollectionType.AssetError, WriteResult.BadRequest);
     
     private static string CollectionType(bool isStorageCollection)

--- a/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingResolver.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingResolver.cs
@@ -82,14 +82,14 @@ public class CanvasPaintingResolver(
     }
     
     private List<InterimCanvasPainting> UpdateCanvasPaintingRecords(List<CanvasPainting> existingCanvasPaintings, 
-        List<InterimCanvasPainting> incomingCanvasPaintings, int? existingSpace)
+        List<InterimCanvasPainting> incomingCanvasPaintings, int? manifestSpace)
     {
         var processedCanvasPaintingIds = new List<int>(incomingCanvasPaintings.Count);
         var toInsert = new List<InterimCanvasPainting>();
         
         foreach (var incoming in incomingCanvasPaintings)
         {
-            UpdateCanvasPainting(existingCanvasPaintings, incoming, processedCanvasPaintingIds, toInsert, existingSpace);
+            UpdateCanvasPainting(existingCanvasPaintings, incoming, processedCanvasPaintingIds, toInsert, manifestSpace);
         }
         
         // Delete canvasPaintings from DB that are not in payload
@@ -104,7 +104,7 @@ public class CanvasPaintingResolver(
     }
     
     private void UpdateCanvasPainting(List<CanvasPainting> existingCanvasPaintings, InterimCanvasPainting incoming,
-        List<int> processedCanvasPaintingIds, List<InterimCanvasPainting> toInsert, int? existingSpace)
+        List<int> processedCanvasPaintingIds, List<InterimCanvasPainting> toInsert, int? manifestSpace)
     {
         var candidates = GetCandidates(existingCanvasPaintings, incoming);
         var matching = TryFindMatching(incoming, processedCanvasPaintingIds, candidates);
@@ -130,7 +130,7 @@ public class CanvasPaintingResolver(
         {
             // Found matching DB record, update...
             logger.LogTrace("Updating canvasPaintingId {CanvasId}", matching.CanvasPaintingId);
-            matching.UpdateFrom(incoming.ToCanvasPainting(existingSpace));
+            matching.UpdateFrom(incoming.ToCanvasPainting(manifestSpace));
             processedCanvasPaintingIds.Add(matching.CanvasPaintingId);
         }
     }
@@ -289,8 +289,8 @@ public class CanvasPaintingResolver(
         catch (AssetException assetException)
         {
             logger.LogDebug(assetException,
-                "Error when parsing asset ");
-            return new ManifestParseResult(UpsertErrorHelper.AssetError<PresentationManifest>(assetException.Message), null,
+                "Error when parsing asset - {AssetException}", assetException.Asset);
+            return new ManifestParseResult(UpsertErrorHelper.AssetError<PresentationManifest>(assetException), null,
                 null);
         }
         catch (PaintableAssetException paintableAssetException)

--- a/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
@@ -163,8 +163,7 @@ public class DlcsManifestCoordinator(
                 createdSpace = true;
             }
 
-            foreach (var asset in assetsWithoutSpaces)
-                asset.Add(AssetProperties.Space, spaceId.Value);
+            SpaceHelper.UpdateAssets(assetsWithoutSpaces, spaceId.Value);
             
         }
 

--- a/src/IIIFPresentation/Models/API/General/ModifyCollectionType.cs
+++ b/src/IIIFPresentation/Models/API/General/ModifyCollectionType.cs
@@ -25,6 +25,7 @@ public enum ModifyCollectionType
     ErrorMergingPaintedResourcesWithItems = 21,
     PublicIdIncorrect = 22,
     PaintableAssetError = 23,
+    AssetError = 24,
     AssetsDoNotMatch = 25,
     Unknown = 1000
 }

--- a/src/IIIFPresentation/Services/Manifests/Exceptions/AssetException.cs
+++ b/src/IIIFPresentation/Services/Manifests/Exceptions/AssetException.cs
@@ -1,0 +1,7 @@
+﻿namespace Services.Manifests.Exceptions;
+
+/// <summary>
+/// General exception for asset errors
+/// </summary>
+/// <param name="message"></param>
+public class AssetException(string? message) : Exception(message);

--- a/src/IIIFPresentation/Services/Manifests/Exceptions/AssetException.cs
+++ b/src/IIIFPresentation/Services/Manifests/Exceptions/AssetException.cs
@@ -4,4 +4,7 @@
 /// General exception for asset errors
 /// </summary>
 /// <param name="message"></param>
-public class AssetException(string? message) : Exception(message);
+public class AssetException(string? message, string asset) : Exception(message)
+{
+    public string Asset { get; } = asset;
+}

--- a/src/IIIFPresentation/Services/Manifests/Helpers/InterimCanvasPaintingX.cs
+++ b/src/IIIFPresentation/Services/Manifests/Helpers/InterimCanvasPaintingX.cs
@@ -35,12 +35,12 @@ public static class InterimCanvasPaintingX
     public static bool ContainsId(this List<InterimCanvasPainting>? canvasPainting, string? id) =>
         canvasPainting?.Any(cp => cp.Id?.Equals(id, StringComparison.OrdinalIgnoreCase) ?? false) ?? false;
 
-    public static CanvasPainting ToCanvasPainting(this InterimCanvasPainting interimCanvasPainting, int? space)
+    public static CanvasPainting ToCanvasPainting(this InterimCanvasPainting interimCanvasPainting, int? existingSpace)
     {
-        interimCanvasPainting.SuspectedSpace ??= space;
+        interimCanvasPainting.SuspectedSpace ??= existingSpace;
 
-        var assetId = interimCanvasPainting is { SuspectedAssetId: not null, SuspectedSpace: not null }
-            ? new AssetId(interimCanvasPainting.CustomerId, interimCanvasPainting.SuspectedSpace.Value,
+        var assetId = interimCanvasPainting is { SuspectedAssetId: not null}
+            ? new AssetId(interimCanvasPainting.CustomerId, interimCanvasPainting.SuspectedSpace ?? SpaceHelper.DefaultSpaceForLaterPopulation,
                 interimCanvasPainting.SuspectedAssetId)
             : null;
 

--- a/src/IIIFPresentation/Services/Manifests/Helpers/InterimCanvasPaintingX.cs
+++ b/src/IIIFPresentation/Services/Manifests/Helpers/InterimCanvasPaintingX.cs
@@ -35,9 +35,9 @@ public static class InterimCanvasPaintingX
     public static bool ContainsId(this List<InterimCanvasPainting>? canvasPainting, string? id) =>
         canvasPainting?.Any(cp => cp.Id?.Equals(id, StringComparison.OrdinalIgnoreCase) ?? false) ?? false;
 
-    public static CanvasPainting ToCanvasPainting(this InterimCanvasPainting interimCanvasPainting, int? existingSpace)
+    public static CanvasPainting ToCanvasPainting(this InterimCanvasPainting interimCanvasPainting, int? manifestSpace)
     {
-        interimCanvasPainting.SuspectedSpace ??= existingSpace;
+        interimCanvasPainting.SuspectedSpace ??= manifestSpace;
 
         var assetId = interimCanvasPainting is { SuspectedAssetId: not null}
             ? new AssetId(interimCanvasPainting.CustomerId, interimCanvasPainting.SuspectedSpace ?? SpaceHelper.DefaultSpaceForLaterPopulation,

--- a/src/IIIFPresentation/Services/Manifests/Helpers/SpaceHelper.cs
+++ b/src/IIIFPresentation/Services/Manifests/Helpers/SpaceHelper.cs
@@ -1,0 +1,42 @@
+﻿using Models.Database;
+using Models.DLCS;
+using Newtonsoft.Json.Linq;
+
+namespace Services.Manifests.Helpers;
+
+/// <summary>
+/// Updates assets and canvas paintings with details of the manifest space
+/// </summary>
+public static class SpaceHelper
+{
+    /// <summary>
+    /// The space used to signal that the space needs to be populated following DLCS interactions
+    /// </summary>
+    /// <remarks>This is a negative number as negative numbers are disallowed for a space id</remarks>
+    public static int DefaultSpaceForLaterPopulation => -1;
+
+    /// <summary>
+    /// Updates asset JObjects that don't have a space with a spoecified space
+    /// </summary>
+    /// <param name="assetsWithoutSpaces">The assets that don't have a space id attached</param>
+    /// <param name="spaceId">The space id to set</param> 
+    public static void UpdateAssets(JObject[] assetsWithoutSpaces, int spaceId)
+    {
+        foreach (var asset in assetsWithoutSpaces) asset.Add(AssetProperties.Space, spaceId);
+    }
+    
+    /// <summary>
+    /// Updates canvas paintings with a specified space id where they have been marked for population following DLCS
+    /// interactions
+    /// </summary>
+    /// <param name="canvasPaintings">The canvas paintings to check</param>
+    /// <param name="spaceId">The space id to set</param>
+    public static void UpdateCanvasPaintings(List<CanvasPainting> canvasPaintings, int? spaceId)
+    {
+        if (!spaceId.HasValue) return;
+        foreach (var canvasPainting in canvasPaintings.Where(canvasPainting => canvasPainting.AssetId?.Space == DefaultSpaceForLaterPopulation))
+        {
+            canvasPainting.AssetId = new AssetId(canvasPainting.AssetId!.Customer, spaceId.Value, canvasPainting.AssetId.Asset);
+        }
+    }
+}

--- a/src/IIIFPresentation/Services/Manifests/Helpers/SpaceHelper.cs
+++ b/src/IIIFPresentation/Services/Manifests/Helpers/SpaceHelper.cs
@@ -16,7 +16,7 @@ public static class SpaceHelper
     public static int DefaultSpaceForLaterPopulation => -1;
 
     /// <summary>
-    /// Updates asset JObjects that don't have a space with a spoecified space
+    /// Updates asset JObjects that don't have a space with a specified space
     /// </summary>
     /// <param name="assetsWithoutSpaces">The assets that don't have a space id attached</param>
     /// <param name="spaceId">The space id to set</param> 

--- a/src/IIIFPresentation/Services/Manifests/ManifestPaintedResourceParser.cs
+++ b/src/IIIFPresentation/Services/Manifests/ManifestPaintedResourceParser.cs
@@ -4,6 +4,7 @@ using Models.API.Manifest;
 using Models.DLCS;
 using Newtonsoft.Json.Linq;
 using Repository.Paths;
+using Services.Manifests.Exceptions;
 using Services.Manifests.Helpers;
 using Services.Manifests.Model;
 using CanvasPainting = Models.Database.CanvasPainting;
@@ -56,6 +57,13 @@ public class ManifestPaintedResourceParser(
         var payloadCanvasPainting = paintedResource.CanvasPainting;
         var (space, assetId) =
             GetCanvasPaintingDetailsForAsset(paintedResource.Asset.ThrowIfNull(nameof(paintedResource.Asset)));
+
+        if (space < 0)
+        {
+            throw new AssetException(
+                $"The space for asset '{assetId}' {(specifiedCanvasId != null ? $"with canvas id '{specifiedCanvasId}' " : "")}is '{space}' and cannot be negative");
+        }
+        
         logger.LogTrace("Processing canvas painting for asset {AssetId}", assetId);
         var cp = new InterimCanvasPainting
         {

--- a/src/IIIFPresentation/Services/Manifests/ManifestPaintedResourceParser.cs
+++ b/src/IIIFPresentation/Services/Manifests/ManifestPaintedResourceParser.cs
@@ -61,7 +61,8 @@ public class ManifestPaintedResourceParser(
         if (space < 0)
         {
             throw new AssetException(
-                $"The space for asset '{assetId}' {(specifiedCanvasId != null ? $"with canvas id '{specifiedCanvasId}' " : "")}is '{space}' and cannot be negative");
+                $"The space for asset '{assetId}' {(specifiedCanvasId != null ? $"with canvas id '{specifiedCanvasId}' " : "")}is '{space}' and cannot be negative",
+                assetId);
         }
         
         logger.LogTrace("Processing canvas painting for asset {AssetId}", assetId);


### PR DESCRIPTION
Resolves #544 
Resolves #518

This issue occurred when an asset was updated with the same `canvasId` as a previous asset, which caused the API to think this was an update to an existing asset, where previously it would reuse the old asset's space id if it was left blank, rather than using a space attached to the manifest.  This then compounded with potentially not knowing the manifest space until after the `dlcsManifestCoordinator` has run.

 This pull request makes it so that if a space id is not specified on an updated `canvasPainting`, it will use the manifest space instead.  Additionally, due to the workflow of `canvasPaintings` -> `dlcsManifestCoordinator` an extra step was added after the `dlcsManifestCoordinator` to update assets like this with a space id, if the space needs to be created by the `dlcsManifestCoordinator` 

Finally, another fix was implemented to make sure the manifest is updated with a space id if it receives one in an update operation.

> [!Note]
> Due to `-1` being used internally to signal that a `canvasPainting` requires updating later,  #518 has been implemented to disallow a client from specifying a negative space number to avoid issues.
