### PR TITLE
Pin version of localstack used in tests

### DIFF
--- a/src/IIIFPresentation/Test.Helpers/Integration/LocalStackFixture.cs
+++ b/src/IIIFPresentation/Test.Helpers/Integration/LocalStackFixture.cs
@@ -25,7 +25,7 @@ public class LocalStackFixture : IAsyncLifetime
     {
         // Configure container binding to host port 0, which will use a random free port
         var localStackBuilder = new ContainerBuilder()
-            .WithImage("localstack/localstack")
+            .WithImage("localstack/localstack:4.14.0")
             .WithCleanUp(true)
             .WithLabel("protagonist_test", "True")
             .WithEnvironment("DEFAULT_REGION", "eu-west-1")


### PR DESCRIPTION
Actions recently started failing, 4.14.0 is the highest version prior to failures occurring.

See https://docs.localstack.cloud/aws/changelog/#official-releases