### PR TITLE
Stop manifest converter from matching the incorrect canvas

### DIFF
--- a/src/IIIFPresentation/API.Tests/Converters/ManifestConverterTests.cs
+++ b/src/IIIFPresentation/API.Tests/Converters/ManifestConverterTests.cs
@@ -4,6 +4,7 @@ using DLCS;
 using IIIF.Presentation.V3;
 using IIIF.Presentation.V3.Annotation;
 using IIIF.Presentation.V3.Content;
+using IIIF.Presentation.V3.Traversal;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Models.API.Manifest;
@@ -717,12 +718,10 @@ public class ManifestConverterTests
                                         {
                                             Id = $"{canvasId}/image/1"
                                         },
-
                                         new Image
                                         {
                                             Id = $"{canvasId}/image/2"
                                         }
-
                                     ]
                                 }
                             }
@@ -766,9 +765,9 @@ public class ManifestConverterTests
         var first = result.First();
         var last = result.Last();
         
-        first.Items.First().Items.First().As<PaintingAnnotation>().Body.Should().BeOfType<PaintingChoice>();
+        first.AllAnnotations().First().As<PaintingAnnotation>().Body.Should().BeOfType<PaintingChoice>();
         first.Id.Should().Be(canvasId);
-        last.Items.First().Items.First().As<PaintingAnnotation>().Body.Should().BeNull();
+        last.AllAnnotations().First().As<PaintingAnnotation>().Body.Should().BeNull();
         last.Id.Should().Be("http://base/123/canvases/assetId3");
     }
 }

--- a/src/IIIFPresentation/API.Tests/Converters/ManifestConverterTests.cs
+++ b/src/IIIFPresentation/API.Tests/Converters/ManifestConverterTests.cs
@@ -696,39 +696,41 @@ public class ManifestConverterTests
         // Arrange
         var customer = 123;
         
-        var canvases = new List<Canvas>
-        {
+        List<Canvas> canvases =
+        [
             new()
             {
                 Id = canvasId,
-                Items = 
+                Items =
                 [
                     new AnnotationPage
                     {
-                        Items = new List<IAnnotation>
-                        {
+                        Items =
+                        [
                             new PaintingAnnotation
                             {
                                 Body = new PaintingChoice
                                 {
-                                    Items = new List<IPaintable>
-                                    {
+                                    Items = (List<IPaintable>)
+                                    [
                                         new Image
                                         {
                                             Id = $"{canvasId}/image/1"
                                         },
+
                                         new Image
                                         {
                                             Id = $"{canvasId}/image/2"
-                                        },
-                                    }
+                                        }
+
+                                    ]
                                 }
                             }
-                        }
+                        ]
                     }
                 ]
             }
-        };
+        ];
 
         var canvasPaintings = new List<CanvasPainting>
         {

--- a/src/IIIFPresentation/API.Tests/Converters/ManifestConverterTests.cs
+++ b/src/IIIFPresentation/API.Tests/Converters/ManifestConverterTests.cs
@@ -687,4 +687,86 @@ public class ManifestConverterTests
         firstCanvas.Homepage.First().Id.Should().Be("https://foo.com/0/homepage/foo");
         result.First().Homepage.Should().NotBeNull();
     }
+    
+    [Theory]
+    [InlineData("https://foo.com/123/canvases/foo")] // able to be parsed for id
+    [InlineData("https://foo.com/foo")] // not able to be parsed for id
+    public void GenerateProvisionalCanvases_SetsCanvasPaintings_WhenMixingItemsAndCanvaPaintingsWithNoMatching(string canvasId)
+    {
+        // Arrange
+        var customer = 123;
+        
+        var canvases = new List<Canvas>
+        {
+            new()
+            {
+                Id = canvasId,
+                Items = 
+                [
+                    new AnnotationPage
+                    {
+                        Items = new List<IAnnotation>
+                        {
+                            new PaintingAnnotation
+                            {
+                                Body = new PaintingChoice
+                                {
+                                    Items = new List<IPaintable>
+                                    {
+                                        new Image
+                                        {
+                                            Id = $"{canvasId}/image/1"
+                                        },
+                                        new Image
+                                        {
+                                            Id = $"{canvasId}/image/2"
+                                        },
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+        };
+
+        var canvasPaintings = new List<CanvasPainting>
+        {
+            new()
+            {
+                ChoiceOrder = 1,
+                CanvasOrder = 1,
+                CanvasOriginalId = new Uri(canvasId),
+                CustomerId = customer,
+                Id = "random1"
+            },
+            new()
+            {
+                ChoiceOrder = 2,
+                CanvasOrder = 1,
+                CanvasOriginalId = new Uri(canvasId),
+                CustomerId = customer,
+                Id = "random1"
+            },
+            new()
+            {
+                CanvasOrder = 2,
+                AssetId = new AssetId(1, 2, "assetId3"),
+                CustomerId = customer,
+                Id = "assetId3"
+            }
+        };
+        
+        // Act
+        var result = canvasPaintings.GenerateProvisionalCanvases(pathGenerator, canvases, pathRewriteParser);
+
+        // Assert
+        var first = result.First();
+        var last = result.Last();
+        
+        first.Items.First().Items.First().As<PaintingAnnotation>().Body.Should().BeOfType<PaintingChoice>();
+        first.Id.Should().Be(canvasId);
+        last.Items.First().Items.First().As<PaintingAnnotation>().Body.Should().BeNull();
+        last.Id.Should().Be("http://base/123/canvases/assetId3");
+    }
 }

--- a/src/IIIFPresentation/API.Tests/Features/Manifest/Validators/PresentationManifestValidatorTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Manifest/Validators/PresentationManifestValidatorTests.cs
@@ -489,4 +489,27 @@ public class PresentationManifestValidatorTests
         result.ShouldHaveValidationErrorFor(m => m.PaintedResources)
             .WithErrorMessage("Painted resources cannot have a null 'choiceOrder' within a detected choice construct");
     }
+    
+    [Fact]
+    public void PaintedResource_Manifest_Error_WhenDuplicateCanvasId()
+    {
+        var manifest = new PresentationManifest
+        {
+            Items = 
+            [
+                new Canvas
+                {
+                    Id = "someCanvasId-1"
+                },
+                new Canvas
+                {
+                    Id = "someCanvasId-1"
+                }
+            ]
+        };
+        
+        var result = sut.TestValidate(manifest);
+        result.ShouldHaveValidationErrorFor(m => m.Items)
+            .WithErrorMessage("The id in 'items' contains duplicates, which is not allowed");
+    }
 }

--- a/src/IIIFPresentation/API/Converters/ManifestConverter.cs
+++ b/src/IIIFPresentation/API/Converters/ManifestConverter.cs
@@ -96,7 +96,7 @@ public static class ManifestConverter
             // Incoming grouping is by canvasId - so could contain 1:n paintingAnnos, some of which are choices
             var canvasPainting = groupedCanvasPaintings.First();
             var canvasIdFromCanvases = existingCanvases.Select(c =>
-                (canvasId: pathRewriteParser.ParsePathWithRewrites(c.Id, canvasPainting.CustomerId).Resource ?? canvasPainting.Id, canvas: c));
+                (canvasId: pathRewriteParser.ParsePathWithRewrites(c.Id, canvasPainting.CustomerId).Resource ?? c.Id, canvas: c));
             
             // if there's a canvas original id, it means items only
             if (canvasPainting.CanvasOriginalId != null)

--- a/src/IIIFPresentation/API/Features/Manifest/Validators/PresentationManifestValidator.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/Validators/PresentationManifestValidator.cs
@@ -14,6 +14,11 @@ public class PresentationManifestValidator : AbstractValidator<PresentationManif
     {
         When(m => !m.PaintedResources.IsNullOrEmpty(), PaintedResourcesValidation);
         RuleFor(c => c).SetValidator(new PresentationValidator());
+        
+        RuleFor(m => m.Items)
+            .Must(i => i.DistinctBy(c => c.Id).Count() == i.Count)
+            .When(m => !m.Items.IsNullOrEmpty())
+            .WithMessage("The id in 'items' contains duplicates, which is not allowed");
     }
 
     // Validation rules specific to PaintedResources only
@@ -36,7 +41,7 @@ public class PresentationManifestValidator : AbstractValidator<PresentationManif
                 .Any(grp => grp.Select(pr => pr.CanvasPainting.CanvasId).Distinct().Count() > 1))
             .When(m => !m.PaintedResources.Any(pr => pr.CanvasPainting == null))
             .WithMessage("Canvases that share 'canvasOrder' must have same 'canvasId'");
-        
+            
         RuleFor(m => m.PaintedResources)
             .Must(lpr => !lpr
                 .GroupBy(pr => pr.CanvasPainting.CanvasOrder)
@@ -68,5 +73,5 @@ public class PresentationManifestValidator : AbstractValidator<PresentationManif
             .Must(pr => pr.CanvasPainting!.StaticHeight.HasValue == pr.CanvasPainting.StaticWidth.HasValue)
             .WithMessage(
                 "'static_width' and 'static_height' have to be both set or both absent within a 'canvasPainting'");
-    }
+     }
 }


### PR DESCRIPTION
Resolves #563 

The issue was that the `ManifestConverter` was falling back to using the `canvasPainting` id instead of the canvas id if the path could not be parsed.  This caused an issue where a canvas was matched with a `canvasPainting` when it shouldn't have been

Additionally, there has been a validator added that disallows multiple canvases with the same id