### PR TITLE
Update README for IIIF-Cloud Services terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ if you would like to view the SQL the migration will produce, you can use the fo
 dotnet ef migrations script -i -o .\migrate.sql -p Repository -s API
 ```
 
-### DLCS Named Query
+### IIIF-Cloud Services Named Query
 
-As part of handling assets in canvas paintings, items are ingested via the DLCS.  In order to track items that have been ingested, a new global named query needs to be added to the DLCS to track manifests.  This can be done in 2 ways, as follows:
+As part of handling assets in canvas paintings, items are ingested via the IIIF-CS.  In order to track items that have been ingested, a new global named query needs to be added to the IIIF-CS to track manifests.  This can be done in 2 ways, as follows:
 
 1. POST to the named query endpoint:
 
-**NOTE:** This is required to be done as the admin customer using the DLCS API
+**NOTE:** This is required to be done as the admin customer using the IIIF-CS API
 
 ```
 POST {{baseUrl}}/customers/1/namedQueries
@@ -48,7 +48,7 @@ POST {{baseUrl}}/customers/1/namedQueries
 }
 ```
 
-2. Directly into the DLCS database
+2. Directly into the Protagonist database
 
 ```sql
 INSERT INTO "NamedQueries" ("Id", "Customer", "Name", "Global", "Template")
@@ -71,7 +71,7 @@ The IIIF Presentation solution is made up of a series of C# projects, scripts an
 | AWS | Module that contains calls and helper functions that interact with AWS |
 | BackgroundHandler | Contains anything that needs to occur after actions from third-party services have completed, such as interactions with Protagonist |
 | Core | Low-level module that provides helper functions to all projects  |
-| DLCS | Contains calling code for the DLCS to allow images to be ingested and retrieved |
+| DLCS | Contains client code for the DLCS to allow assets to be ingested and retrieved |
 | Models | POCO's used throughout the solution |
 | Repository | Used primarily to provide access to the database context, as well as various helper functions and some data access classes |
 | Services | Contains functions that are shared by running applications only, such as the API and BackgroundHandler |


### PR DESCRIPTION
Replace usages of "DLCS" where makes sense

## What does this change?

Readme changes only, prefer "IIIF Cloud Services" over DLCS