### PR TITLE
Allow audio, video and painting choices to correctly set labels and other fields

### DIFF
--- a/src/IIIFPresentation/Services/Manifests/ManifestMerger.cs
+++ b/src/IIIFPresentation/Services/Manifests/ManifestMerger.cs
@@ -270,7 +270,7 @@ public class ManifestMerger(SettingsBasedPathGenerator pathGenerator, IPathRewri
 
             // We might have 1 or more IPaintable elements (e.g. if NQ resource is already a choice, flatten it)
 
-            var paintables = new List<IPaintable>(GetPaintablesForChoice(body));
+            var paintables = GetPaintablesForChoice(body);
             if (canvasPaintingChoice.Label != null)
             {
                 logger.LogTrace("CanvasPainting {CanvasPaintingId} has label, setting on choice paintables",


### PR DESCRIPTION
Resolves #545

This was an issue where audio and video resources didn't correctly break the reference between the named query and the final manifest.  The ultimate issue occurs when the asset id is reused across multiple `canvasPaintings` and changes something like the `label`, which caused the final `canvasPainting` to set the label of all the previous `canvasPaintings` which referenced this asset.

This was handled for images, but it didn't extend to audio or video

Additionally, given audio and video can show as a `PaintingChoice` if multiple transcodes are specified, this has been handled as well