### PR TITLE
Automatically filter queries by customer id

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,5 @@ The general hierarchy of dependencies from lowest to highest are as follows:
 This project takes advantage of a global query filter to filter all queries on the database by customer id automatically, so that it does not need to be specified on queries.  This is because the vast majority (if not all) require filtering by customer id and it's better to avoid issues with missing this filter out. 
 
 Some tests do require checking other customers than the one set for retrieval, and this can be done by using `.IgnoreQueryFilters` on the query to allow querying without the global query filter.
+
+Adding this query filter to tables in the database is controlled using the `ICustomerEntity` interface.  By implementing this interface, everything will automatically be pulled through that is required to get the global query filter working.

--- a/README.md
+++ b/README.md
@@ -91,4 +91,4 @@ This project takes advantage of a global query filter to filter all queries on t
 
 Some tests do require checking other customers than the one set for retrieval, and this can be done by using `.IgnoreQueryFilters` on the query to allow querying without the global query filter.
 
-Adding this query filter to tables in the database is controlled using the `ICustomerEntity` interface.  By implementing this interface, everything will automatically be pulled through that is required to get the global query filter working.
+Adding this query filter to entities in the context is controlled using the `ICustomerEntity` interface.  By implementing this interface, everything will automatically be pulled through that is required to get the global query filter working.

--- a/README.md
+++ b/README.md
@@ -84,3 +84,9 @@ The general hierarchy of dependencies from lowest to highest are as follows:
 | AWS, Repository, DLCS |
 | Services |
 | API, BackgroundHandler |
+
+#### Global query filters
+
+This project takes advantage of a global query filter to filter all queries on the database by customer id automatically, so that it does not need to be specified on queries.  This is because the vast majority (if not all) require filtering by customer id and it's better to avoid issues with missing this filter out. 
+
+Some tests do require checking other customers than the one set for retrieval, and this can be done by using `.IgnoreQueryFilters` on the query to allow querying without the global query filter.

--- a/src/IIIFPresentation/API.Tests/Features/Manifest/ManagedAssetResultFinderTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Manifest/ManagedAssetResultFinderTests.cs
@@ -31,7 +31,7 @@ public class ManagedAssetResultFinderTests
     public ManagedAssetResultFinderTests(PresentationContextFixture dbFixture)
     {
         dbContext = dbFixture.DbContext;
-        dbFixture.CustomerIdProvider.SetCustomerId(DefaultCustomer);
+        dbFixture.CustomerIdProvider.SetCustomerId(PresentationContextFixture.CustomerId);
         
         dlcsApiClient = A.Fake<IDlcsApiClient>();
         

--- a/src/IIIFPresentation/API.Tests/Features/Manifest/ManagedAssetResultFinderTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Manifest/ManagedAssetResultFinderTests.cs
@@ -31,6 +31,7 @@ public class ManagedAssetResultFinderTests
     public ManagedAssetResultFinderTests(PresentationContextFixture dbFixture)
     {
         dbContext = dbFixture.DbContext;
+        dbFixture.CustomerIdProvider.SetCustomerId(DefaultCustomer);
         
         dlcsApiClient = A.Fake<IDlcsApiClient>();
         

--- a/src/IIIFPresentation/API.Tests/Features/Manifest/ManifestWriteServiceTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Manifest/ManifestWriteServiceTests.cs
@@ -50,6 +50,8 @@ public class ManifestWriteServiceTests
     public ManifestWriteServiceTests(PresentationContextFixture dbFixture)
     {
         presentationContext = dbFixture.DbContext;
+        dbFixture.CustomerIdProvider.SetCustomerId(Customer);
+        
         dlcsSettings = DefaultSettings.DlcsSettings();
 
         var typedPathTemplateOptions = Options.Create(PathRewriteOptions.Default);
@@ -108,7 +110,7 @@ public class ManifestWriteServiceTests
             manifestStorageManager, pathRewriteParser, new NullLogger<ManifestWriteService>());
 
         var parentCollection =
-            presentationContext.Collections.First(x => x.CustomerId == Customer && x.Id == RootCollection.Id);
+            presentationContext.Collections.First(x => x.Id == RootCollection.Id);
 
         A.CallTo(() =>
             parentSlugParser.Parse(A<PresentationManifest>._, A<int>._, A<string>._,

--- a/src/IIIFPresentation/API.Tests/Helpers/ParentSlugParserTests.cs
+++ b/src/IIIFPresentation/API.Tests/Helpers/ParentSlugParserTests.cs
@@ -27,6 +27,7 @@ public class ParentSlugParserTests
     public ParentSlugParserTests(PresentationContextFixture dbFixture)
     {
         presentationContext = dbFixture.DbContext;
+        dbFixture.CustomerIdProvider.SetCustomerId(Customer);
         
         var httpContextAccessor = A.Fake<IHttpContextAccessor>();
         httpContextAccessor.HttpContext = A.Fake<HttpContext>();

--- a/src/IIIFPresentation/API.Tests/Helpers/PresentationContextXTests.cs
+++ b/src/IIIFPresentation/API.Tests/Helpers/PresentationContextXTests.cs
@@ -22,7 +22,7 @@ public class PresentationContextXTests
     [Fact]
     public void RetrieveCollectionItems_ReturnsCanonicalOnlyManifestAndCollection()
     {
-        var result = dbContext.RetrieveCollectionItems(PresentationContextFixture.CustomerId, "root");
+        var result = dbContext.RetrieveCollectionItems("root");
         var expectedSlugs = new[]
         {
             "first-child",
@@ -40,7 +40,7 @@ public class PresentationContextXTests
     [Fact]
     public void RetrieveCollectionItems_CanExcludeNonPublicCollectionsAndProcessingManifests()
     {
-        var result = dbContext.RetrieveCollectionItems(PresentationContextFixture.CustomerId, "root", true);
+        var result = dbContext.RetrieveCollectionItems("root", true);
         var expectedSlugs = new[] { "first-child", "iiif-collection", "iiif-collection-with-items", "iiif-manifest" };
 
         result.Count().Should().Be(4);
@@ -50,7 +50,7 @@ public class PresentationContextXTests
     [Fact]
     public void RetrieveCollectionItems_IncludesRelations()
     {
-        var result = dbContext.RetrieveCollectionItems(PresentationContextFixture.CustomerId, "root").ToList();
+        var result = dbContext.RetrieveCollectionItems("root").ToList();
 
         result.Where(r => r.Collection != null).Should().HaveCount(4);
         result.Where(r => r.Manifest != null).Should().HaveCount(2);

--- a/src/IIIFPresentation/API.Tests/Helpers/PresentationContextXTests.cs
+++ b/src/IIIFPresentation/API.Tests/Helpers/PresentationContextXTests.cs
@@ -1,5 +1,6 @@
 ﻿using API.Features.Storage.Helpers;
 using API.Tests.Integration.Infrastructure;
+using DLCS.API;
 using Repository;
 using Test.Helpers.Integration;
 
@@ -14,13 +15,14 @@ public class PresentationContextXTests
     public PresentationContextXTests(PresentationContextFixture dbFixture)
     {
         dbContext = dbFixture.DbContext;
+        dbFixture.CustomerIdProvider.SetCustomerId(PresentationContextFixture.CustomerId);
         dbFixture.CleanUp();
     }
 
     [Fact]
     public void RetrieveCollectionItems_ReturnsCanonicalOnlyManifestAndCollection()
     {
-        var result = dbContext.RetrieveCollectionItems(1, "root");
+        var result = dbContext.RetrieveCollectionItems(PresentationContextFixture.CustomerId, "root");
         var expectedSlugs = new[]
         {
             "first-child",
@@ -38,7 +40,7 @@ public class PresentationContextXTests
     [Fact]
     public void RetrieveCollectionItems_CanExcludeNonPublicCollectionsAndProcessingManifests()
     {
-        var result = dbContext.RetrieveCollectionItems(1, "root", true);
+        var result = dbContext.RetrieveCollectionItems(PresentationContextFixture.CustomerId, "root", true);
         var expectedSlugs = new[] { "first-child", "iiif-collection", "iiif-collection-with-items", "iiif-manifest" };
 
         result.Count().Should().Be(4);
@@ -48,7 +50,7 @@ public class PresentationContextXTests
     [Fact]
     public void RetrieveCollectionItems_IncludesRelations()
     {
-        var result = dbContext.RetrieveCollectionItems(1, "root").ToList();
+        var result = dbContext.RetrieveCollectionItems(PresentationContextFixture.CustomerId, "root").ToList();
 
         result.Where(r => r.Collection != null).Should().HaveCount(4);
         result.Where(r => r.Manifest != null).Should().HaveCount(2);

--- a/src/IIIFPresentation/API.Tests/Infrastructure/Helpers/HttpRequestXTests.cs
+++ b/src/IIIFPresentation/API.Tests/Infrastructure/Helpers/HttpRequestXTests.cs
@@ -1,10 +1,15 @@
 ﻿using API.Infrastructure.Helpers;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace API.Tests.Infrastructure.Helpers;
 
 public class HttpRequestXTests
 {
+    private readonly ILogger<HttpRequestXTests> logger = new NullLogger<HttpRequestXTests>();    
+    
     [Fact]
     public void HasShowExtraHeader_False_IfNotFound()
     {
@@ -66,5 +71,48 @@ public class HttpRequestXTests
         httpRequest.Headers.Link = "<https://dlcs.io/vocab#Space>;rel=\"DCTERMS.requires\"".ToLower();
 
         httpRequest.HasCreateSpaceHeader().Should().BeFalse();
+    }
+    
+    [Fact]
+    public void GetCustomerId_Null_WhenNoCustomerRouteValue()
+    {
+        // Arrange
+        var httpRequest = new DefaultHttpContext().Request;
+
+        // Act
+        var customerId = httpRequest.GetCustomerId(logger);
+
+        // Assert
+        customerId.Should().BeNull();
+    }
+    
+    [Fact]
+    public void GetCustomerId_Null_WhenCustomerRouteValueNotInteger()
+    {
+        // Arrange
+        var httpRequest = new DefaultHttpContext().Request;
+        httpRequest.RouteValues = new RouteValueDictionary { { "customerId", "something" } };
+
+        // Act
+        var customerId = httpRequest.GetCustomerId(logger);
+
+        // Assert
+        customerId.Should().BeNull();
+    }
+    
+    
+    [Fact]
+    public void GetCustomerId_ReturnsCustomerId_WhenCustomerRouteValueNotInteger()
+    {
+        // Arrange
+        var httpRequest = new DefaultHttpContext().Request;
+        var customerIdToCheck = 1;
+        httpRequest.RouteValues = new RouteValueDictionary { { "customerId", customerIdToCheck } };
+
+        // Act
+        var customerId = httpRequest.GetCustomerId(logger);
+
+        // Assert
+        customerId.Should().Be(customerIdToCheck);
     }
 }

--- a/src/IIIFPresentation/API.Tests/Infrastructure/HttpContextCustomerIdProviderTests.cs
+++ b/src/IIIFPresentation/API.Tests/Infrastructure/HttpContextCustomerIdProviderTests.cs
@@ -1,0 +1,83 @@
+﻿using API.Infrastructure;
+using Core.Exceptions;
+using FakeItEasy;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace API.Tests.Infrastructure;
+
+public class HttpContextCustomerIdProviderTests
+{
+    private static readonly IHttpContextAccessor HttpContextAccessor = A.Fake<IHttpContextAccessor>();
+    private static readonly ILogger<HttpContextCustomerIdProvider> logger = new NullLogger<HttpContextCustomerIdProvider>();
+    private readonly HttpContextCustomerIdProvider sut = new(HttpContextAccessor, logger);
+    
+    [Fact]
+    public void SetCustomerId_ThrowsException()
+    {
+        // Arrange and act
+        Action action = () => sut.SetCustomerId(1);
+        
+        // Assert
+        action.Should().Throw<PresentationException>();
+    }
+    
+    [Fact]
+    public void GetCustomerId_ThrowsException_WhenHttpContextNull()
+    {
+        // Arrange and act
+        Action action = () => sut.GetCustomerId();
+        
+        // Assert
+        action.Should().Throw<PresentationException>();
+    }
+    
+    [Fact]
+    public void GetCustomerId_ThrowsException_WhenCustomerIdNotInUrl()
+    {
+        // Arrange
+        var contextAccessor = new HttpContextAccessor
+        {
+            HttpContext = new DefaultHttpContext()
+        };
+
+        var customerIdProvider = new HttpContextCustomerIdProvider(contextAccessor, logger);
+        
+        // act
+        Action action = () => customerIdProvider.GetCustomerId();
+        
+        // Assert
+        action.Should().Throw<PresentationException>();
+    }
+    
+    [Fact]
+    public void GetCustomerId_GetsCustomerId_WhenCustomerIdNotInUrl()
+    {
+        // Arrange
+        var customerIdToTest = 1;
+        
+        var contextAccessor = new HttpContextAccessor
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                Request =
+                {
+                    RouteValues = new RouteValueDictionary
+                    {
+                        { "customerId", customerIdToTest }
+                    }
+                }
+            }
+        };
+
+        var customerIdProvider = new HttpContextCustomerIdProvider(contextAccessor, logger);
+        
+        // act
+        var customerId = customerIdProvider.GetCustomerId();
+        
+        // Assert
+        customerId.Should().Be(customerIdToTest);
+    }
+}

--- a/src/IIIFPresentation/API.Tests/Infrastructure/IdGenerator/IdentityManagerTests.cs
+++ b/src/IIIFPresentation/API.Tests/Infrastructure/IdGenerator/IdentityManagerTests.cs
@@ -18,6 +18,7 @@ public class IdentityManagerTests
     public IdentityManagerTests(PresentationContextFixture dbFixture)
     {
         idGenerator = A.Fake<IIdGenerator>();
+        dbFixture.CustomerIdProvider.SetCustomerId(PresentationContextFixture.CustomerId);
         sut = new IdentityManager(idGenerator, dbFixture.DbContext, new NullLogger<IdentityManager>());
     }
 

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyCollectionTests.cs
@@ -4,8 +4,6 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Text;
 using Amazon.S3;
-using API.Infrastructure.Helpers;
-using API.Infrastructure.Validation;
 using API.Tests.Integration.Infrastructure;
 using Core.Infrastructure;
 using Core.Response;
@@ -14,7 +12,6 @@ using IIIF.Presentation.V3.Content;
 using IIIF.Presentation.V3.Strings;
 using IIIF.Serialisation;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.DependencyInjection;
 using Models.API.Collection;
 using Models.API.General;
 using Models.Database.General;
@@ -47,7 +44,7 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
             appFactory => appFactory.WithLocalStack(storageFixture.LocalStackFixture));
         
         parent = dbContext.Collections
-            .First(x => x.CustomerId == Customer && x.Hierarchy!.Any(h => h.Slug == string.Empty)).Id;
+            .First(x => x.Hierarchy!.Any(h => h.Slug == string.Empty)).Id;
 
         storageFixture.DbFixture.CleanUp();
     }
@@ -108,7 +105,7 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
         var id = responseCollection!.Id!.Split('/', StringSplitOptions.TrimEntries).Last();
 
         var fromDatabase = dbContext.Collections.First(c => c.Id == id);
-        var hierarchyFromDatabase = dbContext.Hierarchy.First(h => h.CustomerId == 1 && h.CollectionId == id);
+        var hierarchyFromDatabase = dbContext.Hierarchy.First(h => h.CollectionId == id);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
@@ -200,7 +197,7 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
         var id = responseCollection!.Id!.Split('/', StringSplitOptions.TrimEntries).Last();
 
         var fromDatabase = dbContext.Collections.First(c => c.Id == id);
-        var hierarchyFromDatabase = dbContext.Hierarchy.First(h => h.CustomerId == 1 && h.CollectionId == id);
+        var hierarchyFromDatabase = dbContext.Hierarchy.First(h => h.CollectionId == id);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
@@ -252,10 +249,10 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
 
         // Act
         // note the current modified timestamp on this and other customer's root collection
-        var thisCustomerRootCollection = dbContext.Collections.First(c => c.CustomerId == Customer && c.Id == RootCollection.Id);
+        var thisCustomerRootCollection = dbContext.Collections.First(c => c.Id == RootCollection.Id);
         var thisCustomerRootModified = thisCustomerRootCollection.Modified;
         
-        var otherCustomerRootCollection = dbContext.Collections.First(c => c.CustomerId == otherCustomerId && c.Id == RootCollection.Id);
+        var otherCustomerRootCollection = dbContext.Collections.IgnoreQueryFilters().First(c => c.CustomerId == otherCustomerId && c.Id == RootCollection.Id);
         var otherCustomerRootModified = otherCustomerRootCollection.Modified; // save to var
         
         // make the modyfying call
@@ -264,8 +261,8 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
         var responseCollection = await response.ReadAsPresentationResponseAsync<PresentationCollection>();
         
         // get after action completed
-        thisCustomerRootCollection = dbContext.Collections.First(c => c.CustomerId == Customer && c.Id == RootCollection.Id);
-        otherCustomerRootCollection = dbContext.Collections.First(c => c.CustomerId == otherCustomerId && c.Id == RootCollection.Id);
+        thisCustomerRootCollection = dbContext.Collections.First(c => c.Id == RootCollection.Id);
+        otherCustomerRootCollection = dbContext.Collections.IgnoreQueryFilters().First(c => c.CustomerId == otherCustomerId && c.Id == RootCollection.Id);
         
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created); // action succeeded
@@ -342,7 +339,7 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
         var id = responseCollection!.Id!.Split('/', StringSplitOptions.TrimEntries).Last();
 
         var fromDatabase = dbContext.Collections.First(c => c.Id == id);
-        var hierarchyFromDatabase = dbContext.Hierarchy.First(h => h.CustomerId == 1 && h.CollectionId == id);
+        var hierarchyFromDatabase = dbContext.Hierarchy.First(h => h.CollectionId == id);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
@@ -394,7 +391,7 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
         var id = responseCollection!.Id!.Split('/', StringSplitOptions.TrimEntries).Last();
 
         var fromDatabase = dbContext.Collections.First(c => c.Id == id);
-        var hierarchyFromDatabase = dbContext.Hierarchy.First(h => h.CustomerId == 1 && h.CollectionId == id);
+        var hierarchyFromDatabase = dbContext.Hierarchy.First(h => h.CollectionId == id);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
@@ -514,7 +511,7 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
         var id = responseCollection!.Id!.Split('/', StringSplitOptions.TrimEntries).Last();
 
         var fromDatabase = dbContext.Collections.First(c => c.Id == id);
-        var hierarchyFromDatabase = dbContext.Hierarchy.First(h => h.CustomerId == 1 && h.CollectionId == id);
+        var hierarchyFromDatabase = dbContext.Hierarchy.First(h => h.CollectionId == id);
 
         var fromS3 =
             await amazonS3.GetObjectAsync(LocalStackFixture.StorageBucketName,
@@ -792,7 +789,7 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
         var id = responseCollection!.Id!.Split('/', StringSplitOptions.TrimEntries).Last();
 
         var fromDatabase = dbContext.Collections.First(c => c.Id == id);
-        var hierarchyFromDatabase = dbContext.Hierarchy.First(h => h.CustomerId == 1 && h.CollectionId == id);
+        var hierarchyFromDatabase = dbContext.Hierarchy.First(h => h.CollectionId == id);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
@@ -844,7 +841,7 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
         var id = responseCollection!.Id!.Split('/', StringSplitOptions.TrimEntries).Last();
 
         var fromDatabase = dbContext.Collections.First(c => c.Id == id);
-        var hierarchyFromDatabase = dbContext.Hierarchy.First(h => h.CustomerId == 1 && h.CollectionId == id);
+        var hierarchyFromDatabase = dbContext.Hierarchy.First(h => h.CollectionId == id);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
@@ -881,7 +878,7 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
         var id = responseCollection!.Id!.Split('/', StringSplitOptions.TrimEntries).Last();
 
         var fromDatabase = dbContext.Collections.First(c => c.Id == id);
-        var hierarchyFromDatabase = dbContext.Hierarchy.First(h => h.CustomerId == 1 && h.CollectionId == id);
+        var hierarchyFromDatabase = dbContext.Hierarchy.First(h => h.CollectionId == id);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
@@ -918,7 +915,7 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
         var id = responseCollection!.Id!.Split('/', StringSplitOptions.TrimEntries).Last();
 
         var fromDatabase = dbContext.Collections.First(c => c.Id == id);
-        var hierarchyFromDatabase = dbContext.Hierarchy.First(h => h.CustomerId == 1 && h.CollectionId == id);
+        var hierarchyFromDatabase = dbContext.Hierarchy.First(h => h.CollectionId == id);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
@@ -957,7 +954,7 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
         var id = responseCollection!.Id!.Split('/', StringSplitOptions.TrimEntries).Last();
 
         var fromDatabase = dbContext.Collections.First(c => c.Id == id);
-        var hierarchyFromDatabase = dbContext.Hierarchy.First(h => h.CustomerId == 1 && h.CollectionId == id);
+        var hierarchyFromDatabase = dbContext.Hierarchy.First(h => h.CollectionId == id);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
@@ -1213,7 +1210,7 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
         var id = responseCollection!.Id!.Split('/', StringSplitOptions.TrimEntries).Last();
 
         var fromDatabase = dbContext.Collections.First(c => c.Id == id);
-        var hierarchyFromDatabase = dbContext.Hierarchy.First(h => h.CustomerId == 1 && h.CollectionId == id);
+        var hierarchyFromDatabase = dbContext.Hierarchy.First(h => h.CollectionId == id);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -1299,7 +1296,7 @@ public class ModifyCollectionTests : IClassFixture<PresentationAppFactory<Progra
         var id = responseCollection!.Id!.Split('/', StringSplitOptions.TrimEntries).Last();
 
         var fromDatabase = dbContext.Collections.First(c => c.Id == id);
-        var hierarchyFromDatabase = dbContext.Hierarchy.First(h => h.CustomerId == 1 && h.CollectionId == id);
+        var hierarchyFromDatabase = dbContext.Hierarchy.First(h => h.CollectionId == id);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -1587,7 +1584,7 @@ $$"""
         var id = responseCollection!.Id!.Split('/', StringSplitOptions.TrimEntries).Last();
 
         var fromDatabase = dbContext.Collections.First(c => c.Id == id);
-        var hierarchyFromDatabase = dbContext.Hierarchy.First(h => h.CustomerId == 1 && h.CollectionId == id);
+        var hierarchyFromDatabase = dbContext.Hierarchy.First(h => h.CollectionId == id);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -1701,7 +1698,7 @@ $$"""
         var id = responseCollection!.Id!.Split('/', StringSplitOptions.TrimEntries).Last();
 
         var fromDatabase = dbContext.Collections.First(c => c.Id == id);
-        var hierarchyFromDatabase = dbContext.Hierarchy.First(h => h.CustomerId == 1 && h.CollectionId == id);
+        var hierarchyFromDatabase = dbContext.Hierarchy.First(h => h.CollectionId == id);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -2223,7 +2220,7 @@ $$"""
         var id = responseCollection!.Id!.Split('/', StringSplitOptions.TrimEntries).Last();
 
         var fromDatabase = dbContext.Collections.First(c => c.Id == id);
-        var hierarchyFromDatabase = dbContext.Hierarchy.First(h => h.CustomerId == 1 && h.CollectionId == id);
+        var hierarchyFromDatabase = dbContext.Hierarchy.First(h => h.CollectionId == id);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -2273,7 +2270,7 @@ $$"""
         var responseCollection = await response.ReadAsPresentationJsonAsync<IIIF.Presentation.V3.Collection>();
 
         var fromDatabase = dbContext.Collections.First(c => c.Hierarchy!.Single(h => h.Canonical).Slug == slug);
-        var hierarchyFromDatabase = dbContext.Hierarchy.First(h => h.CustomerId == 1 && h.Slug == slug);
+        var hierarchyFromDatabase = dbContext.Hierarchy.First(h => h.Slug == slug);
 
         var fromS3 =
             await amazonS3.GetObjectAsync(LocalStackFixture.StorageBucketName,
@@ -2321,7 +2318,7 @@ $$"""
         var responseCollection = await response.ReadAsPresentationJsonAsync<IIIF.Presentation.V3.Collection>();
 
         var fromDatabase = dbContext.Collections.First(c => c.Hierarchy!.Single(h => h.Canonical).Slug == slug);
-        var hierarchyFromDatabase = dbContext.Hierarchy.First(h => h.CustomerId == 1 && h.Slug == slug);
+        var hierarchyFromDatabase = dbContext.Hierarchy.First(h => h.Slug == slug);
 
         var fromS3 =
             await amazonS3.GetObjectAsync(LocalStackFixture.StorageBucketName,

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestCreateTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestCreateTests.cs
@@ -57,7 +57,7 @@ public class ModifyManifestCreateTests : IClassFixture<PresentationAppFactory<Pr
             );
 
         storageFixture.DbFixture.CleanUp();
-        if (!dbContext.Collections.Any(i => i.CustomerId == InvalidSpaceCustomer))
+        if (!dbContext.Collections.IgnoreQueryFilters().Any(i => i.CustomerId == InvalidSpaceCustomer))
         {
             dbContext.Collections.AddTestCollection(RootCollection.Id, customer: InvalidSpaceCustomer).GetAwaiter().GetResult();
             dbContext.SaveChanges();    

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyRewrittenPathTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyRewrittenPathTests.cs
@@ -7,6 +7,7 @@ using DLCS.Models;
 using FakeItEasy;
 using IIIF.Presentation.V3.Strings;
 using IIIF.Serialisation;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Models.API.Collection;
 using Models.API.General;
@@ -79,7 +80,7 @@ public class ModifyRewrittenPathTests : IClassFixture<PresentationAppFactory<Pro
 
         var id = responseCollection!.Id!.Split('/', StringSplitOptions.TrimEntries).Last();
 
-        var hierarchyFromDatabase = dbContext.Hierarchy.First(h => h.CustomerId == NoCustomerCustomer && h.CollectionId == id);
+        var hierarchyFromDatabase = dbContext.Hierarchy.IgnoreQueryFilters().First(h => h.CustomerId == NoCustomerCustomer && h.CollectionId == id);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
@@ -120,7 +121,7 @@ public class ModifyRewrittenPathTests : IClassFixture<PresentationAppFactory<Pro
 
         var id = responseCollection!.Id!.Split('/', StringSplitOptions.TrimEntries).Last();
 
-        var hierarchyFromDatabase = dbContext.Hierarchy.First(h => h.CustomerId == ExampleCustomer && h.CollectionId == id);
+        var hierarchyFromDatabase = dbContext.Hierarchy.IgnoreQueryFilters().First(h => h.CustomerId == ExampleCustomer && h.CollectionId == id);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
@@ -159,7 +160,7 @@ public class ModifyRewrittenPathTests : IClassFixture<PresentationAppFactory<Pro
         var responseCollection = await response.ReadAsPresentationResponseAsync<PresentationCollection>();
 
         var id = responseCollection!.Id!.Split('/', StringSplitOptions.TrimEntries).Last();
-        var hierarchyFromDatabase = dbContext.Hierarchy.First(h => h.CustomerId == NoCustomerCustomer && h.CollectionId == id);
+        var hierarchyFromDatabase = dbContext.Hierarchy.IgnoreQueryFilters().First(h => h.CustomerId == NoCustomerCustomer && h.CollectionId == id);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
@@ -199,8 +200,7 @@ public class ModifyRewrittenPathTests : IClassFixture<PresentationAppFactory<Pro
 
         var id = responseCollection!.Id!.Split('/', StringSplitOptions.TrimEntries).Last();
 
-        var fromDatabase = dbContext.Collections.First(c => c.Id == id);
-        var hierarchyFromDatabase = dbContext.Hierarchy.First(h => h.CustomerId == ExampleCustomer && h.CollectionId == id);
+        var hierarchyFromDatabase = dbContext.Hierarchy.IgnoreQueryFilters().First(h => h.CustomerId == ExampleCustomer && h.CollectionId == id);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
@@ -239,7 +239,7 @@ public class ModifyRewrittenPathTests : IClassFixture<PresentationAppFactory<Pro
 
         var id = responseCollection!.Id!.Split('/', StringSplitOptions.TrimEntries).Last();
         
-        var hierarchyFromDatabase = dbContext.Hierarchy.First(h => h.CustomerId == NoCustomerCustomer && h.CollectionId == id);
+        var hierarchyFromDatabase = dbContext.Hierarchy.IgnoreQueryFilters().First(h => h.CustomerId == NoCustomerCustomer && h.CollectionId == id);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
@@ -277,9 +277,8 @@ public class ModifyRewrittenPathTests : IClassFixture<PresentationAppFactory<Pro
         var responseCollection = await response.ReadAsPresentationResponseAsync<PresentationCollection>();
 
         var id = responseCollection!.Id!.Split('/', StringSplitOptions.TrimEntries).Last();
-
-        var fromDatabase = dbContext.Collections.First(c => c.Id == id);
-        var hierarchyFromDatabase = dbContext.Hierarchy.First(h => h.CustomerId == ExampleCustomer && h.CollectionId == id);
+        
+        var hierarchyFromDatabase = dbContext.Hierarchy.IgnoreQueryFilters().First(h => h.CustomerId == ExampleCustomer && h.CollectionId == id);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyRootCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyRootCollectionTests.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Models;
 using Models.API.Collection;
 using Repository;
+using Repository.Helpers;
 using Test.Helpers.Helpers;
 using Test.Helpers.Integration;
 
@@ -25,10 +26,12 @@ public class ModifyRootCollectionTests: IClassFixture<PresentationAppFactory<Pro
     private readonly HttpClient httpClient;
     private readonly PresentationContext dbContext;
     private readonly IAmazonS3 s3Client = A.Fake<IAmazonS3>();
+    private readonly ICustomerIdProvider customerIdProvider;
 
     public ModifyRootCollectionTests(PresentationContextFixture dbFixture, PresentationAppFactory<Program> factory)
     {
         dbContext = dbFixture.DbContext;
+        customerIdProvider = dbFixture.CustomerIdProvider;
 
         httpClient = factory.ConfigureBasicIntegrationTestHttpClient(dbFixture,
             additionalTestServices: collection => collection.AddSingleton(s3Client));
@@ -134,6 +137,8 @@ public class ModifyRootCollectionTests: IClassFixture<PresentationAppFactory<Pro
     public async Task Put_CanChangeLabel()
     {
         const int customer = 1234892;
+        customerIdProvider.SetCustomerId(customer);
+        
         var dbCollection = await dbContext.Collections.AddTestCollection(KnownCollections.RootCollection, customer, slug: "root", parent: null);
         await dbContext.SaveChangesAsync();
         
@@ -164,6 +169,7 @@ public class ModifyRootCollectionTests: IClassFixture<PresentationAppFactory<Pro
     public async Task Put_CanMakePrivate()
     {
         const int customer = 1234891;
+        customerIdProvider.SetCustomerId(customer);
         var dbCollection = await dbContext.Collections.AddTestCollection(KnownCollections.RootCollection, customer, slug: "root", parent: null);
         await dbContext.SaveChangesAsync();
         
@@ -192,6 +198,7 @@ public class ModifyRootCollectionTests: IClassFixture<PresentationAppFactory<Pro
     public async Task Put_CanChangeThumbnail()
     {
         const int customer = 1234890;
+        customerIdProvider.SetCustomerId(customer);
         var dbCollection = await dbContext.Collections.AddTestCollection(KnownCollections.RootCollection, customer, slug: "root", parent: null);
         await dbContext.SaveChangesAsync();
 

--- a/src/IIIFPresentation/API/Auth/DelegatedAuthenticator.cs
+++ b/src/IIIFPresentation/API/Auth/DelegatedAuthenticator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Concurrent;
 using System.Net.Http.Headers;
+using API.Infrastructure.Helpers;
 using API.Settings;
 using DLCS;
 using DLCS.API;
@@ -19,8 +20,6 @@ public class DelegatedAuthenticator(
     IAppCache appCache,
     ILogger<DelegatedAuthenticator> logger) : IAuthenticator
 {
-    private const string CustomerIdRouteValue = "customerId";
-
     public async Task<AuthResult> ValidateRequest(HttpRequest request, CancellationToken cancellationToken = default)
     {
         var headerValue = request.TryGetValidAuthHeader();
@@ -31,20 +30,10 @@ public class DelegatedAuthenticator(
             return AuthResult.NoCredentials;
         }
 
-        if (!request.RouteValues.TryGetValue(CustomerIdRouteValue, out var customerIdRouteVal)
-            || customerIdRouteVal is null)
-        {
-            logger.LogDebug("Unable to identify customerId in auth request to {Path}", request.Path);
-            return AuthResult.NoCredentials;
-        }
-        
-        if (!int.TryParse(customerIdRouteVal.ToString(), out int customerId))
-        {
-            logger.LogDebug("Specified customerId is not numeric {Path}", request.Path);
-            return AuthResult.NoCredentials;
-        }
+        var customerId = request.GetCustomerId(logger);
+        if (!customerId.HasValue) return AuthResult.NoCredentials;
 
-        return await IsValidUser(headerValue, customerId, cancellationToken)
+        return await IsValidUser(headerValue, customerId.Value, cancellationToken)
             ? AuthResult.Success
             : AuthResult.Failed;
     }

--- a/src/IIIFPresentation/API/Features/Common/Helpers/HierarchyResourceDeleter.cs
+++ b/src/IIIFPresentation/API/Features/Common/Helpers/HierarchyResourceDeleter.cs
@@ -19,7 +19,7 @@ public class HierarchyResourceDeleter(
     public async Task<ResultMessage<DeleteResult, DeleteResourceErrorType>> DeleteResource<T>(string? etagFromRequest, int customerId, 
         string resourceId, CancellationToken cancellationToken) where T : class, IHierarchyResource
     {
-        var resource = await dbContext.Set<T>().Retrieve(customerId,  resourceId, true, cancellationToken);
+        var resource = await dbContext.Set<T>().Retrieve(resourceId, true, cancellationToken);
         
         if (resource is null) return DeleteErrorHelper.NotFound();
 

--- a/src/IIIFPresentation/API/Features/Common/Helpers/HierarchyResourceDeleter.cs
+++ b/src/IIIFPresentation/API/Features/Common/Helpers/HierarchyResourceDeleter.cs
@@ -2,12 +2,10 @@
 using API.Infrastructure.Helpers;
 using AWS.Helpers;
 using Core;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.EntityFrameworkCore;
 using Models.API.General;
 using Models.Database.Collections;
 using Repository;
-using Repository.Helpers;
 
 namespace API.Features.Common.Helpers;
 
@@ -58,7 +56,7 @@ public class HierarchyResourceDeleter(
     private async Task<ResultMessage<DeleteResult, DeleteResourceErrorType>?> DeleteCollection(IHierarchyResource resource, 
         Collection collection, CancellationToken cancellationToken)
     {
-        var hasItems = await dbContext.Hierarchy.AnyAsync( c => c.Parent == collection.Id,
+        var hasItems = await dbContext.Hierarchy.AnyAsync(c => c.Parent == collection.Id,
             cancellationToken: cancellationToken);
 
         if (hasItems)

--- a/src/IIIFPresentation/API/Features/Common/Helpers/HierarchyResourceDeleter.cs
+++ b/src/IIIFPresentation/API/Features/Common/Helpers/HierarchyResourceDeleter.cs
@@ -58,8 +58,7 @@ public class HierarchyResourceDeleter(
     private async Task<ResultMessage<DeleteResult, DeleteResourceErrorType>?> DeleteCollection(IHierarchyResource resource, 
         Collection collection, CancellationToken cancellationToken)
     {
-        var hasItems = await dbContext.Hierarchy.AnyAsync(
-            c => c.CustomerId == collection.CustomerId && c.Parent == collection.Id,
+        var hasItems = await dbContext.Hierarchy.AnyAsync( c => c.Parent == collection.Id,
             cancellationToken: cancellationToken);
 
         if (hasItems)

--- a/src/IIIFPresentation/API/Features/Manifest/ManagedAssetResultFinder.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManagedAssetResultFinder.cs
@@ -191,7 +191,7 @@ public class ManagedAssetResultFinder(
         trackedAssets.AddRange(dlcsAssetIds);
 
         var missingAssets = interimCanvasPaintings.Where(icp => !trackedAssets.Any(a =>
-            icp.SuspectedAssetId == a.Asset && icp.SuspectedSpace == a.Space)).ToList();
+            icp.SuspectedAssetId == a.Asset && icp.CustomerId == a.Customer && icp.SuspectedSpace == a.Space)).ToList();
         
         if (missingAssets.Count != 0)
         {

--- a/src/IIIFPresentation/API/Features/Manifest/ManagedAssetResultFinder.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManagedAssetResultFinder.cs
@@ -166,7 +166,7 @@ public class ManagedAssetResultFinder(
         var assetsToCheckInDlcs =
             assetsToAddToManifest.Where(asset =>
             {
-                if (dbContext.CanvasPaintings.Any(cp => cp.CustomerId == customerId && cp.AssetId == asset))
+                if (dbContext.CanvasPaintings.Any(cp => cp.AssetId == asset))
                 {
                     trackedAssets.Add(asset);
                     return false;
@@ -191,7 +191,7 @@ public class ManagedAssetResultFinder(
         trackedAssets.AddRange(dlcsAssetIds);
 
         var missingAssets = interimCanvasPaintings.Where(icp => !trackedAssets.Any(a =>
-            icp.SuspectedAssetId == a.Asset && icp.CustomerId == a.Customer && icp.SuspectedSpace == a.Space)).ToList();
+            icp.SuspectedAssetId == a.Asset && icp.SuspectedSpace == a.Space)).ToList();
         
         if (missingAssets.Count != 0)
         {
@@ -212,8 +212,7 @@ public class ManagedAssetResultFinder(
         {
             var assetIds = chunkedAssetsToCheck.Select(a => a.assetId);
             
-            inAnotherManifest.AddRange(dbContext.CanvasPaintings.Where(cp =>
-                assetIds.Contains(cp.AssetId) && cp.CustomerId == customerId));
+            inAnotherManifest.AddRange(dbContext.CanvasPaintings.Where(cp => assetIds.Contains(cp.AssetId)));
         }
 
         return inAnotherManifest;

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestReadService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestReadService.cs
@@ -36,7 +36,7 @@ public class ManifestReadService(
     public async Task<FetchEntityResult<PresentationManifest>> GetManifest(int customerId, string manifestId,
         IImmutableSet<Guid> ifNoneMatch, bool pathOnly, CancellationToken cancellationToken)
     {
-        var dbManifest = await dbContext.RetrieveManifestAsync(customerId, manifestId, withBatches: true,
+        var dbManifest = await dbContext.RetrieveManifestAsync(manifestId, withBatches: true,
             cancellationToken: cancellationToken);
 
         if (dbManifest == null) return FetchEntityResult<PresentationManifest>.NotFound();

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
@@ -105,7 +105,7 @@ public class ManifestWriteService(
         try
         {
             var existingManifest =
-                await dbContext.RetrieveManifestAsync(request.CustomerId, request.ManifestId, true,
+                await dbContext.RetrieveManifestAsync(request.ManifestId, true,
                     withCanvasPaintings: true, withBatches: true, cancellationToken: cancellationToken);
 
             if (existingManifest == null)

--- a/src/IIIFPresentation/API/Features/Storage/Helpers/PresentationContextX.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Helpers/PresentationContextX.cs
@@ -95,7 +95,7 @@ public static class PresentationContextX
         var collections = tracked ? dbContext.Collections : dbContext.Collections.AsNoTracking();
         return collections
             .Include(e => e.Hierarchy)!.ThenInclude(h => h.ParentCollection)
-            .FirstOrDefaultAsync(e => e.CustomerId == customerId && e.Id == collectionId, cancellationToken);
+            .FirstOrDefaultAsync(e => e.Id == collectionId, cancellationToken);
     }
 
     /// <summary>
@@ -128,7 +128,7 @@ public static class PresentationContextX
 
         return await resources
             .Include(e => e.Hierarchy)
-            .FirstOrDefaultAsync(e => e.CustomerId == customerId && e.Id == resourceId, cancellationToken);
+            .FirstOrDefaultAsync(e => e.Id == resourceId, cancellationToken);
     }
     
     /// <summary>
@@ -145,7 +145,7 @@ public static class PresentationContextX
         var hierarchy = dbContext.Hierarchy.AsNoTracking()
             .Include(h => h.Collection)
             .Include(h => h.Manifest)
-            .Where(c => c.CustomerId == customerId && c.Canonical && c.Parent == resourceId);
+            .Where(c => c.Canonical && c.Parent == resourceId);
 
         if (publicOnly)
         {
@@ -169,7 +169,7 @@ public static class PresentationContextX
         {
             // if we get PageSize back then there may be more in db
             total = await dbContext.Hierarchy.CountAsync(
-                c => c.CustomerId == collection.CustomerId && c.Parent == collection.Id,
+                c => c.Parent == collection.Id,
                 cancellationToken: cancellationToken);
         }
 

--- a/src/IIIFPresentation/API/Features/Storage/Helpers/PresentationContextX.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Helpers/PresentationContextX.cs
@@ -62,7 +62,7 @@ public static class PresentationContextX
     /// <param name="withBatches">Whether the Batches records should be included</param>
     /// <param name="cancellationToken">A cancellation token</param>
     /// <returns>The retrieved collection</returns>
-    public static Task<DbManifest?> RetrieveManifestAsync(this PresentationContext dbContext, int customerId,
+    public static Task<DbManifest?> RetrieveManifestAsync(this PresentationContext dbContext,
         string manifestId, bool tracked = false, bool withCanvasPaintings = true, bool withBatches = false, CancellationToken cancellationToken = default)
     {
         IQueryable<DbManifest> dbContextManifests = dbContext.Manifests;
@@ -77,19 +77,18 @@ public static class PresentationContextX
             dbContextManifests = dbContextManifests.Include(m => m.Batches);
         }
         
-        return dbContextManifests.Retrieve(customerId, manifestId, tracked, cancellationToken);
+        return dbContextManifests.Retrieve(manifestId, tracked, cancellationToken);
     }
     
     /// <summary>
     /// Retrieves a 'full' collection from the database, with the Hierarchy records (including Parent)
     /// </summary>
     /// <param name="dbContext">The context to pull records from</param>
-    /// <param name="customerId">Customer the record is attached to</param>
     /// <param name="collectionId">The collection to retrieve</param>
     /// <param name="tracked">Whether the resource should be tracked or not</param>
     /// <param name="cancellationToken">A cancellation token</param>
     /// <returns>The retrieved collection</returns>
-    public static Task<Collection?> RetrieveCollectionWithParentAsync(this PresentationContext dbContext, int customerId,
+    public static Task<Collection?> RetrieveCollectionWithParentAsync(this PresentationContext dbContext,
         string collectionId, bool tracked = false, CancellationToken cancellationToken = default)
     {
         var collections = tracked ? dbContext.Collections : dbContext.Collections.AsNoTracking();
@@ -109,19 +108,18 @@ public static class PresentationContextX
     /// <returns>The retrieved collection</returns>
     public static Task<Collection?> RetrieveCollectionAsync(this PresentationContext dbContext, int customerId,
         string collectionId, bool tracked = false, CancellationToken cancellationToken = default)
-        => dbContext.Collections.Retrieve(customerId, collectionId, tracked, cancellationToken);
+        => dbContext.Collections.Retrieve(collectionId, tracked, cancellationToken);
 
     /// <summary>
     /// Retrieves a <see cref="IHierarchyResource"/> from database, with Hierarchy records included
     /// </summary>
     /// <param name="entities">The context to pull records from</param>
-    /// <param name="customerId">Customer the record is attached to</param>
     /// <param name="resourceId">The collection/manifest Id to retrieve</param>
     /// <param name="tracked">Whether the resource should be tracked or not</param>
     /// <param name="cancellationToken">Current cancellation token</param>
     /// <returns>The retrieved <see cref="IHierarchyResource"/></returns>
     public static async Task<T?> Retrieve<T>(this IQueryable<T> entities,
-        int customerId, string resourceId, bool tracked = false, CancellationToken cancellationToken = default)
+        string resourceId, bool tracked = false, CancellationToken cancellationToken = default)
         where T : class, IHierarchyResource
     {
         var resources = tracked ? entities : entities.AsNoTracking();
@@ -135,11 +133,10 @@ public static class PresentationContextX
     /// Retrieves child hierarchy items for the parent record - entities are not tracked
     /// </summary>
     /// <param name="dbContext">The context to pull records from</param>
-    /// <param name="customerId">Customer the record is attached to</param>
     /// <param name="resourceId">The collection to retrieve child items for</param>
     /// <param name="publicOnly">Whether to return public only resources</param>
     /// <returns>A query containing child collections</returns>
-    public static IQueryable<Hierarchy> RetrieveCollectionItems(this PresentationContext dbContext, int customerId, 
+    public static IQueryable<Hierarchy> RetrieveCollectionItems(this PresentationContext dbContext, 
         string resourceId, bool publicOnly = false)
     {
         var hierarchy = dbContext.Hierarchy.AsNoTracking()

--- a/src/IIIFPresentation/API/Features/Storage/Requests/GetCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/GetCollection.cs
@@ -48,7 +48,7 @@ public class GetCollectionHandler(PresentationContext dbContext, IIIIFS3Service 
     public async Task<FetchEntityResult<PresentationCollection>> Handle(GetCollection request,
         CancellationToken cancellationToken)
     {
-        var collection = await dbContext.RetrieveCollectionWithParentAsync(request.CustomerId, request.Id,
+        var collection = await dbContext.RetrieveCollectionWithParentAsync(request.Id,
             cancellationToken: cancellationToken);
 
         if (collection is null) return FetchEntityResult<PresentationCollection>.NotFound();
@@ -72,7 +72,7 @@ public class GetCollectionHandler(PresentationContext dbContext, IIIIFS3Service 
 
         if (collection.IsStorageCollection)
         {
-            var items = await dbContext.RetrieveCollectionItems(request.CustomerId, collection.Id)
+            var items = await dbContext.RetrieveCollectionItems(collection.Id)
                 .AsOrderedCollectionItemsQuery(request.RequestModifiers.OrderBy, request.RequestModifiers.Descending)
                 .Skip((request.RequestModifiers.Page - 1) * request.RequestModifiers.PageSize)
                 .Take(request.RequestModifiers.PageSize)

--- a/src/IIIFPresentation/API/Features/Storage/Requests/GetHierarchicalCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/GetHierarchicalCollection.cs
@@ -61,7 +61,7 @@ public class GetHierarchicalCollectionHandler(
         else
         {
             var items = await dbContext
-                .RetrieveCollectionItems(request.Hierarchy.CustomerId, request.Hierarchy.Collection.Id, true)
+                .RetrieveCollectionItems(request.Hierarchy.Collection.Id, true)
                 .ToListAsync(cancellationToken: cancellationToken);
 
             // The incoming slug will be the base, use that to generate child item path

--- a/src/IIIFPresentation/API/Features/Storage/Requests/UpsertCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/UpsertCollection.cs
@@ -65,7 +65,7 @@ public class UpsertCollectionHandler(
             if (iiifCollection.Error) return UpsertErrorHelper.CannotValidateIIIF<PresentationCollection>();
         }
         var databaseCollection =
-            await dbContext.RetrieveCollectionWithParentAsync(request.CustomerId, request.CollectionId, true, cancellationToken);
+            await dbContext.RetrieveCollectionWithParentAsync(request.CollectionId, true, cancellationToken);
 
         var parsedParentSlugResult = await parentSlugParser.Parse(request.Collection, request.CustomerId,
             request.CollectionId, cancellationToken);
@@ -168,7 +168,7 @@ public class UpsertCollectionHandler(
         await transaction.CommitAsync(cancellationToken);
         
         var items = dbContext
-            .RetrieveCollectionItems(request.CustomerId, databaseCollection.Id)
+            .RetrieveCollectionItems(databaseCollection.Id)
             .Take(settings.PageSize);
 
         var total = await dbContext.GetTotalItemCountForCollection(databaseCollection, items.Count(),

--- a/src/IIIFPresentation/API/Infrastructure/Helpers/HttpRequestX.cs
+++ b/src/IIIFPresentation/API/Infrastructure/Helpers/HttpRequestX.cs
@@ -21,4 +21,31 @@ public static class HttpRequestX
     /// </summary>
     public static bool HasCreateSpaceHeader(this HttpRequest request)
         => request.Headers.Link.Contains(CreateSpaceHeader);
+
+    /// <summary>
+    /// Retrieve the customer id
+    ///
+    /// NOTE: retrieved from route values
+    /// </summary>
+    /// <param name="request">The request to get the customer id from</param>
+    /// <returns>A parsed customer id</returns>
+    public static int? GetCustomerId(this HttpRequest request, ILogger logger)
+    {
+        var customerIdRouteValue = "customerId";
+        
+        if (!request.RouteValues.TryGetValue(customerIdRouteValue, out var customerIdRouteVal)
+            || customerIdRouteVal is null)
+        {
+            logger.LogDebug("Unable to identify customerId in auth request to {Path}", request.Path);
+            return null;
+        }
+        
+        if (!int.TryParse(customerIdRouteVal.ToString(), out int customerId))
+        {
+            logger.LogDebug("Specified customerId is not numeric {Path}", request.Path);
+            return null;
+        }
+        
+        return customerId;
+    }
 }

--- a/src/IIIFPresentation/API/Infrastructure/HttpContextCustomerIdProvider.cs
+++ b/src/IIIFPresentation/API/Infrastructure/HttpContextCustomerIdProvider.cs
@@ -1,0 +1,41 @@
+﻿using Repository.Helpers;
+
+namespace API.Infrastructure;
+
+public class HttpContextCustomerIdProvider(IHttpContextAccessor httpContextAccessor) : ICustomerIdProvider
+{
+    private static readonly AsyncLocal<int?> CurrentCustomerId = new();
+    private const string CustomerIdRouteValue = "customerId";
+    private const int DefaultCustomer = 0; // Customer id with no values
+
+    public int GetCustomerId()
+    {
+        // Check for preset value (testing/background jobs)
+        if (CurrentCustomerId.Value.HasValue)
+        {
+            return CurrentCustomerId.Value.Value;
+        }
+
+        // Return default if no HTTP context (startup, migrations)
+        if (httpContextAccessor.HttpContext == null)
+        {
+            return DefaultCustomer;
+        }
+        
+        // Extract from route claims
+        httpContextAccessor.HttpContext.Request.RouteValues.TryGetValue(CustomerIdRouteValue, out var customerIdRouteVal);
+             
+        if (!string.IsNullOrEmpty(customerIdRouteVal?.ToString()) && 
+            int.TryParse(customerIdRouteVal.ToString(), out var customerId))
+        {
+            return customerId;
+        }
+
+        return DefaultCustomer;
+    }
+
+    public void SetCustomerId(int customerId)
+    {
+        CurrentCustomerId.Value = customerId;
+    }
+}

--- a/src/IIIFPresentation/API/Infrastructure/HttpContextCustomerIdProvider.cs
+++ b/src/IIIFPresentation/API/Infrastructure/HttpContextCustomerIdProvider.cs
@@ -1,24 +1,18 @@
-﻿using API.Infrastructure.Helpers;
+﻿using API.Helpers;
+using API.Infrastructure.Helpers;
 using Core.Exceptions;
 using Repository.Helpers;
 
 namespace API.Infrastructure;
 
 /// <summary>
-/// Retrieves a customer id from HTTPContext to use in 
+/// Retrieves a customer id from HTTPContext to use in the customer id global query filter
 /// </summary>
-/// <param name="httpContextAccessor"></param>
 public class HttpContextCustomerIdProvider(IHttpContextAccessor httpContextAccessor, ILogger<HttpContextCustomerIdProvider> logger) : ICustomerIdProvider
 {
     public int GetCustomerId()
     {
-        // Return default if no HTTP context (startup, migrations)
-        if (httpContextAccessor.HttpContext == null)
-        {
-            throw new PresentationException("HTTP context is null");
-        }
-
-        var customerId = httpContextAccessor.HttpContext.Request.GetCustomerId(logger);
+        var customerId = httpContextAccessor.SafeHttpContext().Request.GetCustomerId(logger);
         if (customerId.HasValue) return  customerId.Value;
 
         throw new PresentationException("Could not resolve customerId from the URL");
@@ -26,6 +20,6 @@ public class HttpContextCustomerIdProvider(IHttpContextAccessor httpContextAcces
 
     public void SetCustomerId(int customerId)
     {
-        throw new PresentationException("Cannot set a customer id to the current customer");
+        throw new PresentationException($"Setting a customer id is not allowed in the {nameof(HttpContextCustomerIdProvider)}");
     }
 }

--- a/src/IIIFPresentation/API/Infrastructure/HttpContextCustomerIdProvider.cs
+++ b/src/IIIFPresentation/API/Infrastructure/HttpContextCustomerIdProvider.cs
@@ -1,41 +1,31 @@
-﻿using Repository.Helpers;
+﻿using API.Infrastructure.Helpers;
+using Core.Exceptions;
+using Repository.Helpers;
 
 namespace API.Infrastructure;
 
-public class HttpContextCustomerIdProvider(IHttpContextAccessor httpContextAccessor) : ICustomerIdProvider
+/// <summary>
+/// Retrieves a customer id from HTTPContext to use in 
+/// </summary>
+/// <param name="httpContextAccessor"></param>
+public class HttpContextCustomerIdProvider(IHttpContextAccessor httpContextAccessor, ILogger<HttpContextCustomerIdProvider> logger) : ICustomerIdProvider
 {
-    private static readonly AsyncLocal<int?> CurrentCustomerId = new();
-    private const string CustomerIdRouteValue = "customerId";
-    private const int DefaultCustomer = 0; // Customer id with no values
-
     public int GetCustomerId()
     {
-        // Check for preset value (testing/background jobs)
-        if (CurrentCustomerId.Value.HasValue)
-        {
-            return CurrentCustomerId.Value.Value;
-        }
-
         // Return default if no HTTP context (startup, migrations)
         if (httpContextAccessor.HttpContext == null)
         {
-            return DefaultCustomer;
-        }
-        
-        // Extract from route claims
-        httpContextAccessor.HttpContext.Request.RouteValues.TryGetValue(CustomerIdRouteValue, out var customerIdRouteVal);
-             
-        if (!string.IsNullOrEmpty(customerIdRouteVal?.ToString()) && 
-            int.TryParse(customerIdRouteVal.ToString(), out var customerId))
-        {
-            return customerId;
+            throw new PresentationException("HTTP context is null");
         }
 
-        return DefaultCustomer;
+        var customerId = httpContextAccessor.HttpContext.Request.GetCustomerId(logger);
+        if (customerId.HasValue) return  customerId.Value;
+
+        throw new PresentationException("Could not resolve customerId from the URL");
     }
 
     public void SetCustomerId(int customerId)
     {
-        CurrentCustomerId.Value = customerId;
+        throw new PresentationException("Cannot set a customer id to the current customer");
     }
 }

--- a/src/IIIFPresentation/API/Infrastructure/IdGenerator/IdentityManager.cs
+++ b/src/IIIFPresentation/API/Infrastructure/IdGenerator/IdentityManager.cs
@@ -24,7 +24,7 @@ public class IdentityManager(
             var id = GenerateIdentity(customerId, random);
 
             var isUnique = !await dbContext.Set<T>()
-                .AnyAsync(e => e.Id == id && e.CustomerId == customerId, cancellationToken);
+                .AnyAsync(e => e.Id == id, cancellationToken);
 
             if (isUnique) return id;
             
@@ -53,7 +53,7 @@ public class IdentityManager(
                 .Select(_ => GenerateIdentity(customerId, random))
                 .ToList();
             var existingIds = await dbContext.Set<T>()
-                .Where(i => candidates.Contains(i.Id) && i.CustomerId == customerId)
+                .Where(i => candidates.Contains(i.Id))
                 .Select(i => i.Id)
                 .ToListAsync(cancellationToken);
 

--- a/src/IIIFPresentation/API/Program.cs
+++ b/src/IIIFPresentation/API/Program.cs
@@ -14,6 +14,7 @@ using FluentValidation;
 using Microsoft.AspNetCore.HttpOverrides;
 using Newtonsoft.Json;
 using Repository;
+using Repository.Helpers;
 using Repository.Paths;
 using Serilog;
 using Services;
@@ -82,6 +83,7 @@ builder.Services
     .AddScoped<IETagCache, ETagCache>()
     .AddScoped<HierarchyResourceDeleter>()
     .AddHttpContextAccessor()
+    .AddScoped<ICustomerIdProvider, HttpContextCustomerIdProvider>()
     .AddOutgoingHeaders();
 builder.Services.ConfigureMediatR();
 builder.Services.ConfigureIdGenerator();
@@ -113,7 +115,7 @@ app
     .UseMiddleware<CorrelationIdMiddleware>()
     .UseMiddleware<TrailingSlashRedirectMiddleware>();
 
-IIIFPresentationContextConfiguration.TryRunMigrations(builder.Configuration, app.Logger);
+IIIFPresentationContextConfiguration.TryRunMigrations(builder.Configuration, new MigrationCustomerIdProvider(), app.Logger);
 
 app
     .UseSwagger()

--- a/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionMessageHandlerTests.cs
+++ b/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionMessageHandlerTests.cs
@@ -70,7 +70,7 @@ public class BatchCompletionMessageHandlerTests
         var manifestMerger = new ManifestMerger(pathGenerator, pathRewriteParser, new NullLogger<ManifestMerger>());
         var manifestS3Manager = new ManifestS3Manager(iiifS3, pathGenerator, dlcsClient, manifestMerger,
             new NullLogger<ManifestS3Manager>());
-        var customerIdProvider = new MessageBasedCustomerIdProvider();
+        var customerIdProvider = new SetCustomerIdProvider();
 
         sut = new BatchCompletionMessageHandler(sutContext, customerIdProvider, manifestS3Manager,
             new NullLogger<BatchCompletionMessageHandler>());

--- a/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionMessageHandlerTests.cs
+++ b/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionMessageHandlerTests.cs
@@ -1,9 +1,7 @@
 ﻿using AWS.Helpers;
-using AWS.Settings;
 using AWS.SQS;
 using BackgroundHandler.BatchCompletion;
-using BackgroundHandler.Helpers;
-using BackgroundHandler.Settings;
+using BackgroundHandler.Infrastructure;
 using BackgroundHandler.Tests.Helpers;
 using BackgroundHandler.Tests.infrastructure;
 using DLCS;
@@ -42,14 +40,16 @@ public class BatchCompletionMessageHandlerTests
     private readonly IIIIFS3Service iiifS3;
     private readonly PathSettings pathSettings;
     private const int CustomerId = 1;
+    private const int AlternativeCustomer = 10;
 
     public BatchCompletionMessageHandlerTests(PresentationContextFixture dbFixture)
     {
         // The context from dbFixture doesn't track changes so setup/assert
         dbContext = dbFixture.DbContext;
+        dbFixture.CustomerIdProvider.SetCustomerId(CustomerId);
         
         // The context used by SUT should track to mimic context config in actual use
-        var sutContext = dbFixture.GetNewPresentationContext();
+        var sutContext = dbFixture.GetNewPresentationContext(dbFixture.CustomerIdProvider);
         
         dlcsClient = A.Fake<IDlcsOrchestratorClient>();
         iiifS3 = A.Fake<IIIIFS3Service>();
@@ -70,8 +70,9 @@ public class BatchCompletionMessageHandlerTests
         var manifestMerger = new ManifestMerger(pathGenerator, pathRewriteParser, new NullLogger<ManifestMerger>());
         var manifestS3Manager = new ManifestS3Manager(iiifS3, pathGenerator, dlcsClient, manifestMerger,
             new NullLogger<ManifestS3Manager>());
+        var customerIdProvider = new MessageBasedCustomerIdProvider();
 
-        sut = new BatchCompletionMessageHandler(sutContext, manifestS3Manager,
+        sut = new BatchCompletionMessageHandler(sutContext, customerIdProvider, manifestS3Manager,
             new NullLogger<BatchCompletionMessageHandler>());
     }
 
@@ -250,5 +251,64 @@ public class BatchCompletionMessageHandlerTests
         canvasPainting.StaticWidth.Should().Be(75, "width taken from NQ manifest image->imageService");
         canvasPainting.StaticHeight.Should().Be(75, "height taken from NQ manifest image->imageService");
         canvasPainting.AssetId!.ToString().Should().Be(assetId.ToString());
+    }
+    
+    [Fact]
+    public async Task HandleMessage_SavesResultingManifest_WhenAnotherCustomerIngestingSameManifestId()
+    {
+        // Arrange
+        var initialBatchId = TestIdentifiers.BatchId();
+        var (identifier, canvasPaintingId) = TestIdentifiers.IdCanvasPainting();
+        const int space = 2;
+        var assetId = new AssetId(CustomerId, space, identifier);
+        
+        
+        var otherCustomerManifest = await dbContext.Manifests.AddTestManifest(batchId: initialBatchId, customer: AlternativeCustomer, ingested: false);
+        await dbContext.CanvasPaintings.AddTestCanvasPainting(otherCustomerManifest.Entity, id: canvasPaintingId, assetId: assetId,
+            canvasOrder: 1, ingesting: true);
+
+        var batchId = TestIdentifiers.BatchId();
+        var flatId = $"https://localhost:5000/1/manifests/{identifier}";
+
+        A.CallTo(() => iiifS3.ReadIIIFFromS3<IIIFManifest>(A<IHierarchyResource>._, true, A<CancellationToken>._))
+            .ReturnsLazily(() => new IIIFManifest
+            {
+                Id = identifier
+            });
+
+        var manifestEntityEntry = await dbContext.Manifests.AddTestManifest(batchId: batchId);
+        var manifest = manifestEntityEntry.Entity;
+        await dbContext.CanvasPaintings.AddTestCanvasPainting(manifest, id: canvasPaintingId, assetId: assetId,
+            canvasOrder: 1, ingesting: true);
+        await dbContext.SaveChangesAsync();
+
+        var message = QueueHelper.CreateQueueMessage(batchId, CustomerId);
+
+        A.CallTo(() => dlcsClient.RetrieveAssetsForManifest(A<int>._, A<string>._, A<CancellationToken>._))
+            .Returns(ManifestTestCreator.GenerateMinimalNamedQueryManifest(assetId, pathSettings.PresentationApiUrl));
+        ResourceBase? resourceBase = null;
+        A.CallTo(() => iiifS3.SaveIIIFToS3(A<ResourceBase>._, A<Manifest>.That.Matches(m => m.Id == manifest.Id),
+                flatId, false, A<CancellationToken>._))
+            .Invokes((ResourceBase arg1, IHierarchyResource _, string _, bool _, CancellationToken _) =>
+                resourceBase = arg1);
+
+        // Act
+        var handleMessage = await sut.HandleMessage(message, CancellationToken.None);
+
+        // Assert
+        handleMessage.Should().BeTrue("Message successfully handled");
+        A.CallTo(() => iiifS3.SaveIIIFToS3(A<ResourceBase>._, A<Manifest>.That.Matches(m => m.Id == manifest.Id),
+                flatId, false, A<CancellationToken>._))
+            .MustHaveHappened(1, Times.Exactly);
+        var savedManifest = (IIIFManifest)resourceBase!;
+        var expectedCanvasId = $"https://localhost:5000/1/canvases/{canvasPaintingId}";
+        savedManifest.Items[0].Id.Should().Be(expectedCanvasId, "Canvas Id overwritten");
+        savedManifest.Items[0].Items[0].Id.Should().Be(
+            $"https://localhost:5000/1/canvases/{canvasPaintingId}/annopages/1",
+            "AnnotationPage Id overwritten");
+        var paintingAnnotation = savedManifest.Items[0].Items[0].Items[0].As<PaintingAnnotation>();
+        paintingAnnotation.Id.Should().Be($"https://localhost:5000/1/canvases/{canvasPaintingId}/annotations/1",
+            "PaintingAnnotation Id overwritten");
+        paintingAnnotation.Target.As<Canvas>().Id.Should().Be(expectedCanvasId, "Target Id matches canvasId");
     }
 }

--- a/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionMessageHandlerTests.cs
+++ b/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionMessageHandlerTests.cs
@@ -262,7 +262,6 @@ public class BatchCompletionMessageHandlerTests
         const int space = 2;
         var assetId = new AssetId(CustomerId, space, identifier);
         
-        
         var otherCustomerManifest = await dbContext.Manifests.AddTestManifest(batchId: initialBatchId, customer: AlternativeCustomer, ingested: false);
         await dbContext.CanvasPaintings.AddTestCanvasPainting(otherCustomerManifest.Entity, id: canvasPaintingId, assetId: assetId,
             canvasOrder: 1, ingesting: true);

--- a/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionPathRewriteTests.cs
+++ b/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionPathRewriteTests.cs
@@ -1,8 +1,5 @@
 ﻿using AWS.Helpers;
-using AWS.Settings;
 using BackgroundHandler.BatchCompletion;
-using BackgroundHandler.Helpers;
-using BackgroundHandler.Settings;
 using BackgroundHandler.Tests.Helpers;
 using BackgroundHandler.Tests.infrastructure;
 using Core.Web;
@@ -45,7 +42,7 @@ public class BatchCompletionPathRewriteTests
         dbContext = dbFixture.DbContext;
         
         // The context used by SUT should track to mimic context config in actual use
-        var sutContext = dbFixture.GetNewPresentationContext();
+        var sutContext = dbFixture.GetNewPresentationContext(dbFixture.CustomerIdProvider);
         
         dlcsClient = A.Fake<IDlcsOrchestratorClient>();
         iiifS3 = A.Fake<IIIIFS3Service>();
@@ -95,7 +92,7 @@ public class BatchCompletionPathRewriteTests
         var manifestS3Manager = new ManifestS3Manager(iiifS3, pathGenerator, dlcsClient, manifestMerger,
             new NullLogger<ManifestS3Manager>());
 
-        sut = new BatchCompletionMessageHandler(sutContext, manifestS3Manager,
+        sut = new BatchCompletionMessageHandler(sutContext, dbFixture.CustomerIdProvider, manifestS3Manager,
             new NullLogger<BatchCompletionMessageHandler>());
     }
     

--- a/src/IIIFPresentation/BackgroundHandler.Tests/CustomerCreation/CustomerCreationMessageHandlerTests.cs
+++ b/src/IIIFPresentation/BackgroundHandler.Tests/CustomerCreation/CustomerCreationMessageHandlerTests.cs
@@ -19,7 +19,8 @@ public class CustomerCreationMessageHandlerTests
     public CustomerCreationMessageHandlerTests(PresentationContextFixture dbFixture)
     {
         dbContext = dbFixture.DbContext;
-        sut = new CustomerCreatedMessageHandler(dbFixture.DbContext, new NullLogger<CustomerCreatedMessageHandler>());
+        sut = new CustomerCreatedMessageHandler(dbFixture.DbContext, dbFixture.CustomerIdProvider,
+            new NullLogger<CustomerCreatedMessageHandler>());
     }
     
     [Fact]

--- a/src/IIIFPresentation/BackgroundHandler.Tests/infrastructure/SetCustomerIdProviderTests.cs
+++ b/src/IIIFPresentation/BackgroundHandler.Tests/infrastructure/SetCustomerIdProviderTests.cs
@@ -1,0 +1,49 @@
+﻿using BackgroundHandler.Infrastructure;
+using Core.Exceptions;
+using FluentAssertions;
+
+namespace BackgroundHandler.Tests.infrastructure;
+
+public class SetCustomerIdProviderTests
+{
+    [Fact]
+    public void SetCustomerId_SetsTheCustomerIdWithoutError()
+    {
+        // Arrange
+        var sut = new SetCustomerIdProvider();
+        
+        //  act
+        Action action = () => sut.SetCustomerId(1);
+        
+        // Assert
+        action.Should().NotThrow();
+    }
+    
+    [Fact]
+    public void GetCustomerId_ThrowsError_WhenNoCustomerIdSet()
+    {
+        // Arrange
+        var sut = new SetCustomerIdProvider();
+        
+        //  Act
+        Action action = () => sut.GetCustomerId();
+        
+        // Assert
+        action.Should().Throw<PresentationException>();
+    }
+    
+    [Fact]
+    public void GetCustomerId_RetrievesCustomerId_WhenCustomerIdSet()
+    {
+        // Arrange
+        var sut = new SetCustomerIdProvider();
+        var customerIdToSet = 1;
+        sut.SetCustomerId(customerIdToSet);
+        
+        //  Act
+        var customerId = sut.GetCustomerId();
+        
+        // Assert
+        customerId.Should().Be(customerIdToSet);
+    }
+}

--- a/src/IIIFPresentation/BackgroundHandler/BatchCompletion/BatchCompletionMessageHandler.cs
+++ b/src/IIIFPresentation/BackgroundHandler/BatchCompletion/BatchCompletionMessageHandler.cs
@@ -2,16 +2,19 @@
 using System.Text.Json;
 using AWS.SQS;
 using BackgroundHandler.Helpers;
+using BackgroundHandler.Infrastructure;
 using Core.Helpers;
 using Microsoft.EntityFrameworkCore;
 using Models.Database.General;
 using Repository;
+using Repository.Helpers;
 using Services.Manifests.AWS;
 
 namespace BackgroundHandler.BatchCompletion;
 
 public class BatchCompletionMessageHandler(
     PresentationContext dbContext,
+    ICustomerIdProvider customerIdProvider,
     IManifestStorageManager manifestS3Manager,
     ILogger<BatchCompletionMessageHandler> logger)
     : IMessageHandler
@@ -25,7 +28,9 @@ public class BatchCompletionMessageHandler(
             try
             {
                 var batchCompletionMessage = DeserializeMessage(message, logger);
-
+                
+                customerIdProvider.SetCustomerId(batchCompletionMessage.Customer);
+                
                 await TryUpdateManifest(batchCompletionMessage, cancellationToken);
                 return true;
             }

--- a/src/IIIFPresentation/BackgroundHandler/CustomerCreation/CustomerCreatedMessageHandler.cs
+++ b/src/IIIFPresentation/BackgroundHandler/CustomerCreation/CustomerCreatedMessageHandler.cs
@@ -53,7 +53,7 @@ public class CustomerCreatedMessageHandler(
         
         logger.LogInformation("Ensuring new customer {CustomerId} has root collection", customerId);
 
-        if (await dbContext.Collections.AnyAsync( c => c.Id == KnownCollections.RootCollection, cancellationToken))
+        if (await dbContext.Collections.AnyAsync(c => c.Id == KnownCollections.RootCollection, cancellationToken))
         {
             logger.LogInformation("Customer {CustomerId} already has root collection, no-op", customerId);
             return;

--- a/src/IIIFPresentation/BackgroundHandler/CustomerCreation/CustomerCreatedMessageHandler.cs
+++ b/src/IIIFPresentation/BackgroundHandler/CustomerCreation/CustomerCreatedMessageHandler.cs
@@ -9,6 +9,7 @@ using Models;
 using Models.Database.Collections;
 using Models.Database.General;
 using Repository;
+using Repository.Helpers;
 
 namespace BackgroundHandler.CustomerCreation;
 
@@ -17,6 +18,7 @@ namespace BackgroundHandler.CustomerCreation;
 /// </summary>
 public class CustomerCreatedMessageHandler(
     PresentationContext dbContext,
+    ICustomerIdProvider  customerIdProvider,
     ILogger<CustomerCreatedMessageHandler> logger)
     : IMessageHandler
 {
@@ -29,6 +31,8 @@ public class CustomerCreatedMessageHandler(
             try
             {
                 var customerCreatedMessage = DeserializeMessage(message);
+                
+                customerIdProvider.SetCustomerId(customerCreatedMessage.Id);
 
                 await EnsureRootCollection(customerCreatedMessage, cancellationToken);
 
@@ -49,9 +53,7 @@ public class CustomerCreatedMessageHandler(
         
         logger.LogInformation("Ensuring new customer {CustomerId} has root collection", customerId);
 
-        if (await dbContext.Collections.AnyAsync(
-                c => c.Id == KnownCollections.RootCollection && c.CustomerId == customerId,
-                cancellationToken))
+        if (await dbContext.Collections.AnyAsync( c => c.Id == KnownCollections.RootCollection, cancellationToken))
         {
             logger.LogInformation("Customer {CustomerId} already has root collection, no-op", customerId);
             return;

--- a/src/IIIFPresentation/BackgroundHandler/Infrastructure/MessageBasedCustomerIdProvider.cs
+++ b/src/IIIFPresentation/BackgroundHandler/Infrastructure/MessageBasedCustomerIdProvider.cs
@@ -1,0 +1,23 @@
+using Repository.Helpers;
+
+namespace BackgroundHandler.Infrastructure;
+
+public class MessageBasedCustomerIdProvider : ICustomerIdProvider
+{
+    private static readonly AsyncLocal<int?> CurrentCustomerId = new();
+    
+    public int GetCustomerId()
+    {
+        if (CurrentCustomerId.Value.HasValue)
+        {
+            return CurrentCustomerId.Value.Value;
+        }
+        
+        return 0;
+    }
+
+    public void SetCustomerId(int customerId)
+    {
+        CurrentCustomerId.Value = customerId;
+    }
+}

--- a/src/IIIFPresentation/BackgroundHandler/Infrastructure/ServiceCollectionX.cs
+++ b/src/IIIFPresentation/BackgroundHandler/Infrastructure/ServiceCollectionX.cs
@@ -7,6 +7,7 @@ using BackgroundHandler.BatchCompletion;
 using BackgroundHandler.CustomerCreation;
 using BackgroundHandler.Listener;
 using Repository;
+using Repository.Helpers;
 
 namespace BackgroundHandler.Infrastructure;
 

--- a/src/IIIFPresentation/BackgroundHandler/Infrastructure/SetCustomerIdProvider.cs
+++ b/src/IIIFPresentation/BackgroundHandler/Infrastructure/SetCustomerIdProvider.cs
@@ -1,8 +1,12 @@
+using Core.Exceptions;
 using Repository.Helpers;
 
 namespace BackgroundHandler.Infrastructure;
 
-public class MessageBasedCustomerIdProvider : ICustomerIdProvider
+/// <summary>
+/// Provider that requires the customer id to be set prior to retrieval
+/// </summary>
+public class SetCustomerIdProvider : ICustomerIdProvider
 {
     private static readonly AsyncLocal<int?> CurrentCustomerId = new();
     
@@ -12,8 +16,8 @@ public class MessageBasedCustomerIdProvider : ICustomerIdProvider
         {
             return CurrentCustomerId.Value.Value;
         }
-        
-        return 0;
+
+        throw new PresentationException("Customer id not set for retrieval");
     }
 
     public void SetCustomerId(int customerId)

--- a/src/IIIFPresentation/BackgroundHandler/Program.cs
+++ b/src/IIIFPresentation/BackgroundHandler/Program.cs
@@ -2,6 +2,7 @@
 using BackgroundHandler.Infrastructure;
 using BackgroundHandler.Settings;
 using DLCS;
+using Repository.Helpers;
 using Repository.Paths;
 using Serilog;
 using Services;
@@ -42,6 +43,7 @@ builder.Services.AddAws(builder.Configuration, builder.Environment)
     .AddSingleton<IPathRewriteParser, PathRewriteParser>()
     .AddSingleton<IManifestMerger, ManifestMerger>()
     .AddSingleton<IManifestStorageManager, ManifestS3Manager>()
+    .AddScoped<ICustomerIdProvider, MessageBasedCustomerIdProvider>()
     .Configure<DlcsSettings>(dlcsSettings);
 
 var app = builder.Build();

--- a/src/IIIFPresentation/BackgroundHandler/Program.cs
+++ b/src/IIIFPresentation/BackgroundHandler/Program.cs
@@ -43,7 +43,7 @@ builder.Services.AddAws(builder.Configuration, builder.Environment)
     .AddSingleton<IPathRewriteParser, PathRewriteParser>()
     .AddSingleton<IManifestMerger, ManifestMerger>()
     .AddSingleton<IManifestStorageManager, ManifestS3Manager>()
-    .AddScoped<ICustomerIdProvider, MessageBasedCustomerIdProvider>()
+    .AddScoped<ICustomerIdProvider, SetCustomerIdProvider>()
     .Configure<DlcsSettings>(dlcsSettings);
 
 var app = builder.Build();

--- a/src/IIIFPresentation/Migrator/Program.cs
+++ b/src/IIIFPresentation/Migrator/Program.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Repository;
+using Repository.Helpers;
 
 Log.Logger = new LoggerConfiguration()
     .MinimumLevel.Debug()
@@ -38,17 +39,8 @@ finally
     Log.CloseAndFlush();
 }
 
-class Migrator
+class Migrator(ILogger<Migrator> logger, IConfiguration configuration)
 {
-    private readonly ILogger<Migrator> logger;
-    private readonly IConfiguration configuration;
-
-    public Migrator(ILogger<Migrator> logger, IConfiguration configuration)
-    {
-        this.logger = logger;
-        this.configuration = configuration;
-    }
-
     public void Execute()
     {
         var connStr = configuration.GetConnectionString("PostgreSQLConnection");
@@ -64,6 +56,6 @@ class Migrator
             }
         }
 
-        IIIFPresentationContextConfiguration.TryRunMigrations(configuration, logger);
+        IIIFPresentationContextConfiguration.TryRunMigrations(configuration, new MigrationCustomerIdProvider(), logger);
     }
 }

--- a/src/IIIFPresentation/Models/Database/General/Batch.cs
+++ b/src/IIIFPresentation/Models/Database/General/Batch.cs
@@ -2,7 +2,7 @@
 
 namespace Models.Database.General;
 
-public class Batch
+public class Batch : ICustomerEntity
 {
     /// <summary>
     /// Id of the batch, coming from the DLCS

--- a/src/IIIFPresentation/Models/Database/General/Hierarchy.cs
+++ b/src/IIIFPresentation/Models/Database/General/Hierarchy.cs
@@ -3,7 +3,7 @@ using Manifest = Models.Database.Collections.Manifest;
 
 namespace Models.Database.General;
 
-public class Hierarchy
+public class Hierarchy : ICustomerEntity
 {
     public int Id { get; set; }
     

--- a/src/IIIFPresentation/Models/Database/ICustomerEntity.cs
+++ b/src/IIIFPresentation/Models/Database/ICustomerEntity.cs
@@ -1,5 +1,10 @@
 ﻿namespace Models.Database;
 
+/// <summary>
+/// Entity has a customer id
+///
+/// NOTE: implementing this interface causes a global query filter to be enabled on the customer id
+/// </summary>
 public interface ICustomerEntity
 {
     public int CustomerId { get; set; }

--- a/src/IIIFPresentation/Models/Database/ICustomerEntity.cs
+++ b/src/IIIFPresentation/Models/Database/ICustomerEntity.cs
@@ -1,0 +1,6 @@
+﻿namespace Models.Database;
+
+public interface ICustomerEntity
+{
+    public int CustomerId { get; set; }
+}

--- a/src/IIIFPresentation/Models/Database/IIdentifiable.cs
+++ b/src/IIIFPresentation/Models/Database/IIdentifiable.cs
@@ -3,9 +3,7 @@ namespace Models.Database;
 /// <summary>
 /// Marks classes as having a string identifier field and is for a specific Customer
 /// </summary>
-public interface IIdentifiable
+public interface IIdentifiable : ICustomerEntity
 {
     string Id { get; }
-    
-    int CustomerId { get; }
 }

--- a/src/IIIFPresentation/Repository.Tests/Helpers/CollectionRetrievalTests.cs
+++ b/src/IIIFPresentation/Repository.Tests/Helpers/CollectionRetrievalTests.cs
@@ -17,6 +17,7 @@ public class CollectionRetrievalTests
     public CollectionRetrievalTests(PresentationContextFixture dbFixture)
     {
         dbContext = dbFixture.DbContext;
+        dbFixture.CustomerIdProvider.SetCustomerId(CustomerId);
 
         if (initialised) return;
 

--- a/src/IIIFPresentation/Repository.Tests/PresentationContextTests.cs
+++ b/src/IIIFPresentation/Repository.Tests/PresentationContextTests.cs
@@ -13,7 +13,7 @@ public class PresentationContextTests
     
     public PresentationContextTests(PresentationContextFixture dbFixture)
     {
-        dbContext = dbFixture.GetNewPresentationContext();
+        dbContext = dbFixture.GetNewPresentationContext(dbFixture.CustomerIdProvider);
         
         dbContext.SaveChanges();
     }

--- a/src/IIIFPresentation/Repository.Tests/PresentationContextTests.cs
+++ b/src/IIIFPresentation/Repository.Tests/PresentationContextTests.cs
@@ -13,7 +13,7 @@ public class PresentationContextTests
     
     public PresentationContextTests(PresentationContextFixture dbFixture)
     {
-        dbContext = dbFixture.GetNewPresentationContext();;
+        dbContext = dbFixture.GetNewPresentationContext();
         
         dbContext.SaveChanges();
     }

--- a/src/IIIFPresentation/Repository/Helpers/CollectionRetrieval.cs
+++ b/src/IIIFPresentation/Repository/Helpers/CollectionRetrieval.cs
@@ -83,7 +83,7 @@ public static class CollectionRetrieval
                 .Include(h => h.Collection)
                 .Include(h => h.Manifest)
                 .AsNoTracking()
-                .FirstOrDefaultAsync(s => s.CustomerId == customerId && s.Parent == null, cancellationToken);
+                .FirstOrDefaultAsync(s => s.Parent == null, cancellationToken);
         }
 
         return await dbContext.Hierarchy

--- a/src/IIIFPresentation/Repository/Helpers/ICustomerIdProvider.cs
+++ b/src/IIIFPresentation/Repository/Helpers/ICustomerIdProvider.cs
@@ -1,7 +1,7 @@
 ﻿namespace Repository.Helpers;
 
 /// <summary>
-/// retrieves and sets a customer id used by a global query filter
+/// Retrieves and sets a customer id used by a global query filter
 /// </summary>
 public interface ICustomerIdProvider
 {

--- a/src/IIIFPresentation/Repository/Helpers/ICustomerIdProvider.cs
+++ b/src/IIIFPresentation/Repository/Helpers/ICustomerIdProvider.cs
@@ -1,5 +1,8 @@
 ﻿namespace Repository.Helpers;
 
+/// <summary>
+/// retrieves and sets a customer id used by a global query filter
+/// </summary>
 public interface ICustomerIdProvider
 {
     /// <summary>

--- a/src/IIIFPresentation/Repository/Helpers/ICustomerIdProvider.cs
+++ b/src/IIIFPresentation/Repository/Helpers/ICustomerIdProvider.cs
@@ -2,7 +2,13 @@
 
 public interface ICustomerIdProvider
 {
+    /// <summary>
+    /// Retrieves the customer id for the current interaction
+    /// </summary>
     public int GetCustomerId();
     
+    /// <summary>
+    /// Sets the customer id for this interaction
+    /// </summary>
     public void SetCustomerId(int customerId);
 }

--- a/src/IIIFPresentation/Repository/Helpers/ICustomerIdProvider.cs
+++ b/src/IIIFPresentation/Repository/Helpers/ICustomerIdProvider.cs
@@ -1,0 +1,8 @@
+﻿namespace Repository.Helpers;
+
+public interface ICustomerIdProvider
+{
+    public int GetCustomerId();
+    
+    public void SetCustomerId(int customerId);
+}

--- a/src/IIIFPresentation/Repository/Helpers/MigrationCustomerIdProvider.cs
+++ b/src/IIIFPresentation/Repository/Helpers/MigrationCustomerIdProvider.cs
@@ -1,0 +1,8 @@
+﻿namespace Repository.Helpers;
+
+public class MigrationCustomerIdProvider : ICustomerIdProvider
+{
+    public int GetCustomerId() => 0; // Default for migrations
+    public void SetCustomerId(int customerId) =>
+        throw new NotImplementedException(); // do not set the customer id for migrations
+}

--- a/src/IIIFPresentation/Repository/Helpers/MigrationCustomerIdProvider.cs
+++ b/src/IIIFPresentation/Repository/Helpers/MigrationCustomerIdProvider.cs
@@ -1,10 +1,8 @@
-﻿using Core.Exceptions;
-
-namespace Repository.Helpers;
+﻿namespace Repository.Helpers;
 
 public class MigrationCustomerIdProvider : ICustomerIdProvider
 {
     public int GetCustomerId() => 0; // Default for migrations
     public void SetCustomerId(int customerId) =>
-        throw new PresentationException(); // do not set the customer id for migrations
+        throw new NotImplementedException(); // do not set the customer id for migrations
 }

--- a/src/IIIFPresentation/Repository/Helpers/MigrationCustomerIdProvider.cs
+++ b/src/IIIFPresentation/Repository/Helpers/MigrationCustomerIdProvider.cs
@@ -1,8 +1,10 @@
-﻿namespace Repository.Helpers;
+﻿using Core.Exceptions;
+
+namespace Repository.Helpers;
 
 public class MigrationCustomerIdProvider : ICustomerIdProvider
 {
     public int GetCustomerId() => 0; // Default for migrations
     public void SetCustomerId(int customerId) =>
-        throw new NotImplementedException(); // do not set the customer id for migrations
+        throw new PresentationException(); // do not set the customer id for migrations
 }

--- a/src/IIIFPresentation/Repository/IIIFPresentationContextConfiguration.cs
+++ b/src/IIIFPresentation/Repository/IIIFPresentationContextConfiguration.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore;
+using Repository.Helpers;
 
 namespace Repository;
 
@@ -20,11 +21,11 @@ public static class IIIFPresentationContextConfiguration
     /// <summary>
     ///     Run EF migrations if "RunMigrations" = true
     /// </summary>
-    public static void TryRunMigrations(IConfiguration configuration, ILogger logger)
+    public static void TryRunMigrations(IConfiguration configuration, ICustomerIdProvider customerProvider, ILogger logger)
     {
         if (configuration.GetValue(RunMigrationsKey, false))
         {
-            using var context = new PresentationContext(GetOptionsBuilder(configuration).Options);
+            using var context = new PresentationContext(GetOptionsBuilder(configuration).Options, customerProvider);
 
             var pendingMigrations = context.Database.GetPendingMigrations().ToList();
             if (pendingMigrations.Count == 0)
@@ -41,9 +42,9 @@ public static class IIIFPresentationContextConfiguration
     /// <summary>
     ///     Get a new instantiated <see cref="PresentationContext" /> object
     /// </summary>
-    public static PresentationContext GetNewDbContext(IConfiguration configuration)
+    public static PresentationContext GetNewDbContext(IConfiguration configuration, ICustomerIdProvider customerProvider)
     {
-        return new PresentationContext(GetOptionsBuilder(configuration).Options);
+        return new PresentationContext(GetOptionsBuilder(configuration).Options, customerProvider);
     }
 
     private static DbContextOptionsBuilder<PresentationContext> GetOptionsBuilder(IConfiguration configuration)

--- a/src/IIIFPresentation/Repository/PresentationContext.cs
+++ b/src/IIIFPresentation/Repository/PresentationContext.cs
@@ -13,21 +13,20 @@ namespace Repository;
 
 public class PresentationContext : DbContext
 {
-    ICustomerIdProvider customerProvider;
+    private readonly ICustomerIdProvider customerIdProvider;
     
     public PresentationContext(ICustomerIdProvider customerIdProvider)
     {
-        this.customerProvider = customerIdProvider;
+        this.customerIdProvider = customerIdProvider;
     }
 
     public PresentationContext(DbContextOptions<PresentationContext> options, ICustomerIdProvider customerIdProvider)
         : base(options)
     {
-        customerProvider = customerIdProvider;
+        this.customerIdProvider = customerIdProvider;
     }
-
-    // Critical: This method is called for EACH query execution
-    public int GetCurrentCustomerId() => customerProvider.GetCustomerId();
+    
+    public int GetCurrentCustomerId() => customerIdProvider.GetCustomerId();
 
     public virtual DbSet<Collection> Collections { get; set; }
     

--- a/src/IIIFPresentation/Repository/PresentationContext.cs
+++ b/src/IIIFPresentation/Repository/PresentationContext.cs
@@ -152,6 +152,10 @@ public class PresentationContext : DbContext
     
     private void ApplyGlobalFilters(ModelBuilder builder)
     {
+        // get the method GetCustomerId from this class
+        var currentCustomerIdMethod = typeof(PresentationContext).GetMethod(nameof(GetCurrentCustomerId))!;
+        var methodCall = Expression.Call( Expression.Constant(this), currentCustomerIdMethod);
+        
         // Automatically apply customer filter to all ICustomerEntity implementations
         foreach (var entityType in builder.Model.GetEntityTypes())
         {
@@ -160,11 +164,7 @@ public class PresentationContext : DbContext
                 // grab the class from the entity
                 var parameter = Expression.Parameter(entityType.ClrType, "entity");
                 // grab the CustomerId property from the class
-                var customerIdProperty = Expression.Property(parameter, "CustomerId");
-                // get the method GetCustomerId from this class
-                var methodCall = Expression.Call(
-                    Expression.Constant(this),
-                    typeof(PresentationContext).GetMethod(nameof(GetCurrentCustomerId))!);
+                var customerIdProperty = Expression.Property(parameter, nameof(ICustomerEntity.CustomerId));
                 // create a lambda expression using the customer id property and the method call i.e.: entity.CustomerId == GetCustomerId()
                 var filter = Expression.Lambda(
                     Expression.Equal(customerIdProperty, methodCall), 

--- a/src/IIIFPresentation/Repository/PresentationContext.cs
+++ b/src/IIIFPresentation/Repository/PresentationContext.cs
@@ -153,20 +153,24 @@ public class PresentationContext : DbContext
     
     private void ApplyGlobalFilters(ModelBuilder builder)
     {
-        // Automatically apply tenant filter to all ITenantEntity implementations
+        // Automatically apply customer filter to all ICustomerEntity implementations
         foreach (var entityType in builder.Model.GetEntityTypes())
         {
             if (typeof(ICustomerEntity).IsAssignableFrom(entityType.ClrType))
             {
-                var parameter = Expression.Parameter(entityType.ClrType, "e");
+                // grab the class from the entity
+                var parameter = Expression.Parameter(entityType.ClrType, "entity");
+                // grab the CustomerId property from the class
                 var customerIdProperty = Expression.Property(parameter, "CustomerId");
+                // get the method GetCustomerId from this class
                 var methodCall = Expression.Call(
                     Expression.Constant(this),
                     typeof(PresentationContext).GetMethod(nameof(GetCurrentCustomerId))!);
+                // create a lambda expression using the customer id property and the method call i.e.: entity.CustomerId == GetCustomerId()
                 var filter = Expression.Lambda(
                     Expression.Equal(customerIdProperty, methodCall), 
                     parameter);
-
+                // add the query filter to the entity
                 builder.Entity(entityType.ClrType).HasQueryFilter(filter);
             }
         }

--- a/src/IIIFPresentation/Repository/PresentationContext.cs
+++ b/src/IIIFPresentation/Repository/PresentationContext.cs
@@ -1,4 +1,5 @@
-﻿using Core.Helpers;
+﻿using System.Linq.Expressions;
+using Core.Helpers;
 using IIIF.Presentation.V3.Strings;
 using Microsoft.EntityFrameworkCore;
 using Models.Database;
@@ -6,19 +7,27 @@ using Models.Database.Collections;
 using Models.Database.General;
 using Models.DLCS;
 using Repository.Converters;
+using Repository.Helpers;
 
 namespace Repository;
 
 public class PresentationContext : DbContext
 {
-    public PresentationContext()
+    ICustomerIdProvider customerProvider;
+    
+    public PresentationContext(ICustomerIdProvider customerIdProvider)
     {
+        this.customerProvider = customerIdProvider;
     }
 
-    public PresentationContext(DbContextOptions<PresentationContext> options)
+    public PresentationContext(DbContextOptions<PresentationContext> options, ICustomerIdProvider customerIdProvider)
         : base(options)
     {
+        customerProvider = customerIdProvider;
     }
+
+    // Critical: This method is called for EACH query execution
+    public int GetCurrentCustomerId() => customerProvider.GetCustomerId();
 
     public virtual DbSet<Collection> Collections { get; set; }
     
@@ -40,6 +49,8 @@ public class PresentationContext : DbContext
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.HasPostgresExtension("citext");
+        
+        ApplyGlobalFilters(modelBuilder);
 
         modelBuilder.Entity<Collection>(entity =>
         {
@@ -138,5 +149,26 @@ public class PresentationContext : DbContext
                     b => b.ToString(),
                     b => b.GetEnumFromString<BatchStatus>(true));
         });
+    }
+    
+    private void ApplyGlobalFilters(ModelBuilder builder)
+    {
+        // Automatically apply tenant filter to all ITenantEntity implementations
+        foreach (var entityType in builder.Model.GetEntityTypes())
+        {
+            if (typeof(ICustomerEntity).IsAssignableFrom(entityType.ClrType))
+            {
+                var parameter = Expression.Parameter(entityType.ClrType, "e");
+                var customerIdProperty = Expression.Property(parameter, "CustomerId");
+                var methodCall = Expression.Call(
+                    Expression.Constant(this),
+                    typeof(PresentationContext).GetMethod(nameof(GetCurrentCustomerId))!);
+                var filter = Expression.Lambda(
+                    Expression.Equal(customerIdProperty, methodCall), 
+                    parameter);
+
+                builder.Entity(entityType.ClrType).HasQueryFilter(filter);
+            }
+        }
     }
 }

--- a/src/IIIFPresentation/Test.Helpers/Integration/PresentationContextFixture.cs
+++ b/src/IIIFPresentation/Test.Helpers/Integration/PresentationContextFixture.cs
@@ -382,7 +382,7 @@ public class PresentationContextFixture : IAsyncLifetime
 
 public class TestCustomerIdProvider : ICustomerIdProvider
 {
-    private int customerId = 1;
+    private int customerId = PresentationContextFixture.CustomerId;
     
     public int GetCustomerId() => customerId;
 

--- a/src/IIIFPresentation/Test.Helpers/Integration/PresentationContextFixture.cs
+++ b/src/IIIFPresentation/Test.Helpers/Integration/PresentationContextFixture.cs
@@ -328,23 +328,6 @@ public class PresentationContextFixture : IAsyncLifetime
     }
 
     public async Task DisposeAsync() => await postgresContainer.StopAsync();
-
-    /// <summary>
-    /// Get a new <see cref="PresentationContext"/> using connection string of this Postgres docker image.
-    /// Unlike the DbContext property this has full query tracking enabled to mimic 'real' context. This should be
-    /// used in instances where integration tests aren't using WebApplicationFactory to bootstrap environment
-    /// </summary>
-    public PresentationContext GetNewPresentationContext(
-        QueryTrackingBehavior queryTrackingBehavior = QueryTrackingBehavior.TrackAll)
-    {
-        var context = new PresentationContext(
-            new DbContextOptionsBuilder<PresentationContext>()
-                .UseNpgsql(ConnectionString, builder => builder.SetPostgresVersion(14, 0))
-                .UseSnakeCaseNamingConvention()
-                .Options, new MigrationCustomerIdProvider());
-        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
-        return context;
-    }
     
     /// <summary>
     /// Get a new <see cref="PresentationContext"/> using connection string of this Postgres docker image.

--- a/src/IIIFPresentation/Test.Helpers/Integration/PresentationContextFixture.cs
+++ b/src/IIIFPresentation/Test.Helpers/Integration/PresentationContextFixture.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using Models.Database.Collections;
 using Models.Database.General;
 using Repository;
+using Repository.Helpers;
 using Test.Helpers.Helpers;
 using Testcontainers.PostgreSql;
 
@@ -15,6 +16,9 @@ public class PresentationContextFixture : IAsyncLifetime
     private readonly PostgreSqlContainer postgresContainer;
     
     public PresentationContext DbContext { get; private set; }
+    
+    public ICustomerIdProvider  CustomerIdProvider { get; private set; }
+    
     public string ConnectionString { get; private set; }
     
     /// <summary>
@@ -300,11 +304,13 @@ public class PresentationContextFixture : IAsyncLifetime
         // Start DB + apply migrations
         try
         {
+            var customerIdProvider = new TestCustomerIdProvider();
             await postgresContainer.StartAsync();
-            SetPropertiesFromContainer();
+            SetPropertiesFromContainer(customerIdProvider);
             await DbContext.Database.MigrateAsync();
             await SeedRewriteCustomers();
             await SeedCustomer();
+            CustomerIdProvider =  customerIdProvider;
         }
         catch (Exception ex)
         {
@@ -335,17 +341,34 @@ public class PresentationContextFixture : IAsyncLifetime
             new DbContextOptionsBuilder<PresentationContext>()
                 .UseNpgsql(ConnectionString, builder => builder.SetPostgresVersion(14, 0))
                 .UseSnakeCaseNamingConvention()
-                .Options);
+                .Options, new MigrationCustomerIdProvider());
+        context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
+        return context;
+    }
+    
+    /// <summary>
+    /// Get a new <see cref="PresentationContext"/> using connection string of this Postgres docker image.
+    /// Unlike the DbContext property this has full query tracking enabled to mimic 'real' context. This should be
+    /// used in instances where integration tests aren't using WebApplicationFactory to bootstrap environment
+    /// </summary>
+    public PresentationContext GetNewPresentationContext(ICustomerIdProvider customerIdProvider, 
+        QueryTrackingBehavior queryTrackingBehavior = QueryTrackingBehavior.TrackAll)
+    {
+        var context = new PresentationContext(
+            new DbContextOptionsBuilder<PresentationContext>()
+                .UseNpgsql(ConnectionString, builder => builder.SetPostgresVersion(14, 0))
+                .UseSnakeCaseNamingConvention()
+                .Options, customerIdProvider);
         context.ChangeTracker.QueryTrackingBehavior = queryTrackingBehavior;
         return context;
     }
 
-    private void SetPropertiesFromContainer()
+    private void SetPropertiesFromContainer(ICustomerIdProvider customerIdProvider)
     {
         ConnectionString = $"{postgresContainer.GetConnectionString()};Include Error Detail=true";
 
         // Create new PresentationContext using connection string for Postgres container
-        DbContext = GetNewPresentationContext(QueryTrackingBehavior.NoTracking);
+        DbContext = GetNewPresentationContext(customerIdProvider, QueryTrackingBehavior.NoTracking);
     }
 
     public void CleanUp()
@@ -355,4 +378,13 @@ public class PresentationContextFixture : IAsyncLifetime
         DbContext.Database.ExecuteSqlRaw(
             "DELETE FROM manifests WHERE customer_id != 1 AND id NOT IN ('FirstChildManifest', 'FirstChildManifestProcessing')");
     }
+}
+
+public class TestCustomerIdProvider : ICustomerIdProvider
+{
+    private int customerId = 1;
+    
+    public int GetCustomerId() => customerId;
+
+    public void SetCustomerId(int customerId) => this.customerId = customerId;
 }

--- a/src/IIIFPresentation/Test.Helpers/Integration/PresentationContextX.cs
+++ b/src/IIIFPresentation/Test.Helpers/Integration/PresentationContextX.cs
@@ -11,9 +11,9 @@ public static class PresentationContextX
     public static Guid? GetETag<T>(this PresentationContext db, T obj)
         => obj switch
         {
-            Collection c => db.Collections.AsNoTracking().FirstOrDefault(x => x.Id == c.Id && x.CustomerId == c.CustomerId)?.Etag,
+            Collection c => db.Collections.AsNoTracking().FirstOrDefault(x => x.Id == c.Id)?.Etag,
             EntityEntry<Collection> c => db.GetETag(c.Entity),
-            Manifest m => db.Manifests.AsNoTracking().FirstOrDefault(x => x.Id == m.Id && x.CustomerId == m.CustomerId)?.Etag,
+            Manifest m => db.Manifests.AsNoTracking().FirstOrDefault(x => x.Id == m.Id)?.Etag,
             EntityEntry<Manifest> c => db.GetETag(c.Entity),
             _ => null
         };
@@ -21,7 +21,7 @@ public static class PresentationContextX
     public static Guid? GetETag(this PresentationContext db, string id, int customerId, ResourceType resourceType)
         => resourceType switch
         {
-            ResourceType.IIIFManifest => db.Manifests.AsNoTracking().FirstOrDefault(x => x.Id == id && x.CustomerId == customerId)?.Etag,
-            _ => db.Collections.AsNoTracking().FirstOrDefault(x => x.Id == id && x.CustomerId == customerId)?.Etag
+            ResourceType.IIIFManifest => db.Manifests.AsNoTracking().FirstOrDefault(x => x.Id == id)?.Etag,
+            _ => db.Collections.AsNoTracking().FirstOrDefault(x => x.Id == id)?.Etag
         };
 }


### PR DESCRIPTION
Resolves #573

## What does this change?

This PR adds global query filter on customer id across the tables in the database so that it can be omitted from any data retrieval.  This will fix any occurrences of not filtering by customer id, which is required on effectively every query

> [!Note]
> Certain tests and test classes do require not filtering across customer id, this can be accomplished with adding `.IgnoreFilterQueries` to LINQ

Adding this filter to any future database tables just requires implementing the `ICustomerEntity` interface and through reflection the new table will receive the benefits of the customer id filter.  This should have minimal impact on performance as it happens once during startup

## Database Migration

While there is no migration for this work, there *is* changes to how querying for data works.  This has been called out on the readme

