### PR TITLE
Validate customer id in paths

### DIFF
--- a/src/IIIFPresentation/API.Tests/Helpers/ParentSlugParserTests.cs
+++ b/src/IIIFPresentation/API.Tests/Helpers/ParentSlugParserTests.cs
@@ -11,6 +11,7 @@ using Models.API.Collection;
 using Models.API.Manifest;
 using Repository;
 using Repository.Paths;
+using Test.Helpers;
 using Test.Helpers.Integration;
 
 namespace API.Tests.Helpers;
@@ -112,7 +113,7 @@ public class ParentSlugParserTests
     public async Task ParentSlugParser_ParsesFlatRootParentSlug_IfRootIdButNotCollection()
     {
         // Arrange
-        var slug = nameof(ParentSlugParser_ParsesFlatRootParentSlug);
+        var slug = TestIdentifiers.Slug();
         const string rootId = "root"; 
         
         // Act
@@ -133,7 +134,7 @@ public class ParentSlugParserTests
     public async Task ParentSlugParser_ParsesFlatRootParentSlug()
     {
         // Arrange
-        var slug = nameof(ParentSlugParser_ParsesFlatRootParentSlug);
+        var slug = TestIdentifiers.Slug();
         
         // Act
         var parentSlugParserResult = await parentSlugParser.Parse(new PresentationCollection
@@ -153,7 +154,7 @@ public class ParentSlugParserTests
     public async Task ParentSlugParser_ParsesFlatChildParentSlug()
     {
         // Arrange
-        var slug = nameof(ParentSlugParser_ParsesFlatRootParentSlug);
+        var slug = TestIdentifiers.Slug();
         
         // Act
         var parentSlugParserResult = await parentSlugParser.Parse(new PresentationCollection
@@ -173,7 +174,7 @@ public class ParentSlugParserTests
     public async Task ParentSlugParser_ParsesHierarchicalRootParentSlug()
     {
         // Arrange
-        var slug = nameof(ParentSlugParser_ParsesHierarchicalRootParentSlug);
+        var slug = TestIdentifiers.Slug();
         
         // Act
         var parentSlugParserResult = await parentSlugParser.Parse(new PresentationCollection
@@ -193,7 +194,7 @@ public class ParentSlugParserTests
     public async Task ParentSlugParser_ParsesHierarchicalChildParentSlug()
     {
         // Arrange
-        var slug = nameof(ParentSlugParser_ParsesHierarchicalChildParentSlug);
+        var slug = TestIdentifiers.Slug();
         
         // Act
         var parentSlugParserResult = await parentSlugParser.Parse(new PresentationCollection
@@ -213,7 +214,7 @@ public class ParentSlugParserTests
     public async Task ParentSlugParser_ParsesPublicId()
     {
         // Arrange
-        var slug = nameof(ParentSlugParser_ParsesPublicId);
+        var slug = TestIdentifiers.Slug();
         
         // Act
         var parentSlugParserResult = await parentSlugParser.Parse(new PresentationCollection
@@ -232,7 +233,7 @@ public class ParentSlugParserTests
     public async Task ParentSlugParser_ParsesPublicIdChild()
     {
         // Arrange
-        var slug = nameof(ParentSlugParser_ParsesPublicIdChild);
+        var slug = TestIdentifiers.Slug();
         
         // Act
         var parentSlugParserResult = await parentSlugParser.Parse(new PresentationCollection
@@ -251,7 +252,7 @@ public class ParentSlugParserTests
     public async Task ParentSlugParser_Fails_PublicIdNotMatchingSlug()
     {
         // Arrange
-        var slug = nameof(ParentSlugParser_Fails_PublicIdNotMatchingSlug);
+        var slug = TestIdentifiers.Slug();
         
         // Act
         var parentSlugParserResult = await parentSlugParser.Parse(new PresentationCollection
@@ -266,10 +267,27 @@ public class ParentSlugParserTests
     }
     
     [Fact]
+    public async Task ParentSlugParser_FailsToParsePublicId_MismatchBetweenPublicIdCustomerAndCallingCustomer()
+    {
+        // Arrange
+        var slug = TestIdentifiers.Slug();
+        
+        // Act
+        var parentSlugParserResult = await parentSlugParser.Parse(new PresentationCollection
+        {
+            PublicId = $"http://localhost/{Customer}/{slug}",
+        }, 2, null);
+
+        // Assert
+        parentSlugParserResult.IsError.Should().BeTrue();
+        parentSlugParserResult.Errors.Error.Should().Be($"The publicId has a customer id ({Customer}) that does not match the calling customer id (2)");
+    }
+    
+    [Fact]
     public async Task ParentSlugParser_Fails_PublicIdNotMatchingParent()
     {
         // Arrange
-        var slug = nameof(ParentSlugParser_Fails_PublicIdNotMatchingParent);
+        var slug = TestIdentifiers.Slug();
         
         // Act
         var parentSlugParserResult = await parentSlugParser.Parse(new PresentationCollection
@@ -287,7 +305,7 @@ public class ParentSlugParserTests
     public async Task ParentSlugParser_Fails_InvalidParent()
     {
         // Arrange
-        var slug = nameof(ParentSlugParser_Fails_InvalidParent);
+        var slug = TestIdentifiers.Slug();
         
         // Act
         var parentSlugParserResult = await parentSlugParser.Parse(new PresentationCollection
@@ -304,7 +322,7 @@ public class ParentSlugParserTests
     [Fact]
     public async Task ParentSlugParser_Fails_InvalidHost()
     {
-        var slug = nameof(ParentSlugParser_Fails_InvalidHost);
+        var slug = TestIdentifiers.Slug();
         
         // Act
         var parentSlugParserResult = await parentSlugParser.Parse(new PresentationCollection
@@ -323,7 +341,7 @@ public class ParentSlugParserTests
     public async Task ParentSlugParser_Fails_ParentIsIIIF()
     {
         // Arrange
-        var slug = nameof(ParentSlugParser_Fails_ParentIsIIIF);
+        var slug = TestIdentifiers.Slug();
         
         // Act
         var parentSlugParserResult = await parentSlugParser.Parse(new PresentationCollection
@@ -335,5 +353,23 @@ public class ParentSlugParserTests
         // Assert
         parentSlugParserResult.IsError.Should().BeTrue();
         parentSlugParserResult.Errors.Error.Should().Be("The parent must be a storage collection");
+    }
+    
+    [Fact]
+    public async Task ParentSlugParser_Fails_ParentCustomerDoesNotMatchCustomer()
+    {
+        // Arrange
+        var slug = TestIdentifiers.Slug();
+        
+        // Act
+        var parentSlugParserResult = await parentSlugParser.Parse(new PresentationCollection
+        {
+            Parent = $"http://localhost/{Customer}/collections/root",
+            Slug = slug
+        }, 2, null);
+
+        // Assert
+        parentSlugParserResult.IsError.Should().BeTrue();
+        parentSlugParserResult.Errors.Error.Should().Be($"The parent has a customer id ({Customer}) that does not match the calling customer id (2)");
     }
 }

--- a/src/IIIFPresentation/API.Tests/Helpers/ParentSlugParserTests.cs
+++ b/src/IIIFPresentation/API.Tests/Helpers/ParentSlugParserTests.cs
@@ -280,7 +280,7 @@ public class ParentSlugParserTests
 
         // Assert
         parentSlugParserResult.IsError.Should().BeTrue();
-        parentSlugParserResult.Errors.Error.Should().Be($"The publicId has a customer id ({Customer}) that does not match the calling customer id (2)");
+        parentSlugParserResult.Errors.Error.Should().Be($"The publicId has a customer id that does not match the customer id found on the calling URL");
     }
     
     [Fact]
@@ -370,6 +370,6 @@ public class ParentSlugParserTests
 
         // Assert
         parentSlugParserResult.IsError.Should().BeTrue();
-        parentSlugParserResult.Errors.Error.Should().Be($"The parent has a customer id ({Customer}) that does not match the calling customer id (2)");
+        parentSlugParserResult.Errors.Error.Should().Be($"The publicId has a customer id that does not match the customer id found on the calling URL");
     }
 }

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestExternalItemsTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestExternalItemsTests.cs
@@ -1776,7 +1776,7 @@ public class ModifyManifestExternalItemsTests : IClassFixture<PresentationAppFac
     ""slug"": ""{slug}"",
     ""items"": [
         {{
-            ""id"": ""https://localhost:7230/2/canvases/{slug}"",
+            ""id"": ""https://localhost:7230/{Customer + 1}/canvases/{slug}"",
             ""type"": ""Canvas""
         }}
     ]
@@ -1796,6 +1796,6 @@ public class ModifyManifestExternalItemsTests : IClassFixture<PresentationAppFac
         var canvasPainting = responseManifest.PaintedResources.First().CanvasPainting;
         canvasPainting.CanvasId.Split('/').Last().Should().NotBe(slug, "recognised host with unrecognised path");
         canvasPainting.CanvasOriginalId.Should()
-            .Be($"https://localhost:7230/2/canvases/{slug}");
+            .Be($"https://localhost:7230/{Customer + 1}/canvases/{slug}");
     }
 }

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestExternalItemsTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestExternalItemsTests.cs
@@ -1761,4 +1761,41 @@ public class ModifyManifestExternalItemsTests : IClassFixture<PresentationAppFac
         canvasPainting.CanvasOriginalId.Should()
             .Be($"https://localhost:7230/{Customer}/canvases/additionalSlug/{slug}");
     }
+    
+    [Fact]
+    public async Task PutFlatId_ReturnsCanvasPaintingWithRandomId_WhenCanvasIdForAnotherCustomer()
+    {
+        // Arrange
+        var (slug, id) = TestIdentifiers.SlugResource();
+        var manifest = $@"
+{{
+    ""@context"": ""http://iiif.io/api/presentation/3/context.json"",
+    ""id"": ""https://iiif.example/manifest.json"",
+    ""type"": ""Manifest"",
+    ""parent"": ""http://localhost/{Customer}/collections/{RootCollection.Id}"",
+    ""slug"": ""{slug}"",
+    ""items"": [
+        {{
+            ""id"": ""https://localhost:7230/2/canvases/{slug}"",
+            ""type"": ""Canvas""
+        }}
+    ]
+}}";
+        
+        var requestMessage =
+            HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Put, $"{Customer}/manifests/{id}", manifest);
+        
+        // Act
+        var response = await httpClient.AsCustomer().SendAsync(requestMessage);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        
+        var responseManifest = await response.ReadAsPresentationResponseAsync<PresentationManifest>();
+
+        var canvasPainting = responseManifest.PaintedResources.First().CanvasPainting;
+        canvasPainting.CanvasId.Split('/').Last().Should().NotBe(slug, "recognised host with unrecognised path");
+        canvasPainting.CanvasOriginalId.Should()
+            .Be($"https://localhost:7230/2/canvases/{slug}");
+    }
 }

--- a/src/IIIFPresentation/API/Features/Common/Helpers/UpsertErrorHelper.cs
+++ b/src/IIIFPresentation/API/Features/Common/Helpers/UpsertErrorHelper.cs
@@ -116,9 +116,9 @@ public static class UpsertErrorHelper
         => ModifyEntityResult<TCollection, ModifyCollectionType>.Failure(exception.Message,
             ModifyCollectionType.AssetError, WriteResult.BadRequest);
     
-    public static ModifyEntityResult<TCollection, ModifyCollectionType> CustomerIdDoesNotMatchCaller<TCollection>(string field, int customerIdFromField, int callerCustomerId)
+    public static ModifyEntityResult<TCollection, ModifyCollectionType> CustomerIdDoesNotMatchCaller<TCollection>(string field)
         where TCollection : JsonLdBase
-        => ModifyEntityResult<TCollection, ModifyCollectionType>.Failure($"The {field} has a customer id ({customerIdFromField}) that does not match the calling customer id ({callerCustomerId})",
+        => ModifyEntityResult<TCollection, ModifyCollectionType>.Failure($"The {field} has a customer id that does not match the customer id found on the calling URL",
             ModifyCollectionType.CustomerIdDoesNotMatchCaller, WriteResult.BadRequest);
     
     private static string CollectionType(bool isStorageCollection)

--- a/src/IIIFPresentation/API/Features/Common/Helpers/UpsertErrorHelper.cs
+++ b/src/IIIFPresentation/API/Features/Common/Helpers/UpsertErrorHelper.cs
@@ -116,6 +116,11 @@ public static class UpsertErrorHelper
         => ModifyEntityResult<TCollection, ModifyCollectionType>.Failure(exception.Message,
             ModifyCollectionType.AssetError, WriteResult.BadRequest);
     
+    public static ModifyEntityResult<TCollection, ModifyCollectionType> CustomerIdDoesNotMatchCaller<TCollection>(string field, int customerIdFromField, int callerCustomerId)
+        where TCollection : JsonLdBase
+        => ModifyEntityResult<TCollection, ModifyCollectionType>.Failure($"The {field} has a customer id ({customerIdFromField}) that does not match the calling customer id ({callerCustomerId})",
+            ModifyCollectionType.CustomerIdDoesNotMatchCaller, WriteResult.BadRequest);
+    
     private static string CollectionType(bool isStorageCollection)
     {
         return isStorageCollection ? "Storage" : "IIIF";

--- a/src/IIIFPresentation/API/Helpers/ParentSlugParser.cs
+++ b/src/IIIFPresentation/API/Helpers/ParentSlugParser.cs
@@ -116,10 +116,8 @@ public class ParentSlugParser(PresentationContext dbContext,
         // Try and get a parent from publicId 
         var publicIdParent = await RetrieveParent<T>(presentation, customerId, true, cancellationToken);
         
-        if (publicIdParent.Errors != null) return publicIdParent;
-
-        // If we don't have parent, return what we could parse from publicId 
-        if (presentation.Parent == null) return publicIdParent;
+        // If we don't have parent or there are errors, return what we could parse from publicId 
+        if (publicIdParent.Errors != null || presentation.Parent == null) return publicIdParent;
 
         // We have Parent property - find Collection for that 
         var parent = await RetrieveParent<T>(presentation, customerId, false, cancellationToken);
@@ -146,12 +144,12 @@ public class ParentSlugParser(PresentationContext dbContext,
         Uri? parentUri;
         if (fromPublicId)
         {
-            if (presentation.PublicId == null) return new ParsedParent<T>();
+            if (presentation.PublicId == null) return ParsedParent<T>.Empty();
             parentUri = PathParser.GetParentUriFromPublicId(presentation.PublicId);
         }
         else
         {
-            if (Uri.TryCreate(presentation.Parent, UriKind.Absolute, out parentUri) is not true) return new ParsedParent<T>();
+            if (!Uri.TryCreate(presentation.Parent, UriKind.Absolute, out parentUri)) return ParsedParent<T>.Empty();
         }
 
         try
@@ -160,7 +158,7 @@ public class ParentSlugParser(PresentationContext dbContext,
                 pathRewriteParser.ParsePathWithRewrites(parentUri.Host, parentUri.AbsolutePath,
                     customerId);
             
-            if (parentPath.Resource == null) return new ParsedParent<T>();
+            if (parentPath.Resource == null) return ParsedParent<T>.Empty();
 
             if (parentPath.Customer != customerId)
             {
@@ -181,7 +179,7 @@ public class ParentSlugParser(PresentationContext dbContext,
         catch (FormatException fe)
         {
             logger.LogDebug(fe, "Cannot parse parent from public id");
-            return new ParsedParent<T>();
+            return ParsedParent<T>.Empty();
         }
     }
 
@@ -195,6 +193,8 @@ public class ParentSlugParser(PresentationContext dbContext,
             new() { Errors = errors};
         
         public static ParsedParent<T> Success(Collection? parent) => new() { Parent = parent };
+        
+        public static ParsedParent<T> Empty() => new();
     }
 
     private string GetBaseUrl() => contextAccessor.HttpContext!.Request.GetBaseUrl();

--- a/src/IIIFPresentation/API/Helpers/ParentSlugParser.cs
+++ b/src/IIIFPresentation/API/Helpers/ParentSlugParser.cs
@@ -3,9 +3,7 @@ using API.Features.Common.Helpers;
 using API.Features.Storage.Helpers;
 using API.Infrastructure.Requests;
 using Core.Helpers;
-using Core.Web;
 using IIIF;
-using Microsoft.Extensions.Options;
 using Models;
 using Models.API;
 using Models.API.Collection;
@@ -116,28 +114,36 @@ public class ParentSlugParser(PresentationContext dbContext,
             CancellationToken cancellationToken) where T : JsonLdBase
     {
         // Try and get a parent from publicId 
-        var publicIdParent = await GetParentFromPublicId(presentation, customerId, cancellationToken);
+        var publicIdParent = await GetParentFromPublicId<T>(presentation, customerId, cancellationToken);
+        
+        if (publicIdParent.Errors != null) return publicIdParent;
 
         // If we don't have parent, return what we could parse from publicId 
-        if (presentation.Parent == null) return (null, publicIdParent);
+        if (presentation.Parent == null) return (null, publicIdParent.Parent);
 
         // We have Parent property - find Collection for that 
-        var parent = await RetrieveParentFromPresentation(presentation, customerId, cancellationToken);
+        var parent = await RetrieveParentFromPresentation<T>(presentation, customerId, cancellationToken);
+        
+        if (parent.Errors != null) return parent; 
 
         // Validate that if we have publicId AND parent they are for the same thing 
-        if (publicIdParent != null && parent != null && publicIdParent.Id != parent.Id)
+        if (publicIdParent.Parent != null && parent.Parent != null && publicIdParent.Parent.Id != parent.Parent.Id)
         {
             logger.LogDebug("PublicId parent '{PublicIdParent}' and explicit parent {Parent} do not match",
                 presentation.PublicId, presentation.Parent);
             return (UpsertErrorHelper.ParentMustMatchPublicId<T>(), null);
         }
 
-        return (null, parent);
+        return (null, parent.Parent);
     }
 
-    private async Task<Collection?> GetParentFromPublicId(IPresentation presentation, int customerId, CancellationToken cancellationToken)
+    private async Task<(ModifyEntityResult<T, ModifyCollectionType>? Errors, Collection? Parent)> 
+        GetParentFromPublicId<T>(
+            IPresentation presentation,
+            int customerId, 
+            CancellationToken cancellationToken)  where T : JsonLdBase
     {
-        if (presentation.PublicId == null) return null;
+        if (presentation.PublicId == null) return (null, null);
 
         // Lookup the parent Collection, handling Api and Public paths
         var publicIdParentUri = PathParser.GetParentUriFromPublicId(presentation.PublicId);
@@ -148,31 +154,45 @@ public class ParentSlugParser(PresentationContext dbContext,
                 pathRewriteParser.ParsePathWithRewrites(publicIdParentUri.Host, publicIdParentUri.AbsolutePath,
                     customerId);
             
-            if (parentPath.Resource == null) return null;
+            if (parentPath.Resource == null) return (null, null);
+
+            if (parentPath.Customer != customerId)
+            {
+                return (UpsertErrorHelper.CustomerIdDoesNotMatchCaller<T>("publicId", parentPath.Customer!.Value, customerId), null);
+            }
+            
             var publicIdParentHierarchy =
                 await dbContext.RetrieveHierarchy(customerId, parentPath.Resource, cancellationToken);
             var publicIdParent = publicIdParentHierarchy?.Collection;
-            return publicIdParent;
+            return (null, publicIdParent);
         }
         catch (FormatException fe)
         {
             logger.LogDebug(fe, "Cannot parse parent from public id");
-            return null;
+            return (null, null);
         }
     }
     
-    private async Task<Collection?> RetrieveParentFromPresentation(IPresentation presentation, int customerId,
-        CancellationToken cancellationToken)
+    private async Task<(ModifyEntityResult<T, ModifyCollectionType>? Errors, Collection? Parent)> 
+        RetrieveParentFromPresentation<T>(
+            IPresentation presentation, 
+            int customerId,
+            CancellationToken cancellationToken) where T : JsonLdBase
     {
-        if (Uri.TryCreate(presentation.Parent, UriKind.Absolute, out var parentUri) is not true) return null;
+        if (Uri.TryCreate(presentation.Parent, UriKind.Absolute, out var parentUri) is not true) return (null, null);
         var parentPath = pathRewriteParser.ParsePathWithRewrites(parentUri.Host, parentUri.AbsolutePath, customerId);
 
-        if (parentPath.Resource == null) return null;
+        if (parentPath.Resource == null) return (null, null);
+        
+        if (parentPath.Customer != customerId)
+        {
+            return (UpsertErrorHelper.CustomerIdDoesNotMatchCaller<T>("parent", parentPath.Customer!.Value, customerId), null);
+        }
 
         if (!parentPath.Hierarchical)
         {
-            return await dbContext.RetrieveCollectionAsync(customerId, parentPath.Resource,
-                cancellationToken: cancellationToken);
+            return (null, await dbContext.RetrieveCollectionAsync(customerId, parentPath.Resource,
+                cancellationToken: cancellationToken));
         }
         
         var parentHierarchy = await dbContext.RetrieveHierarchy(customerId, parentPath.Resource,
@@ -181,7 +201,7 @@ public class ParentSlugParser(PresentationContext dbContext,
         
         if (parent != null) parent.Hierarchy.GetCanonical().FullPath = parentPath.Resource;
         
-        return parent;
+        return (null, parent);
     }
 
     private string GetBaseUrl() => contextAccessor.HttpContext!.Request.GetBaseUrl();

--- a/src/IIIFPresentation/API/Helpers/ParentSlugParser.cs
+++ b/src/IIIFPresentation/API/Helpers/ParentSlugParser.cs
@@ -114,7 +114,7 @@ public class ParentSlugParser(PresentationContext dbContext,
             CancellationToken cancellationToken) where T : JsonLdBase
     {
         // Try and get a parent from publicId 
-        var publicIdParent = await GetParentFromPublicId<T>(presentation, customerId, cancellationToken);
+        var publicIdParent = await RetrieveParent<T>(presentation, customerId, true, cancellationToken);
         
         if (publicIdParent.Errors != null) return publicIdParent;
 
@@ -122,7 +122,7 @@ public class ParentSlugParser(PresentationContext dbContext,
         if (presentation.Parent == null) return publicIdParent;
 
         // We have Parent property - find Collection for that 
-        var parent = await RetrieveParentFromPresentation<T>(presentation, customerId, cancellationToken);
+        var parent = await RetrieveParent<T>(presentation, customerId, false, cancellationToken);
         
         if (parent.Errors != null) return parent; 
 
@@ -136,72 +136,53 @@ public class ParentSlugParser(PresentationContext dbContext,
 
         return parent;
     }
-
-    private async Task<ParsedParent<T>> 
-        GetParentFromPublicId<T>(
+    
+    private async Task<ParsedParent<T>> RetrieveParent<T>(
             IPresentation presentation,
             int customerId, 
+            bool fromPublicId, 
             CancellationToken cancellationToken)  where T : JsonLdBase
     {
-        if (presentation.PublicId == null) return new ParsedParent<T>();
-
-        // Lookup the parent Collection, handling Api and Public paths
-        var publicIdParentUri = PathParser.GetParentUriFromPublicId(presentation.PublicId);
+        Uri? parentUri;
+        if (fromPublicId)
+        {
+            if (presentation.PublicId == null) return new ParsedParent<T>();
+            parentUri = PathParser.GetParentUriFromPublicId(presentation.PublicId);
+        }
+        else
+        {
+            if (Uri.TryCreate(presentation.Parent, UriKind.Absolute, out parentUri) is not true) return new ParsedParent<T>();
+        }
 
         try
         {
             var parentPath =
-                pathRewriteParser.ParsePathWithRewrites(publicIdParentUri.Host, publicIdParentUri.AbsolutePath,
+                pathRewriteParser.ParsePathWithRewrites(parentUri.Host, parentUri.AbsolutePath,
                     customerId);
             
             if (parentPath.Resource == null) return new ParsedParent<T>();
 
             if (parentPath.Customer != customerId)
             {
-                return ParsedParent<T>.Fail(UpsertErrorHelper.CustomerIdDoesNotMatchCaller<T>("publicId", parentPath.Customer!.Value, customerId));
+                return ParsedParent<T>.Fail(UpsertErrorHelper.CustomerIdDoesNotMatchCaller<T>("publicId"));
             }
             
-            var publicIdParentHierarchy =
+            if (!parentPath.Hierarchical)
+            {
+                return ParsedParent<T>.Success(await dbContext.RetrieveCollectionAsync(customerId, parentPath.Resource,
+                    cancellationToken: cancellationToken));
+            }
+            
+            var parentHierarchy =
                 await dbContext.RetrieveHierarchy(customerId, parentPath.Resource, cancellationToken);
-            var publicIdParent = publicIdParentHierarchy?.Collection;
-            return ParsedParent<T>.Success(publicIdParent);
+            var parent = parentHierarchy?.Collection;
+            return ParsedParent<T>.Success(parent);
         }
         catch (FormatException fe)
         {
             logger.LogDebug(fe, "Cannot parse parent from public id");
             return new ParsedParent<T>();
         }
-    }
-    
-    private async Task<ParsedParent<T>> 
-        RetrieveParentFromPresentation<T>(
-            IPresentation presentation, 
-            int customerId,
-            CancellationToken cancellationToken) where T : JsonLdBase
-    {
-        if (Uri.TryCreate(presentation.Parent, UriKind.Absolute, out var parentUri) is not true) return new ParsedParent<T>();
-        var parentPath = pathRewriteParser.ParsePathWithRewrites(parentUri.Host, parentUri.AbsolutePath, customerId);
-
-        if (parentPath.Resource == null) return new ParsedParent<T>();
-        
-        if (parentPath.Customer != customerId)
-        {
-            return ParsedParent<T>.Fail(UpsertErrorHelper.CustomerIdDoesNotMatchCaller<T>("parent", parentPath.Customer!.Value, customerId));
-        }
-
-        if (!parentPath.Hierarchical)
-        {
-            return ParsedParent<T>.Success(await dbContext.RetrieveCollectionAsync(customerId, parentPath.Resource,
-                cancellationToken: cancellationToken));
-        }
-        
-        var parentHierarchy = await dbContext.RetrieveHierarchy(customerId, parentPath.Resource,
-            cancellationToken);
-        var parent = parentHierarchy?.Collection;
-        
-        if (parent != null) parent.Hierarchy.GetCanonical().FullPath = parentPath.Resource;
-        
-        return ParsedParent<T>.Success(parent);
     }
 
     private class ParsedParent<T> where T : JsonLdBase

--- a/src/IIIFPresentation/API/Helpers/ParentSlugParser.cs
+++ b/src/IIIFPresentation/API/Helpers/ParentSlugParser.cs
@@ -53,14 +53,14 @@ public class ParentSlugParser(PresentationContext dbContext,
             return ParsedParentSlugResult<T>.Fail(slugErrors);
         }
 
-        var (parentErrors, parent) = await TryGetParent<T>(presentation, customerId, cancellationToken);
-        if (parentErrors != null)
+        var parent = await TryGetParent<T>(presentation, customerId, cancellationToken);
+        if (parent.Errors != null)
         {
-            return ParsedParentSlugResult<T>.Fail(parentErrors);
+            return ParsedParentSlugResult<T>.Fail(parent.Errors);
         }
 
         return ParsedParentSlugResult<T>.Success(
-            new ParsedParentSlug(parent.ThrowIfNull(nameof(parent)), slug.ThrowIfNull(nameof(slug)))
+            new ParsedParentSlug(parent.Parent.ThrowIfNull(nameof(parent)), slug.ThrowIfNull(nameof(slug)))
         );
     }
 
@@ -92,22 +92,22 @@ public class ParentSlugParser(PresentationContext dbContext,
         return (null, slug);
     }
 
-    private async Task<(ModifyEntityResult<T, ModifyCollectionType>? errors, Collection? parent)>
+    private async Task<ParsedParent<T>>
         TryGetParent<T>(IPresentation presentation, int customerId, CancellationToken cancellationToken)
         where T : JsonLdBase
     {
-        var (parentErrors, parent) =
+        var parent =
             await TryGetParentFromPresentation<T>(presentation, customerId, cancellationToken);
-        if (parentErrors != null) return (parentErrors, parent);
+        if (parent.Errors != null) return parent;
 
         // Passed values match, validate parent can be used
-        var parentValidationError = ParentValidator.ValidateParentCollection<T>(parent);
-        if (parentValidationError != null) return (parentValidationError, null);
+        var parentValidationError = ParentValidator.ValidateParentCollection<T>(parent.Parent);
+        if (parentValidationError != null) return ParsedParent<T>.Fail(parentValidationError);
 
-        return (null, parent);
+        return parent;
     }
 
-    private async Task<(ModifyEntityResult<T, ModifyCollectionType>? errors, Collection? parent)>
+    private async Task<ParsedParent<T>>
         TryGetParentFromPresentation<T>(
             IPresentation presentation,
             int customerId,
@@ -119,7 +119,7 @@ public class ParentSlugParser(PresentationContext dbContext,
         if (publicIdParent.Errors != null) return publicIdParent;
 
         // If we don't have parent, return what we could parse from publicId 
-        if (presentation.Parent == null) return (null, publicIdParent.Parent);
+        if (presentation.Parent == null) return publicIdParent;
 
         // We have Parent property - find Collection for that 
         var parent = await RetrieveParentFromPresentation<T>(presentation, customerId, cancellationToken);
@@ -131,19 +131,19 @@ public class ParentSlugParser(PresentationContext dbContext,
         {
             logger.LogDebug("PublicId parent '{PublicIdParent}' and explicit parent {Parent} do not match",
                 presentation.PublicId, presentation.Parent);
-            return (UpsertErrorHelper.ParentMustMatchPublicId<T>(), null);
+            return ParsedParent<T>.Fail(UpsertErrorHelper.ParentMustMatchPublicId<T>());
         }
 
-        return (null, parent.Parent);
+        return parent;
     }
 
-    private async Task<(ModifyEntityResult<T, ModifyCollectionType>? Errors, Collection? Parent)> 
+    private async Task<ParsedParent<T>> 
         GetParentFromPublicId<T>(
             IPresentation presentation,
             int customerId, 
             CancellationToken cancellationToken)  where T : JsonLdBase
     {
-        if (presentation.PublicId == null) return (null, null);
+        if (presentation.PublicId == null) return new ParsedParent<T>();
 
         // Lookup the parent Collection, handling Api and Public paths
         var publicIdParentUri = PathParser.GetParentUriFromPublicId(presentation.PublicId);
@@ -154,44 +154,44 @@ public class ParentSlugParser(PresentationContext dbContext,
                 pathRewriteParser.ParsePathWithRewrites(publicIdParentUri.Host, publicIdParentUri.AbsolutePath,
                     customerId);
             
-            if (parentPath.Resource == null) return (null, null);
+            if (parentPath.Resource == null) return new ParsedParent<T>();
 
             if (parentPath.Customer != customerId)
             {
-                return (UpsertErrorHelper.CustomerIdDoesNotMatchCaller<T>("publicId", parentPath.Customer!.Value, customerId), null);
+                return ParsedParent<T>.Fail(UpsertErrorHelper.CustomerIdDoesNotMatchCaller<T>("publicId", parentPath.Customer!.Value, customerId));
             }
             
             var publicIdParentHierarchy =
                 await dbContext.RetrieveHierarchy(customerId, parentPath.Resource, cancellationToken);
             var publicIdParent = publicIdParentHierarchy?.Collection;
-            return (null, publicIdParent);
+            return ParsedParent<T>.Success(publicIdParent);
         }
         catch (FormatException fe)
         {
             logger.LogDebug(fe, "Cannot parse parent from public id");
-            return (null, null);
+            return new ParsedParent<T>();
         }
     }
     
-    private async Task<(ModifyEntityResult<T, ModifyCollectionType>? Errors, Collection? Parent)> 
+    private async Task<ParsedParent<T>> 
         RetrieveParentFromPresentation<T>(
             IPresentation presentation, 
             int customerId,
             CancellationToken cancellationToken) where T : JsonLdBase
     {
-        if (Uri.TryCreate(presentation.Parent, UriKind.Absolute, out var parentUri) is not true) return (null, null);
+        if (Uri.TryCreate(presentation.Parent, UriKind.Absolute, out var parentUri) is not true) return new ParsedParent<T>();
         var parentPath = pathRewriteParser.ParsePathWithRewrites(parentUri.Host, parentUri.AbsolutePath, customerId);
 
-        if (parentPath.Resource == null) return (null, null);
+        if (parentPath.Resource == null) return new ParsedParent<T>();
         
         if (parentPath.Customer != customerId)
         {
-            return (UpsertErrorHelper.CustomerIdDoesNotMatchCaller<T>("parent", parentPath.Customer!.Value, customerId), null);
+            return ParsedParent<T>.Fail(UpsertErrorHelper.CustomerIdDoesNotMatchCaller<T>("parent", parentPath.Customer!.Value, customerId));
         }
 
         if (!parentPath.Hierarchical)
         {
-            return (null, await dbContext.RetrieveCollectionAsync(customerId, parentPath.Resource,
+            return ParsedParent<T>.Success(await dbContext.RetrieveCollectionAsync(customerId, parentPath.Resource,
                 cancellationToken: cancellationToken));
         }
         
@@ -201,7 +201,19 @@ public class ParentSlugParser(PresentationContext dbContext,
         
         if (parent != null) parent.Hierarchy.GetCanonical().FullPath = parentPath.Resource;
         
-        return (null, parent);
+        return ParsedParent<T>.Success(parent);
+    }
+
+    private class ParsedParent<T> where T : JsonLdBase
+    {
+        public Collection? Parent { get; private init; }
+        
+        public ModifyEntityResult<T, ModifyCollectionType>? Errors { get; private init; }
+        
+        public static ParsedParent<T> Fail(ModifyEntityResult<T, ModifyCollectionType> errors) =>
+            new() { Errors = errors};
+        
+        public static ParsedParent<T> Success(Collection? parent) => new() { Parent = parent };
     }
 
     private string GetBaseUrl() => contextAccessor.HttpContext!.Request.GetBaseUrl();

--- a/src/IIIFPresentation/Models/API/General/ModifyCollectionType.cs
+++ b/src/IIIFPresentation/Models/API/General/ModifyCollectionType.cs
@@ -27,5 +27,6 @@ public enum ModifyCollectionType
     PaintableAssetError = 23,
     AssetError = 24,
     AssetsDoNotMatch = 25,
+    CustomerIdDoesNotMatchCaller = 26,
     Unknown = 1000
 }

--- a/src/IIIFPresentation/Services.Tests/Manifests/ManifestPaintedResourceParserTests.cs
+++ b/src/IIIFPresentation/Services.Tests/Manifests/ManifestPaintedResourceParserTests.cs
@@ -39,14 +39,15 @@ public class ManifestPaintedResourceParserTests
         => sut.ParseToCanvasPainting(new PresentationManifest(), CustomerId).Should().BeEmpty();
 
     [Theory]
-    [InlineData("https://foo.com/example/1/canvases/canvas")]
-    [InlineData("https://default.com/additionalElement/1/canvases/canvas")]
-    [InlineData("https://dlcs.example/1/random/foo/bar/baz")]
-    [InlineData("https://invalid/format")]
-    [InlineData("https://dlcs.example/1/canvases/")]
-    [InlineData("https://dlcs.example/1/canvases")]
-    [InlineData("https://dlcs.example/1/canvases/canvas/")]
-    public void Parse_Throws_InvalidCanvasId(string canvasId)
+    [InlineData("https://foo.com/example/1234/canvases/canvas", "Canvas Id /example/1234/canvases/canvas is not valid")]
+    [InlineData("https://default.com/additionalElement/1234/canvases/canvas", "Canvas Id /additionalElement/1234/canvases/canvas is not valid")]
+    [InlineData("https://dlcs.example/1234/random/foo/bar/baz", "Canvas id contains a prohibited character. Cannot contain any of: '/','=',','")]
+    [InlineData("https://invalid/format", "Canvas Id /format is not valid")]
+    [InlineData("https://dlcs.example/1234/canvases/", "Canvas Id /1234/canvases/ is not valid")]
+    [InlineData("https://dlcs.example/1234/canvases", "Canvas Id /1234/canvases is not valid")]
+    [InlineData("https://dlcs.example/1234/canvases/canvas/", "Canvas id contains a prohibited character. Cannot contain any of: '/','=',','")]
+    [InlineData("https://default.com/1/canvases/canvas", "The customer parsed from the canvas id (1) does not match the calling customer (1234)")]
+    public void Parse_Throws_InvalidCanvasId(string canvasId, string message)
     {
         var manifest = new PresentationManifest
         {
@@ -61,15 +62,15 @@ public class ManifestPaintedResourceParserTests
         };
 
         Action action = () => sut.ParseToCanvasPainting(manifest, CustomerId);
-        action.Should().Throw<InvalidCanvasIdException>();
+        action.Should().Throw<InvalidCanvasIdException>().WithMessage(message);
     }
     
     [Theory]
-    [InlineData("https://default.com/1/canvases/canvas")]
-    [InlineData("https://foo.com/foo/1/canvases/canvas")]
+    [InlineData("https://default.com/1234/canvases/canvas")]
+    [InlineData("https://foo.com/foo/1234/canvases/canvas")]
     [InlineData("https://no-customer.com/canvases/canvas")]
     [InlineData("https://additional-path-no-customer.com/foo/canvases/canvas")]
-    [InlineData("https://dlcs.example/1/canvases/canvas?foo=bar")]
+    [InlineData("https://dlcs.example/1234/canvases/canvas?foo=bar")]
     [InlineData("canvas")]
     public void Parse_Parses_WhenRewrittenCanvasId(string canvasId)
     {

--- a/src/IIIFPresentation/Services.Tests/Manifests/ManifestPaintedResourceParserTests.cs
+++ b/src/IIIFPresentation/Services.Tests/Manifests/ManifestPaintedResourceParserTests.cs
@@ -46,7 +46,7 @@ public class ManifestPaintedResourceParserTests
     [InlineData("https://dlcs.example/1234/canvases/", "Canvas Id /1234/canvases/ is not valid")]
     [InlineData("https://dlcs.example/1234/canvases", "Canvas Id /1234/canvases is not valid")]
     [InlineData("https://dlcs.example/1234/canvases/canvas/", "Canvas id contains a prohibited character. Cannot contain any of: '/','=',','")]
-    [InlineData("https://default.com/1/canvases/canvas", "The customer parsed from the canvas id (1) does not match the calling customer (1234)")]
+    [InlineData("https://default.com/1/canvases/canvas", "The customer parsed from the canvas id does not match the customer found from the calling URL")]
     public void Parse_Throws_InvalidCanvasId(string canvasId, string message)
     {
         var manifest = new PresentationManifest

--- a/src/IIIFPresentation/Services/Manifests/ManifestPaintedResourceParser.cs
+++ b/src/IIIFPresentation/Services/Manifests/ManifestPaintedResourceParser.cs
@@ -122,7 +122,7 @@ public class ManifestPaintedResourceParser(
         if (customerId != parsedCanvasId.Customer)
         {
             throw new InvalidCanvasIdException(canvasPainting.CanvasId,
-                $"The customer parsed from the canvas id ({parsedCanvasId.Customer}) does not match the calling customer ({customerId})");
+                $"The customer parsed from the canvas id does not match the customer found from the calling URL");
         }
 
         return parsedCanvasId.Resource;

--- a/src/IIIFPresentation/Services/Manifests/ManifestPaintedResourceParser.cs
+++ b/src/IIIFPresentation/Services/Manifests/ManifestPaintedResourceParser.cs
@@ -1,4 +1,5 @@
-﻿using Core.Helpers;
+﻿using Core.Exceptions;
+using Core.Helpers;
 using Microsoft.Extensions.Logging;
 using Models.API.Manifest;
 using Models.DLCS;
@@ -115,7 +116,14 @@ public class ManifestPaintedResourceParser(
         }
         
         var parsedCanvasId = pathRewriteParser.ParsePathWithRewrites(canvasId.Host, canvasId.AbsolutePath, customerId);
+        
         CanvasHelper.CheckParsedCanvasIdForErrors(parsedCanvasId, canvasId.AbsolutePath, logger);
+        
+        if (customerId != parsedCanvasId.Customer)
+        {
+            throw new InvalidCanvasIdException(canvasPainting.CanvasId,
+                $"The customer parsed from the canvas id ({parsedCanvasId.Customer}) does not match the calling customer ({customerId})");
+        }
 
         return parsedCanvasId.Resource;
     }


### PR DESCRIPTION
Resolves #527 

Adds checks on differing customer id to the following values:

- canvas id
- parent
- public id

Now if there's a difference between the calling customer id vs an FQDN, an error will be returned to the user in painted resources and parent/public id

By contrast, if there's an incorrect customer id in `items`, a random canvas id is generated as this could be a customer dropping somebody else's manifest into the system