### PR TITLE
Add /version endpoint to API

### DIFF
--- a/.github/actions/docker-build-and-push/action.yml
+++ b/.github/actions/docker-build-and-push/action.yml
@@ -46,3 +46,5 @@ runs:
         tags: ${{ steps.docker-meta.outputs.tags }}
         labels: ${{ steps.docker-meta.outputs.labels }}
         push: ${{ github.actor != 'dependabot[bot]' }}
+        build-args: |
+          APP_VERSION=${{ steps.docker-meta.outputs.version }}

--- a/.github/workflows/run_build.yml
+++ b/.github/workflows/run_build.yml
@@ -10,6 +10,10 @@ on:
       - "docs/**"
       - "scripts/**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-dotnet:
     runs-on: ubuntu-latest

--- a/Dockerfile.API
+++ b/Dockerfile.API
@@ -16,6 +16,8 @@ FROM build AS publish
 RUN dotnet publish "API.csproj" -c Release -o /app/publish
 
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+ARG APP_VERSION=dev
+ENV APP_VERSION=${APP_VERSION}
 
 LABEL maintainer="Donald Gray <donald.gray@digirati.com>,Tom Crane <tom.crane@digirati.com>, Jack Lewis <jack.lewis@digirati.com>"
 LABEL org.opencontainers.image.source=https://github.com/dlcs/iiif-presentation

--- a/src/IIIFPresentation/API/Infrastructure/Http/EndpointRouteBuilderX.cs
+++ b/src/IIIFPresentation/API/Infrastructure/Http/EndpointRouteBuilderX.cs
@@ -1,0 +1,10 @@
+namespace API.Infrastructure.Http;
+
+public static class EndpointRouteBuilderX
+{
+    public static RouteHandlerBuilder AddVersionEndpoint(this IEndpointRouteBuilder endpoints, string path = "/version")
+    {
+        return endpoints.MapGet(path,
+            () => Results.Ok(new { version = Environment.GetEnvironmentVariable("APP_VERSION") ?? "unknown" }));
+    }
+}

--- a/src/IIIFPresentation/API/Program.cs
+++ b/src/IIIFPresentation/API/Program.cs
@@ -129,6 +129,7 @@ app
 app.MapControllers();
 
 app.MapHealthChecks("/health");
+app.AddVersionEndpoint();
 
 app.Run();
 


### PR DESCRIPTION
## What does this change?

Add `/version` endpoint to API.

This mimics how protagonist works, will make it easier to implement an automated version checker in future.

Basically brings over the same changes as 
* https://github.com/dlcs/protagonist/pull/1156
* https://github.com/dlcs/protagonist/pull/1131
