### PR TITLE
Provide more information when an invalid asset id is provided

### DIFF
--- a/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
@@ -1,6 +1,6 @@
 using System.Net;
 using API.Features.Common.Helpers;
-using API.Features.Storage.Helpers;
+using API.Features.Manifest.Exceptions;
 using API.Helpers;
 using API.Infrastructure.Helpers;
 using Core;
@@ -175,9 +175,29 @@ public class DlcsManifestCoordinator(
         List<AssetId>? previousManifestAssetIds, List<JObject> assets, List<AssetId> assetsFromItems, int? spaceId, bool spaceCreated, 
         CancellationToken cancellationToken)
     {
-        var dlcsInteractionRequests = await knownAssetChecker.FindAssetsThatRequireAdditionalWork(
-            request.PresentationManifest, previousManifestAssetIds, spaceId, spaceCreated, request.CustomerId, cancellationToken);
+        List<DlcsInteractionRequest> dlcsInteractionRequests;
         
+        try
+        {
+            dlcsInteractionRequests = await knownAssetChecker.FindAssetsThatRequireAdditionalWork(
+                request.PresentationManifest, previousManifestAssetIds, spaceId, spaceCreated, request.CustomerId,
+                cancellationToken);
+        }
+        catch (ArgumentException argumentException)
+        {
+            logger.LogError(argumentException, "Error parsing  DLCS asset that requires more work for manifest {ManifestId}", manifestId);
+
+            var error = $"Error parsing the asset id from an attached asset - {argumentException.Message}";
+
+            if (argumentException.Data.Contains(ExceptionDataType.CanvasPaintingId))
+            {
+                error += $" for canvas painting id '{argumentException.Data[ExceptionDataType.CanvasPaintingId]}'";
+            }
+            
+            return new DlcsInteractionResult(EntityResult.Failure(error, ModifyCollectionType.AssetError,
+                WriteResult.BadRequest), spaceId);
+        }
+
         var assetsToIngest = dlcsInteractionRequests.Where(d => d.Ingest != IngestType.NoIngest).ToList();
         // create batches for assets
         var batchError = await CreateBatches(request.CustomerId, manifestId, assetsToIngest.ToList(), cancellationToken);

--- a/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
@@ -183,15 +183,15 @@ public class DlcsManifestCoordinator(
                 request.PresentationManifest, previousManifestAssetIds, spaceId, spaceCreated, request.CustomerId,
                 cancellationToken);
         }
-        catch (ArgumentException argumentException)
+        catch (AssetIdException assetIdException)
         {
-            logger.LogError(argumentException, "Error parsing  DLCS asset that requires more work for manifest {ManifestId}", manifestId);
+            logger.LogError(assetIdException, "Error parsing  DLCS asset that requires more work for manifest {ManifestId}", manifestId);
 
-            var error = $"Error parsing the asset id from an attached asset - {argumentException.Message}";
+            var error = $"Error parsing the asset id from an attached asset - {assetIdException.Message}";
 
-            if (argumentException.Data.Contains(ExceptionDataType.CanvasPaintingId))
+            if (assetIdException.Data.Contains(ExceptionDataType.CanvasPaintingId))
             {
-                error += $" for canvas painting id '{argumentException.Data[ExceptionDataType.CanvasPaintingId]}'";
+                error += $" for canvas painting id '{assetIdException.Data[ExceptionDataType.CanvasPaintingId]}'";
             }
             
             return new DlcsInteractionResult(EntityResult.Failure(error, ModifyCollectionType.AssetError,

--- a/src/IIIFPresentation/API/Features/Manifest/Exceptions/ExceptionDataType.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/Exceptions/ExceptionDataType.cs
@@ -1,0 +1,6 @@
+﻿namespace API.Features.Manifest.Exceptions;
+
+public enum ExceptionDataType
+{
+    CanvasPaintingId
+}

--- a/src/IIIFPresentation/API/Features/Manifest/ManagedAssetResultFinder.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManagedAssetResultFinder.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using API.Features.Manifest.Exceptions;
 using API.Infrastructure.Helpers;
 using Core.Exceptions;
 using Core.Helpers;
@@ -38,7 +39,20 @@ public class ManagedAssetResultFinder(
         foreach (var paintedResource in presentationManifest.PaintedResources?.Where(pr => pr.Asset != null) ?? [])
         {
             var asset = paintedResource.Asset!;
-            var assetId = asset.GetAssetId(customerId);
+            AssetId assetId;
+
+            try
+            {
+                assetId = asset.GetAssetId(customerId);
+            }
+            catch (ArgumentException argumentException)
+            {
+                if (!string.IsNullOrEmpty(paintedResource.CanvasPainting?.CanvasId))
+                {
+                    argumentException.Data.Add(ExceptionDataType.CanvasPaintingId, paintedResource.CanvasPainting?.CanvasId);
+                }
+                throw;
+            }
 
             if (IsAssetNew(spaceId, spaceCreated, assetId))
             {

--- a/src/IIIFPresentation/API/Features/Manifest/ManagedAssetResultFinder.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManagedAssetResultFinder.cs
@@ -45,11 +45,11 @@ public class ManagedAssetResultFinder(
             {
                 assetId = asset.GetAssetId(customerId);
             }
-            catch (ArgumentException argumentException)
+            catch (AssetIdException assetIdException)
             {
                 if (!string.IsNullOrEmpty(paintedResource.CanvasPainting?.CanvasId))
                 {
-                    argumentException.Data.Add(ExceptionDataType.CanvasPaintingId, paintedResource.CanvasPainting?.CanvasId);
+                    assetIdException.Data.Add(ExceptionDataType.CanvasPaintingId, paintedResource.CanvasPainting?.CanvasId);
                 }
                 throw;
             }

--- a/src/IIIFPresentation/API/Infrastructure/Helpers/JObjectX.cs
+++ b/src/IIIFPresentation/API/Infrastructure/Helpers/JObjectX.cs
@@ -1,5 +1,4 @@
 ﻿using Core.Helpers;
-using DLCS.Models;
 using Models.DLCS;
 using Newtonsoft.Json.Linq;
 

--- a/src/IIIFPresentation/Models/DLCS/AssetId.cs
+++ b/src/IIIFPresentation/Models/DLCS/AssetId.cs
@@ -35,7 +35,7 @@ public class AssetId
         var parts = assetImageId.Split("/", StringSplitOptions.RemoveEmptyEntries);
         if (parts.Length != 3)
         {
-            throw new ArgumentException(
+            throw new AssetIdException(
                 $"AssetId '{assetImageId}' is invalid. Must be in format customer/space/asset");
         }
 
@@ -45,7 +45,7 @@ public class AssetId
         }
         catch (FormatException fmEx)
         {
-            throw new ArgumentException(
+            throw new AssetIdException(
                 $"AssetId '{assetImageId}' is invalid. Must be in format customer/space/asset",
                 fmEx);
         }

--- a/src/IIIFPresentation/Models/DLCS/AssetIdException.cs
+++ b/src/IIIFPresentation/Models/DLCS/AssetIdException.cs
@@ -1,0 +1,12 @@
+﻿namespace Models.DLCS;
+
+public class AssetIdException : Exception
+{
+    public AssetIdException(string? message) : base(message)
+    {
+    }
+    
+    public AssetIdException(string? message, Exception? innerException) : base(message, innerException)
+    {
+    }
+}


### PR DESCRIPTION
Resolves #546

Modifies a generic error message to be more specific to the issue of an invalid asset id.  This occurred as it happens before the asset is sent to the DLCS and thus wasn't handled as well as it should have been

> [!Note]
> Takes advantage of `Exception.Data` as this allows for more efficient `rethrow` logic to add additional context to an error message