### PR TITLE
Implement manifest level adjuncts into the API

### DIFF
--- a/src/IIIFPresentation/API.Tests/Features/Common/Helpers/ResourceAdjunctInteractionsTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Common/Helpers/ResourceAdjunctInteractionsTests.cs
@@ -1,0 +1,72 @@
+using API.Features.Common.Helpers;
+using Models.DLCS;
+using Newtonsoft.Json.Linq;
+
+namespace API.Tests.Features.Common.Helpers;
+
+public class ResourceAdjunctInteractionsTests
+{
+    [Fact]
+    public void GetResourceStubAssetId_ReturnsAssetIdInSpace0()
+    {
+        var result = ResourceAdjunctInteractions.GetResourceStubAssetId(5, "my-manifest");
+
+        result.Customer.Should().Be(5);
+        result.Space.Should().Be(0);
+        result.Asset.Should().Be("Manifest_my-manifest");
+    }
+
+    [Fact]
+    public void GetAdjunctInteraction_ReturnsNull_WhenAdjunctsIsNull()
+    {
+        var result = ResourceAdjunctInteractions.GetAdjunctInteraction(null, 1, "my-manifest");
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetAdjunctInteraction_ReturnsEmptyAdjuncts_WhenAdjunctsIsEmptyList()
+    {
+        var result = ResourceAdjunctInteractions.GetAdjunctInteraction([], 1, "my-manifest");
+
+        result.Should().NotBeNull();
+        result!.Adjuncts.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GetAdjunctInteraction_SetsCorrectAssetId()
+    {
+        var result = ResourceAdjunctInteractions.GetAdjunctInteraction([], 5, "my-manifest");
+
+        result!.AssetId.Should().Be(new AssetId(5, 0, "Manifest_my-manifest"));
+    }
+
+    [Fact]
+    public void GetAdjunctInteraction_StampsAssetPropertyOnEachAdjunct()
+    {
+        var adjuncts = new List<JObject>
+        {
+            JObject.Parse("""{ "id": "mets.xml", "mediaType": "text/xml" }"""),
+            JObject.Parse("""{ "id": "thumb.jpg", "mediaType": "image/jpeg" }""")
+        };
+
+        ResourceAdjunctInteractions.GetAdjunctInteraction(adjuncts, 3, "res-1");
+
+        adjuncts[0]["asset"]!.Value<string>().Should().Be("3/0/Manifest_res-1");
+        adjuncts[1]["asset"]!.Value<string>().Should().Be("3/0/Manifest_res-1");
+    }
+
+    [Fact]
+    public void GetAdjunctInteraction_ReturnedAdjunctsContainAllItems()
+    {
+        var adjuncts = new List<JObject>
+        {
+            JObject.Parse("""{ "id": "mets.xml" }"""),
+            JObject.Parse("""{ "id": "thumb.jpg" }""")
+        };
+
+        var result = ResourceAdjunctInteractions.GetAdjunctInteraction(adjuncts, 1, "res-1");
+
+        result!.Adjuncts.Should().HaveCount(2);
+    }
+}

--- a/src/IIIFPresentation/API.Tests/Features/Common/Helpers/ResourceAdjunctInteractionsTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Common/Helpers/ResourceAdjunctInteractionsTests.cs
@@ -10,7 +10,7 @@ public class ResourceAdjunctInteractionsTests
     [Fact]
     public void GetResourceStubAssetId_ReturnsAssetIdInSpace0()
     {
-        var result = ResourceAdjunctInteractions.GetResourceStubAssetId(5, "my-manifest");
+        var result = ResourceAdjunctInteractions.GetResourceStubAssetId(new PresentationManifest(), 5, "my-manifest");
 
         result.Customer.Should().Be(5);
         result.Space.Should().Be(0);

--- a/src/IIIFPresentation/API.Tests/Features/Common/Helpers/ResourceAdjunctInteractionsTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Common/Helpers/ResourceAdjunctInteractionsTests.cs
@@ -1,4 +1,5 @@
 using API.Features.Common.Helpers;
+using Models.API.Manifest;
 using Models.DLCS;
 using Newtonsoft.Json.Linq;
 
@@ -19,7 +20,7 @@ public class ResourceAdjunctInteractionsTests
     [Fact]
     public void GetAdjunctInteraction_ReturnsNull_WhenAdjunctsIsNull()
     {
-        var result = ResourceAdjunctInteractions.GetAdjunctInteraction(null, 1, "my-manifest");
+        var result = ResourceAdjunctInteractions.GetAdjunctInteraction(new PresentationManifest { Id = "my-manifest" }, 1);
 
         result.Should().BeNull();
     }
@@ -27,7 +28,8 @@ public class ResourceAdjunctInteractionsTests
     [Fact]
     public void GetAdjunctInteraction_ReturnsEmptyAdjuncts_WhenAdjunctsIsEmptyList()
     {
-        var result = ResourceAdjunctInteractions.GetAdjunctInteraction([], 1, "my-manifest");
+        var result = ResourceAdjunctInteractions.GetAdjunctInteraction(
+            new PresentationManifest { Id = "my-manifest", Adjuncts = [] }, 1);
 
         result.Should().NotBeNull();
         result!.Adjuncts.Should().BeEmpty();
@@ -36,7 +38,8 @@ public class ResourceAdjunctInteractionsTests
     [Fact]
     public void GetAdjunctInteraction_SetsCorrectAssetId()
     {
-        var result = ResourceAdjunctInteractions.GetAdjunctInteraction([], 5, "my-manifest");
+        var result = ResourceAdjunctInteractions.GetAdjunctInteraction(
+            new PresentationManifest { Id = "my-manifest", Adjuncts = [] }, 5);
 
         result!.AssetId.Should().Be(new AssetId(5, 0, "Manifest_my-manifest"));
     }
@@ -50,7 +53,8 @@ public class ResourceAdjunctInteractionsTests
             JObject.Parse("""{ "id": "thumb.jpg", "mediaType": "image/jpeg" }""")
         };
 
-        ResourceAdjunctInteractions.GetAdjunctInteraction(adjuncts, 3, "res-1");
+        ResourceAdjunctInteractions.GetAdjunctInteraction(
+            new PresentationManifest { Id = "res-1", Adjuncts = adjuncts }, 3);
 
         adjuncts[0]["asset"]!.Value<string>().Should().Be("3/0/Manifest_res-1");
         adjuncts[1]["asset"]!.Value<string>().Should().Be("3/0/Manifest_res-1");
@@ -65,7 +69,8 @@ public class ResourceAdjunctInteractionsTests
             JObject.Parse("""{ "id": "thumb.jpg" }""")
         };
 
-        var result = ResourceAdjunctInteractions.GetAdjunctInteraction(adjuncts, 1, "res-1");
+        var result = ResourceAdjunctInteractions.GetAdjunctInteraction(
+            new PresentationManifest { Id = "res-1", Adjuncts = adjuncts }, 1);
 
         result!.Adjuncts.Should().HaveCount(2);
     }

--- a/src/IIIFPresentation/API.Tests/Features/Manifest/Validators/PresentationManifestValidatorTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Manifest/Validators/PresentationManifestValidatorTests.cs
@@ -566,4 +566,95 @@ public class PresentationManifestValidatorTests
         var result = sut.TestValidate(manifest);
         result.Errors.Should().Contain(e => e.ErrorMessage == "Adjunct 'id' must not be empty");
     }
+
+    [Fact]
+    public void ManifestAdjuncts_NoError_WhenValidAdjunct()
+    {
+        var manifest = new PresentationManifest
+        {
+            Slug = "test",
+            Parent = "https://example.com/root",
+            Adjuncts =
+            [
+                new JObject
+                {
+                    [AdjunctProperties.Id] = "manifest-adjunct",
+                    ["mediaType"] = "text/xml"
+                }
+            ]
+        };
+
+        var result = sut.TestValidate(manifest);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void ManifestAdjuncts_NoError_WhenAdjunctsNull()
+    {
+        var manifest = new PresentationManifest
+        {
+            Slug = "test",
+            Parent = "https://example.com/root",
+            Adjuncts = null
+        };
+
+        var result = sut.TestValidate(manifest);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void ManifestAdjuncts_NoError_WhenAdjunctsEmpty()
+    {
+        var manifest = new PresentationManifest
+        {
+            Slug = "test",
+            Parent = "https://example.com/root",
+            Adjuncts = []
+        };
+
+        var result = sut.TestValidate(manifest);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void ManifestAdjuncts_Error_WhenAdjunctHasNoId()
+    {
+        var manifest = new PresentationManifest
+        {
+            Slug = "test",
+            Parent = "https://example.com/root",
+            Adjuncts =
+            [
+                new JObject
+                {
+                    ["mediaType"] = "text/xml"
+                }
+            ]
+        };
+
+        var result = sut.TestValidate(manifest);
+        result.Errors.Should().Contain(e => e.ErrorMessage == "Adjunct 'id' must not be empty");
+    }
+
+    [Theory]
+    [InlineData("foo/bar")]
+    [InlineData("foo\\bar")]
+    public void ManifestAdjuncts_Error_WhenAdjunctIdHasProhibitedCharacters(string adjunctId)
+    {
+        var manifest = new PresentationManifest
+        {
+            Slug = "test",
+            Parent = "https://example.com/root",
+            Adjuncts =
+            [
+                new JObject
+                {
+                    [AdjunctProperties.Id] = adjunctId
+                }
+            ]
+        };
+
+        var result = sut.TestValidate(manifest);
+        result.Errors.Should().Contain(e => e.ErrorMessage.StartsWith("Adjunct 'id' contains a prohibited character"));
+    }
 }

--- a/src/IIIFPresentation/API.Tests/Features/Manifest/Validators/PresentationManifestValidatorTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Manifest/Validators/PresentationManifestValidatorTests.cs
@@ -657,4 +657,25 @@ public class PresentationManifestValidatorTests
         var result = sut.TestValidate(manifest);
         result.Errors.Should().Contain(e => e.ErrorMessage.StartsWith("Adjunct 'id' contains a prohibited character"));
     }
+
+    [Fact]
+    public void ManifestAdjuncts_Error_WhenAdjunctHasAssetProperty()
+    {
+        var manifest = new PresentationManifest
+        {
+            Slug = "test",
+            Parent = "https://example.com/root",
+            Adjuncts =
+            [
+                new JObject
+                {
+                    [AdjunctProperties.Id] = "mets.xml",
+                    [AssetProperties.Asset] = "1/0/Manifest_some-id"
+                }
+            ]
+        };
+
+        var result = sut.TestValidate(manifest);
+        result.Errors.Should().Contain(e => e.ErrorMessage.Contains("'asset'"));
+    }
 }

--- a/src/IIIFPresentation/API.Tests/Integration/GetManifestTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/GetManifestTests.cs
@@ -513,7 +513,7 @@ public class GetManifestTests : IClassFixture<PresentationAppFactory<Program>>
             ContentBody = TestContent.ManifestJson,
         });
 
-        var manifestAdjunctId = ResourceAdjunctInteractions.GetResourceStubAssetId(PresentationContextFixture.CustomerId, id).Asset;
+        var manifestAdjunctId = ResourceAdjunctInteractions.GetResourceStubAssetId(new PresentationManifest(), PresentationContextFixture.CustomerId, id).Asset;
         A.CallTo(() => DLCSApiClient.GetCustomerImages(PresentationContextFixture.CustomerId, id, A<CancellationToken>._))
             .Returns(Task.FromResult<IList<JObject>>(
             [

--- a/src/IIIFPresentation/API.Tests/Integration/GetManifestTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/GetManifestTests.cs
@@ -512,16 +512,16 @@ public class GetManifestTests : IClassFixture<PresentationAppFactory<Program>>
             ContentBody = TestContent.ManifestJson,
         });
 
-        var stubAssetName = CanvasPaintingResolver.ManifestStubAssetId(id);
+        var manifestAdjunctId = CanvasPaintingResolver.ManifestLevelAdjunctId(id);
         A.CallTo(() => DLCSApiClient.GetCustomerImages(PresentationContextFixture.CustomerId, id, A<CancellationToken>._))
             .Returns(Task.FromResult<IList<JObject>>(
             [
                 JObject.Parse($$"""
                     {
-                        "@id": "https://localhost/customers/1/spaces/0/images/{{stubAssetName}}",
-                        "id": "{{stubAssetName}}",
+                        "@id": "https://localhost/customers/1/spaces/0/images/{{manifestAdjunctId}}",
+                        "id": "{{manifestAdjunctId}}",
                         "space": 0,
-                        "adjuncts": [{ "id": "mets.xml", "asset": "1/0/{{stubAssetName}}" }]
+                        "adjuncts": [{ "id": "mets.xml", "asset": "1/0/{{manifestAdjunctId}}" }]
                     }
                     """)
             ]));

--- a/src/IIIFPresentation/API.Tests/Integration/GetManifestTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/GetManifestTests.cs
@@ -50,7 +50,6 @@ public class GetManifestTests : IClassFixture<PresentationAppFactory<Program>>
     {
         s3 = storageFixture.LocalStackFixture.AWSS3ClientFactory();
         dbContext = storageFixture.DbFixture.DbContext;
-        Fake.ClearRecordedCalls(DLCSApiClient);
         httpClient = factory.ConfigureBasicIntegrationTestHttpClient(storageFixture.DbFixture,
             appFactory => appFactory.WithLocalStack(storageFixture.LocalStackFixture),
             services => services.AddSingleton(DLCSApiClient));

--- a/src/IIIFPresentation/API.Tests/Integration/GetManifestTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/GetManifestTests.cs
@@ -512,7 +512,7 @@ public class GetManifestTests : IClassFixture<PresentationAppFactory<Program>>
             ContentBody = TestContent.ManifestJson,
         });
 
-        var manifestAdjunctId = CanvasPaintingResolver.ManifestLevelAdjunctId(id);
+        var manifestAdjunctId = CanvasPaintingResolver.ManifestStubAssetId(PresentationContextFixture.CustomerId, id).Asset;
         A.CallTo(() => DLCSApiClient.GetCustomerImages(PresentationContextFixture.CustomerId, id, A<CancellationToken>._))
             .Returns(Task.FromResult<IList<JObject>>(
             [

--- a/src/IIIFPresentation/API.Tests/Integration/GetManifestTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/GetManifestTests.cs
@@ -3,6 +3,7 @@
 using System.Net;
 using Amazon.S3;
 using API.Converters;
+using API.Features.Common.Helpers;
 using API.Features.Manifest;
 using API.Tests.Integration.Infrastructure;
 using Core.Response;
@@ -512,7 +513,7 @@ public class GetManifestTests : IClassFixture<PresentationAppFactory<Program>>
             ContentBody = TestContent.ManifestJson,
         });
 
-        var manifestAdjunctId = CanvasPaintingResolver.ManifestStubAssetId(PresentationContextFixture.CustomerId, id).Asset;
+        var manifestAdjunctId = ResourceAdjunctInteractions.GetResourceStubAssetId(PresentationContextFixture.CustomerId, id).Asset;
         A.CallTo(() => DLCSApiClient.GetCustomerImages(PresentationContextFixture.CustomerId, id, A<CancellationToken>._))
             .Returns(Task.FromResult<IList<JObject>>(
             [

--- a/src/IIIFPresentation/API.Tests/Integration/GetManifestTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/GetManifestTests.cs
@@ -3,6 +3,7 @@
 using System.Net;
 using Amazon.S3;
 using API.Converters;
+using API.Features.Manifest;
 using API.Tests.Integration.Infrastructure;
 using Core.Response;
 using Core.Web;
@@ -37,7 +38,7 @@ public class GetManifestTests : IClassFixture<PresentationAppFactory<Program>>
     private readonly PresentationContext dbContext;
 
     private readonly IAmazonS3 amazonS3;
-    private readonly IDlcsApiClient dlcsApiClient;
+    private static readonly IDlcsApiClient DLCSApiClient = A.Fake<IDlcsApiClient>();
     private readonly IAmazonS3 s3;
     private readonly JObject sampleAsset;
     private const string PaintedResource = "foo-paintedResource";
@@ -48,13 +49,12 @@ public class GetManifestTests : IClassFixture<PresentationAppFactory<Program>>
     {
         s3 = storageFixture.LocalStackFixture.AWSS3ClientFactory();
         dbContext = storageFixture.DbFixture.DbContext;
-        dlcsApiClient = A.Fake<IDlcsApiClient>();
+        Fake.ClearRecordedCalls(DLCSApiClient);
         httpClient = factory.ConfigureBasicIntegrationTestHttpClient(storageFixture.DbFixture,
             appFactory => appFactory.WithLocalStack(storageFixture.LocalStackFixture),
-            services => services.AddSingleton(dlcsApiClient));
+            services => services.AddSingleton(DLCSApiClient));
 
         amazonS3 = storageFixture.LocalStackFixture.AWSS3ClientFactory();
-
         storageFixture.DbFixture.CleanUp();
 
         sampleAsset = JObject.Parse(
@@ -96,12 +96,12 @@ public class GetManifestTests : IClassFixture<PresentationAppFactory<Program>>
             """
         );
         
-        A.CallTo(() => dlcsApiClient.GetCustomerImages(PresentationContextFixture.CustomerId,
+        A.CallTo(() => DLCSApiClient.GetCustomerImages(PresentationContextFixture.CustomerId,
                 A<string>.That.Matches(l => l.EndsWith("_returnsPainted")),
                 A<CancellationToken>._))
             .ReturnsLazily(() => [sampleAsset]);
         
-        A.CallTo(() => dlcsApiClient.GetCustomerImages(PresentationContextFixture.CustomerId,
+        A.CallTo(() => DLCSApiClient.GetCustomerImages(PresentationContextFixture.CustomerId,
                 A<string>.That.Matches(l => l.EndsWith("_ingestingAssets")),
                 A<CancellationToken>._))
             .ReturnsLazily(() => [ingestingAsset, errorAsset]);
@@ -496,5 +496,47 @@ public class GetManifestTests : IClassFixture<PresentationAppFactory<Program>>
         manifest!.Type.Should().Be("Manifest");
         manifest.Id.Should().Be($"http://localhost/1/sm_{id}", "requested by hierarchical URI");
         manifest.Items.Should().HaveCount(3, "the test content contains 3 children");
+    }
+
+    [Fact]
+    public async Task Get_IiifManifest_Flat_WithStubAsset_StripsAssetPropertyFromAdjuncts()
+    {
+        // Arrange
+        var (_, id) = TestIdentifiers.SlugResource();
+        await dbContext.Manifests.AddTestManifest(id);
+        await dbContext.SaveChangesAsync();
+        await s3.PutObjectAsync(new()
+        {
+            BucketName = LocalStackFixture.StorageBucketName,
+            Key = $"1/manifests/{id}",
+            ContentBody = TestContent.ManifestJson,
+        });
+
+        var stubAssetName = CanvasPaintingResolver.ManifestStubAssetId(id);
+        A.CallTo(() => DLCSApiClient.GetCustomerImages(PresentationContextFixture.CustomerId, id, A<CancellationToken>._))
+            .Returns(Task.FromResult<IList<JObject>>(
+            [
+                JObject.Parse($$"""
+                    {
+                        "@id": "https://localhost/customers/1/spaces/0/images/{{stubAssetName}}",
+                        "id": "{{stubAssetName}}",
+                        "space": 0,
+                        "adjuncts": [{ "id": "mets.xml", "asset": "1/0/{{stubAssetName}}" }]
+                    }
+                    """)
+            ]));
+
+        var requestMessage = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get, $"1/manifests/{id}");
+
+        // Act
+        var response = await httpClient.AsCustomer().SendAsync(requestMessage);
+        var manifest = await response.ReadAsPresentationJsonAsync<PresentationManifest>();
+        
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        manifest.Adjuncts.Should().HaveCount(1);
+        // "asset" back-reference to stub is not exposed in the API response
+        manifest.Adjuncts[0].ContainsKey("asset").Should().BeFalse();
+        manifest.Adjuncts[0]["id"].Value<string>().Should().Be("mets.xml");
     }
 }

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestManifestAdjunctTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestManifestAdjunctTests.cs
@@ -139,6 +139,7 @@ public class ModifyManifestManifestAdjunctTests : IClassFixture<PresentationAppF
 
         responseManifest!.Adjuncts.Should().HaveCount(1);
         responseManifest.Adjuncts![0]["id"]!.Value<string>().Should().Be("mets.xml");
+        responseManifest.Adjuncts[0]["asset"].Should().BeNull("asset property should be stripped from response");
     }
 
     [Fact]

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestManifestAdjunctTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestManifestAdjunctTests.cs
@@ -1,0 +1,512 @@
+using System.Net;
+using API.Features.Manifest;
+using API.Tests.Integration.Infrastructure;
+using Core.Response;
+using DLCS.API;
+using DLCS.Models;
+using FakeItEasy;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Models.API.Manifest;
+using Models.Database.General;
+using Models.DLCS;
+using Newtonsoft.Json.Linq;
+using Repository;
+using Test.Helpers;
+using Test.Helpers.Helpers;
+using Test.Helpers.Integration;
+using Batch = DLCS.Models.Batch;
+
+namespace API.Tests.Integration;
+
+[Trait("Category", "Integration")]
+[Collection(CollectionDefinitions.StorageCollection.CollectionName)]
+public class ModifyManifestManifestAdjunctTests : IClassFixture<PresentationAppFactory<Program>>
+{
+    private readonly HttpClient httpClient;
+    private readonly PresentationContext dbContext;
+    private const int Customer = 1;
+    private const int NewlyCreatedSpace = 999;
+    private static readonly IDlcsApiClient DLCSApiClient = A.Fake<IDlcsApiClient>();
+    private static readonly IDlcsOrchestratorClient DLCSOrchestratorClient = A.Fake<IDlcsOrchestratorClient>();
+
+    public ModifyManifestManifestAdjunctTests(StorageFixture storageFixture, PresentationAppFactory<Program> factory)
+    {
+        dbContext = storageFixture.DbFixture.DbContext;
+
+        Fake.ClearRecordedCalls(DLCSApiClient);
+
+        A.CallTo(() => DLCSApiClient.CreateSpace(Customer, A<string>._, A<CancellationToken>._))
+            .Returns(new Space { Id = NewlyCreatedSpace, Name = "test" });
+
+        // Return a fresh batch ID for each IngestDeliverables call
+        A.CallTo(() => DLCSApiClient.IngestDeliverables(Customer, A<List<JObject>>._, A<bool>._, A<CancellationToken>._))
+            .ReturnsLazily(_ => Task.FromResult(new List<Batch>
+            {
+                new() { ResourceId = TestIdentifiers.BatchId().ToString(), Submitted = DateTime.Now }
+            }));
+
+        // Default: no images exist in DLCS
+        A.CallTo(() => DLCSApiClient.GetCustomerImages(Customer, A<ICollection<string>>._, A<CancellationToken>._))
+            .Returns(Task.FromResult<IList<JObject>>([]));
+
+        httpClient = factory.ConfigureBasicIntegrationTestHttpClient(storageFixture.DbFixture,
+            appFactory => appFactory.WithLocalStack(storageFixture.LocalStackFixture),
+            services => services
+                .AddSingleton(DLCSApiClient)
+                .AddSingleton(DLCSOrchestratorClient));
+
+        storageFixture.DbFixture.CleanUp();
+        dbContext.ChangeTracker.Clear();
+    }
+
+    [Fact]
+    public async Task CreateManifest_WithManifestAdjuncts_CreatesStubAssetAndIngestsAdjuncts()
+    {
+        // Arrange
+        var (slug, _) = TestIdentifiers.SlugResource();
+        var adjunctId = "mets.xml";
+
+        var payload = $$"""
+            {
+                "type": "Manifest",
+                "slug": "{{slug}}",
+                "parent": "http://localhost/{{Customer}}/collections/root",
+                "adjuncts": [
+                    { "id": "{{adjunctId}}", "mediaType": "text/xml", "iiifLink": "seeAlso" }
+                ]
+            }
+            """;
+
+        var request = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Post,
+            $"{Customer}/manifests", payload);
+
+        // Act
+        var response = await httpClient.AsCustomer().SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var responseManifest = await response.ReadAsPresentationResponseAsync<PresentationManifest>();
+        var manifestId = responseManifest!.Id!.Split('/').Last();
+
+        var expectedStubAssetId = CanvasPaintingResolver.ManifestStubAssetId(manifestId);
+
+        // Stub asset should be created via regular queue (adjunctQueue = false) in space 0
+        A.CallTo(() => DLCSApiClient.IngestDeliverables(Customer,
+                A<List<JObject>>.That.Matches(list =>
+                    list.Count == 1 &&
+                    list[0][AssetProperties.Id]!.Value<string>() == expectedStubAssetId &&
+                    list[0][AssetProperties.Space]!.Value<int>() == 0),
+                false, A<CancellationToken>._))
+            .MustHaveHappenedOnceExactly();
+
+        // Adjuncts should be ingested via adjunct queue (adjunctQueue = true)
+        A.CallTo(() => DLCSApiClient.IngestDeliverables(Customer,
+                A<List<JObject>>.That.Matches(list =>
+                    list.Count == 1 &&
+                    list[0][AdjunctProperties.Id]!.Value<string>() == adjunctId),
+                true, A<CancellationToken>._))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
+    public async Task CreateManifest_WithManifestAdjuncts_ReturnsAdjunctsInResponse()
+    {
+        // Arrange
+        var (slug, _) = TestIdentifiers.SlugResource();
+
+        var payload = $$"""
+            {
+                "type": "Manifest",
+                "slug": "{{slug}}",
+                "parent": "http://localhost/{{Customer}}/collections/root",
+                "adjuncts": [
+                    { "id": "mets.xml", "mediaType": "text/xml" }
+                ]
+            }
+            """;
+
+        var request = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Post,
+            $"{Customer}/manifests", payload);
+
+        // Act
+        var response = await httpClient.AsCustomer().SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var responseManifest = await response.ReadAsPresentationResponseAsync<PresentationManifest>();
+
+        responseManifest!.Adjuncts.Should().HaveCount(1);
+        responseManifest.Adjuncts![0]["id"]!.Value<string>().Should().Be("mets.xml");
+    }
+
+    [Fact]
+    public async Task CreateManifest_WithManifestAdjuncts_TracksBatchesInDb()
+    {
+        // Arrange
+        var (slug, _) = TestIdentifiers.SlugResource();
+
+        var payload = $$"""
+            {
+                "type": "Manifest",
+                "slug": "{{slug}}",
+                "parent": "http://localhost/{{Customer}}/collections/root",
+                "adjuncts": [
+                    { "id": "mets.xml", "mediaType": "text/xml" }
+                ]
+            }
+            """;
+
+        var request = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Post,
+            $"{Customer}/manifests", payload);
+
+        // Act
+        var response = await httpClient.AsCustomer().SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var responseManifest = await response.ReadAsPresentationResponseAsync<PresentationManifest>();
+        var manifestId = responseManifest!.Id!.Split('/').Last();
+
+        var dbManifest = dbContext.Manifests
+            .Include(m => m.Batches)
+            .First(m => m.Id == manifestId);
+
+        // One batch for the stub asset (Asset type) and one for the adjuncts (Adjunct type)
+        dbManifest.Batches.Should().HaveCount(2);
+        dbManifest.Batches.Should().Contain(b => b.DeliverableType == DeliverableType.Asset);
+        dbManifest.Batches.Should().Contain(b => b.DeliverableType == DeliverableType.Adjunct);
+    }
+
+    [Fact]
+    public async Task CreateManifest_WithManifestAdjuncts_SetsManifestScopeOnStubAsset()
+    {
+        // Arrange
+        var (slug, _) = TestIdentifiers.SlugResource();
+
+        var payload = $$"""
+            {
+                "type": "Manifest",
+                "slug": "{{slug}}",
+                "parent": "http://localhost/{{Customer}}/collections/root",
+                "adjuncts": [
+                    { "id": "mets.xml", "mediaType": "text/xml" }
+                ]
+            }
+            """;
+
+        var request = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Post,
+            $"{Customer}/manifests", payload);
+
+        // Act
+        var response = await httpClient.AsCustomer().SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var responseManifest = await response.ReadAsPresentationResponseAsync<PresentationManifest>();
+        var manifestId = responseManifest!.Id!.Split('/').Last();
+
+        // Stub asset should have the manifest ID in its scopes
+        A.CallTo(() => DLCSApiClient.IngestDeliverables(Customer,
+                A<List<JObject>>.That.Matches(list =>
+                    list.Count == 1 &&
+                    list[0][AssetProperties.Manifests] != null &&
+                    ((JArray)list[0][AssetProperties.Manifests]!).Any(m => m.Value<string>() == manifestId)),
+                false, A<CancellationToken>._))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
+    public async Task CreateManifest_WithManifestAdjunctsAndCanvasAssets_CreatesBothStubAndCanvasAssets()
+    {
+        // Arrange
+        var (slug, _) = TestIdentifiers.SlugResource();
+
+        var payload = $$"""
+            {
+                "type": "Manifest",
+                "slug": "{{slug}}",
+                "parent": "http://localhost/{{Customer}}/collections/root",
+                "adjuncts": [
+                    { "id": "mets.xml", "mediaType": "text/xml" }
+                ],
+                "paintedResources": [
+                    {
+                        "asset": {
+                            "id": "canvas-asset",
+                            "origin": "https://example.com/image.jpg",
+                            "mediaType": "image/jpeg"
+                        }
+                    }
+                ]
+            }
+            """;
+
+        var request = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Post,
+            $"{Customer}/manifests", payload);
+
+        // Act
+        var response = await httpClient.AsCustomer().SendAsync(request);
+
+        // Assert - 202 because canvas assets are ingesting
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        var responseManifest = await response.ReadAsPresentationResponseAsync<PresentationManifest>();
+        var manifestId = responseManifest!.Id!.Split('/').Last();
+
+        // Canvas asset batch (space = newly created space)
+        A.CallTo(() => DLCSApiClient.IngestDeliverables(Customer,
+                A<List<JObject>>.That.Matches(list =>
+                    list.Count == 1 && list[0][AssetProperties.Id]!.Value<string>() == "canvas-asset"),
+                false, A<CancellationToken>._))
+            .MustHaveHappened();
+
+        // Stub asset batch (space 0)
+        A.CallTo(() => DLCSApiClient.IngestDeliverables(Customer,
+                A<List<JObject>>.That.Matches(list =>
+                    list.Count == 1 &&
+                    list[0][AssetProperties.Id]!.Value<string>() == CanvasPaintingResolver.ManifestStubAssetId(manifestId) &&
+                    list[0][AssetProperties.Space]!.Value<int>() == 0),
+                false, A<CancellationToken>._))
+            .MustHaveHappened();
+
+        // Adjunct batch
+        A.CallTo(() => DLCSApiClient.IngestDeliverables(Customer,
+                A<List<JObject>>.That.Matches(list =>
+                    list.Count == 1 && list[0][AdjunctProperties.Id]!.Value<string>() == "mets.xml"),
+                true, A<CancellationToken>._))
+            .MustHaveHappened();
+    }
+
+    [Fact]
+    public async Task UpdateManifest_AddingManifestAdjuncts_CreatesStubAssetAndIngestsAdjuncts()
+    {
+        // Arrange
+        var (slug, id) = TestIdentifiers.SlugResource();
+        var testManifest = await dbContext.Manifests.AddTestManifest(id: id, slug: slug,
+            batchId: TestIdentifiers.BatchId(), ingested: true);
+        await dbContext.SaveChangesAsync();
+
+        var payload = $$"""
+            {
+                "type": "Manifest",
+                "slug": "{{slug}}",
+                "parent": "http://localhost/{{Customer}}/collections/root",
+                "adjuncts": [
+                    { "id": "mets.xml", "mediaType": "text/xml" }
+                ]
+            }
+            """;
+
+        var request = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Put,
+            $"{Customer}/manifests/{id}", payload, dbContext.GetETag(testManifest));
+
+        // Act
+        var response = await httpClient.AsCustomer().SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // Stub asset created
+        A.CallTo(() => DLCSApiClient.IngestDeliverables(Customer,
+                A<List<JObject>>.That.Matches(list =>
+                    list.Count == 1 &&
+                    list[0][AssetProperties.Id]!.Value<string>() == CanvasPaintingResolver.ManifestStubAssetId(id) &&
+                    list[0][AssetProperties.Space]!.Value<int>() == 0),
+                false, A<CancellationToken>._))
+            .MustHaveHappenedOnceExactly();
+
+        // Adjuncts ingested
+        A.CallTo(() => DLCSApiClient.IngestDeliverables(Customer,
+                A<List<JObject>>.That.Matches(list =>
+                    list.Count == 1 && list[0][AdjunctProperties.Id]!.Value<string>() == "mets.xml"),
+                true, A<CancellationToken>._))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
+    public async Task UpdateManifest_ReplacingManifestAdjuncts_DeletesOldAndIngestsNew()
+    {
+        // Arrange
+        var (slug, id) = TestIdentifiers.SlugResource();
+        var existingAdjunctId = "old-mets.xml";
+        var newAdjunctId = "new-mets.xml";
+        var stubAssetId = CanvasPaintingResolver.ManifestStubAssetId(id);
+
+        // Simulate: stub asset exists in DLCS with an existing adjunct
+        A.CallTo(() => DLCSApiClient.GetCustomerImages(Customer, A<ICollection<string>>._, A<CancellationToken>._))
+            .ReturnsLazily((int _, ICollection<string> assetIds, CancellationToken _) =>
+                Task.FromResult<IList<JObject>>(assetIds
+                    .Where(a => a.EndsWith(stubAssetId))
+                    .Select(_ => JObject.Parse($$"""
+                        {
+                            "id": "{{stubAssetId}}",
+                            "space": 0,
+                            "adjuncts": [{ "id": "{{existingAdjunctId}}" }]
+                        }
+                        """))
+                    .ToList()));
+
+        var testManifest = await dbContext.Manifests.AddTestManifest(id: id, slug: slug,
+            batchId: TestIdentifiers.BatchId(), ingested: true);
+        await dbContext.SaveChangesAsync();
+
+        var payload = $$"""
+            {
+                "type": "Manifest",
+                "slug": "{{slug}}",
+                "parent": "http://localhost/{{Customer}}/collections/root",
+                "adjuncts": [
+                    { "id": "{{newAdjunctId}}", "mediaType": "text/xml" }
+                ]
+            }
+            """;
+
+        var request = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Put,
+            $"{Customer}/manifests/{id}", payload, dbContext.GetETag(testManifest));
+
+        // Act
+        var response = await httpClient.AsCustomer().SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // Old adjunct deleted
+        A.CallTo(() => DLCSApiClient.DeleteAdjuncts(Customer,
+                A<IEnumerable<AdjunctAssetIdentifier>>.That.Matches(list =>
+                    list.Any(a => a.Adjunct.Contains(existingAdjunctId))),
+                A<CancellationToken>._))
+            .MustHaveHappenedOnceExactly();
+
+        // New adjunct ingested
+        A.CallTo(() => DLCSApiClient.IngestDeliverables(Customer,
+                A<List<JObject>>.That.Matches(list =>
+                    list.Count == 1 && list[0][AdjunctProperties.Id]!.Value<string>() == newAdjunctId),
+                true, A<CancellationToken>._))
+            .MustHaveHappenedOnceExactly();
+
+        // Stub asset NOT re-created (it already exists)
+        A.CallTo(() => DLCSApiClient.IngestDeliverables(Customer,
+                A<List<JObject>>.That.Matches(list =>
+                    list.Any(j => j[AssetProperties.Space] != null && j[AssetProperties.Space]!.Value<int>() == 0)),
+                false, A<CancellationToken>._))
+            .MustNotHaveHappened();
+    }
+
+    [Fact]
+    public async Task UpdateManifest_EmptyManifestAdjuncts_DeletesAllExistingAdjuncts()
+    {
+        // Arrange
+        var (slug, id) = TestIdentifiers.SlugResource();
+        var existingAdjunctId = "old-mets.xml";
+        var stubAssetId = CanvasPaintingResolver.ManifestStubAssetId(id);
+
+        // Simulate: stub asset exists with existing adjunct
+        A.CallTo(() => DLCSApiClient.GetCustomerImages(Customer, A<ICollection<string>>._, A<CancellationToken>._))
+            .ReturnsLazily((int _, ICollection<string> assetIds, CancellationToken _) =>
+                Task.FromResult<IList<JObject>>(assetIds
+                    .Where(a => a.EndsWith(stubAssetId))
+                    .Select(_ => JObject.Parse($$"""
+                        {
+                            "id": "{{stubAssetId}}",
+                            "space": 0,
+                            "adjuncts": [{ "id": "{{existingAdjunctId}}" }]
+                        }
+                        """))
+                    .ToList()));
+
+        var testManifest = await dbContext.Manifests.AddTestManifest(id: id, slug: slug,
+            batchId: TestIdentifiers.BatchId(), ingested: true);
+        await dbContext.SaveChangesAsync();
+
+        var payload = $$"""
+            {
+                "type": "Manifest",
+                "slug": "{{slug}}",
+                "parent": "http://localhost/{{Customer}}/collections/root",
+                "adjuncts": []
+            }
+            """;
+
+        var request = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Put,
+            $"{Customer}/manifests/{id}", payload, dbContext.GetETag(testManifest));
+
+        // Act
+        var response = await httpClient.AsCustomer().SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // Existing adjunct deleted
+        A.CallTo(() => DLCSApiClient.DeleteAdjuncts(Customer,
+                A<IEnumerable<AdjunctAssetIdentifier>>.That.Matches(list =>
+                    list.Any(a => a.Adjunct.Contains(existingAdjunctId))),
+                A<CancellationToken>._))
+            .MustHaveHappenedOnceExactly();
+
+        // No new adjuncts ingested
+        A.CallTo(() => DLCSApiClient.IngestDeliverables(Customer, A<List<JObject>>._, true, A<CancellationToken>._))
+            .MustNotHaveHappened();
+    }
+
+    [Fact]
+    public async Task UpdateManifest_NullManifestAdjuncts_LeavesAdjunctsAlone()
+    {
+        // Arrange
+        var (slug, id) = TestIdentifiers.SlugResource();
+
+        var testManifest = await dbContext.Manifests.AddTestManifest(id: id, slug: slug,
+            batchId: TestIdentifiers.BatchId(), ingested: true);
+        await dbContext.SaveChangesAsync();
+
+        // No adjuncts property in payload
+        var payload = $$"""
+            {
+                "type": "Manifest",
+                "slug": "{{slug}}",
+                "parent": "http://localhost/{{Customer}}/collections/root"
+            }
+            """;
+
+        var request = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Put,
+            $"{Customer}/manifests/{id}", payload, dbContext.GetETag(testManifest));
+
+        // Act
+        var response = await httpClient.AsCustomer().SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // No DLCS calls for adjuncts
+        A.CallTo(() => DLCSApiClient.DeleteAdjuncts(Customer, A<IEnumerable<AdjunctAssetIdentifier>>._, A<CancellationToken>._))
+            .MustNotHaveHappened();
+        A.CallTo(() => DLCSApiClient.IngestDeliverables(Customer, A<List<JObject>>._, true, A<CancellationToken>._))
+            .MustNotHaveHappened();
+    }
+
+    [Fact]
+    public async Task CreateManifest_WithInvalidAdjunctId_Returns400()
+    {
+        // Arrange
+        var (slug, _) = TestIdentifiers.SlugResource();
+
+        var payload = $$"""
+            {
+                "type": "Manifest",
+                "slug": "{{slug}}",
+                "parent": "http://localhost/{{Customer}}/collections/root",
+                "adjuncts": [
+                    { "mediaType": "text/xml" }
+                ]
+            }
+            """;
+
+        var request = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Post,
+            $"{Customer}/manifests", payload);
+
+        // Act
+        var response = await httpClient.AsCustomer().SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+}

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestManifestAdjunctTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestManifestAdjunctTests.cs
@@ -89,7 +89,7 @@ public class ModifyManifestManifestAdjunctTests : IClassFixture<PresentationAppF
         var responseManifest = await response.ReadAsPresentationResponseAsync<PresentationManifest>();
         var manifestId = responseManifest!.Id!.Split('/').Last();
 
-        var expectedManifestAdjunctId = CanvasPaintingResolver.ManifestLevelAdjunctId(manifestId);
+        var expectedManifestAdjunctId = CanvasPaintingResolver.ManifestStubAssetId(Customer, manifestId).Asset;
 
         // Manifest-level adjunct asset should be created via regular queue (adjunctQueue = false) in space 0
         A.CallTo(() => DLCSApiClient.IngestDeliverables(Customer,
@@ -264,7 +264,7 @@ public class ModifyManifestManifestAdjunctTests : IClassFixture<PresentationAppF
         A.CallTo(() => DLCSApiClient.IngestDeliverables(Customer,
                 A<List<JObject>>.That.Matches(list =>
                     list.Count == 1 &&
-                    list[0][AssetProperties.Id]!.Value<string>() == CanvasPaintingResolver.ManifestLevelAdjunctId(manifestId) &&
+                    list[0][AssetProperties.Id]!.Value<string>() == CanvasPaintingResolver.ManifestStubAssetId(Customer, manifestId).Asset &&
                     list[0][AssetProperties.Space]!.Value<int>() == 0),
                 false, A<CancellationToken>._))
             .MustHaveHappened();
@@ -310,7 +310,7 @@ public class ModifyManifestManifestAdjunctTests : IClassFixture<PresentationAppF
         A.CallTo(() => DLCSApiClient.IngestDeliverables(Customer,
                 A<List<JObject>>.That.Matches(list =>
                     list.Count == 1 &&
-                    list[0][AssetProperties.Id]!.Value<string>() == CanvasPaintingResolver.ManifestLevelAdjunctId(id) &&
+                    list[0][AssetProperties.Id]!.Value<string>() == CanvasPaintingResolver.ManifestStubAssetId(Customer, id).Asset &&
                     list[0][AssetProperties.Space]!.Value<int>() == 0),
                 false, A<CancellationToken>._))
             .MustHaveHappenedOnceExactly();
@@ -330,7 +330,7 @@ public class ModifyManifestManifestAdjunctTests : IClassFixture<PresentationAppF
         var (slug, id) = TestIdentifiers.SlugResource();
         var existingAdjunctId = "old-mets.xml";
         var newAdjunctId = "new-mets.xml";
-        var manifestAdjunctId = CanvasPaintingResolver.ManifestLevelAdjunctId(id);
+        var manifestAdjunctId = CanvasPaintingResolver.ManifestStubAssetId(Customer, id).Asset;
 
         // Simulate: manifest-level adjunct asset exists in DLCS with an existing adjunct
         A.CallTo(() => DLCSApiClient.GetCustomerImages(Customer, A<ICollection<string>>._, A<CancellationToken>._))
@@ -398,7 +398,7 @@ public class ModifyManifestManifestAdjunctTests : IClassFixture<PresentationAppF
         // Arrange
         var (slug, id) = TestIdentifiers.SlugResource();
         var existingAdjunctId = "old-mets.xml";
-        var manifestAdjunctId = CanvasPaintingResolver.ManifestLevelAdjunctId(id);
+        var manifestAdjunctId = CanvasPaintingResolver.ManifestStubAssetId(Customer, id).Asset;
 
         // Simulate: manifest-level adjunct asset exists with existing adjunct
         A.CallTo(() => DLCSApiClient.GetCustomerImages(Customer, A<ICollection<string>>._, A<CancellationToken>._))
@@ -534,7 +534,7 @@ public class ModifyManifestManifestAdjunctTests : IClassFixture<PresentationAppF
         var manifestId = (await postResponse.ReadAsPresentationResponseAsync<PresentationManifest>())!.Id!.Split('/').Last();
 
         // Mock DLCS to return the manifest-level adjunct asset with adjuncts for the manifest-scoped lookup
-        var manifestAdjunctId = CanvasPaintingResolver.ManifestLevelAdjunctId(manifestId);
+        var manifestAdjunctId = CanvasPaintingResolver.ManifestStubAssetId(Customer, manifestId).Asset;
         A.CallTo(() => DLCSApiClient.GetCustomerImages(Customer, manifestId, A<CancellationToken>._))
             .Returns(Task.FromResult<IList<JObject>>(
             [
@@ -562,7 +562,7 @@ public class ModifyManifestManifestAdjunctTests : IClassFixture<PresentationAppF
         A.CallTo(() => DLCSApiClient.IngestDeliverables(Customer,
                 A<List<JObject>>.That.Matches(list =>
                     list.Count == 1 &&
-                    list[0][AssetProperties.Id]!.Value<string>() == CanvasPaintingResolver.ManifestLevelAdjunctId(manifestId) &&
+                    list[0][AssetProperties.Id]!.Value<string>() == CanvasPaintingResolver.ManifestStubAssetId(Customer, manifestId).Asset &&
                     list[0][AssetProperties.Space]!.Value<int>() == 0),
                 false, A<CancellationToken>._))
             .MustHaveHappenedOnceExactly();

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestManifestAdjunctTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestManifestAdjunctTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using API.Features.Common.Helpers;
 using API.Features.Manifest;
 using API.Tests.Integration.Infrastructure;
 using Core.Response;
@@ -89,7 +90,7 @@ public class ModifyManifestManifestAdjunctTests : IClassFixture<PresentationAppF
         var responseManifest = await response.ReadAsPresentationResponseAsync<PresentationManifest>();
         var manifestId = responseManifest!.Id!.Split('/').Last();
 
-        var expectedManifestAdjunctId = CanvasPaintingResolver.ManifestStubAssetId(Customer, manifestId).Asset;
+        var expectedManifestAdjunctId = ResourceAdjunctInteractions.GetResourceStubAssetId(Customer, manifestId).Asset;
 
         // Manifest-level adjunct asset should be created via regular queue (adjunctQueue = false) in space 0
         A.CallTo(() => DLCSApiClient.IngestDeliverables(Customer,
@@ -264,7 +265,7 @@ public class ModifyManifestManifestAdjunctTests : IClassFixture<PresentationAppF
         A.CallTo(() => DLCSApiClient.IngestDeliverables(Customer,
                 A<List<JObject>>.That.Matches(list =>
                     list.Count == 1 &&
-                    list[0][AssetProperties.Id]!.Value<string>() == CanvasPaintingResolver.ManifestStubAssetId(Customer, manifestId).Asset &&
+                    list[0][AssetProperties.Id]!.Value<string>() == ResourceAdjunctInteractions.GetResourceStubAssetId(Customer, manifestId).Asset &&
                     list[0][AssetProperties.Space]!.Value<int>() == 0),
                 false, A<CancellationToken>._))
             .MustHaveHappened();
@@ -310,7 +311,7 @@ public class ModifyManifestManifestAdjunctTests : IClassFixture<PresentationAppF
         A.CallTo(() => DLCSApiClient.IngestDeliverables(Customer,
                 A<List<JObject>>.That.Matches(list =>
                     list.Count == 1 &&
-                    list[0][AssetProperties.Id]!.Value<string>() == CanvasPaintingResolver.ManifestStubAssetId(Customer, id).Asset &&
+                    list[0][AssetProperties.Id]!.Value<string>() == ResourceAdjunctInteractions.GetResourceStubAssetId(Customer, id).Asset &&
                     list[0][AssetProperties.Space]!.Value<int>() == 0),
                 false, A<CancellationToken>._))
             .MustHaveHappenedOnceExactly();
@@ -330,7 +331,7 @@ public class ModifyManifestManifestAdjunctTests : IClassFixture<PresentationAppF
         var (slug, id) = TestIdentifiers.SlugResource();
         var existingAdjunctId = "old-mets.xml";
         var newAdjunctId = "new-mets.xml";
-        var manifestAdjunctId = CanvasPaintingResolver.ManifestStubAssetId(Customer, id).Asset;
+        var manifestAdjunctId = ResourceAdjunctInteractions.GetResourceStubAssetId(Customer, id).Asset;
 
         // Simulate: manifest-level adjunct asset exists in DLCS with an existing adjunct
         A.CallTo(() => DLCSApiClient.GetCustomerImages(Customer, A<ICollection<string>>._, A<CancellationToken>._))
@@ -398,7 +399,7 @@ public class ModifyManifestManifestAdjunctTests : IClassFixture<PresentationAppF
         // Arrange
         var (slug, id) = TestIdentifiers.SlugResource();
         var existingAdjunctId = "old-mets.xml";
-        var manifestAdjunctId = CanvasPaintingResolver.ManifestStubAssetId(Customer, id).Asset;
+        var manifestAdjunctId = ResourceAdjunctInteractions.GetResourceStubAssetId(Customer, id).Asset;
 
         // Simulate: manifest-level adjunct asset exists with existing adjunct
         A.CallTo(() => DLCSApiClient.GetCustomerImages(Customer, A<ICollection<string>>._, A<CancellationToken>._))
@@ -534,7 +535,7 @@ public class ModifyManifestManifestAdjunctTests : IClassFixture<PresentationAppF
         var manifestId = (await postResponse.ReadAsPresentationResponseAsync<PresentationManifest>())!.Id!.Split('/').Last();
 
         // Mock DLCS to return the manifest-level adjunct asset with adjuncts for the manifest-scoped lookup
-        var manifestAdjunctId = CanvasPaintingResolver.ManifestStubAssetId(Customer, manifestId).Asset;
+        var manifestAdjunctId = ResourceAdjunctInteractions.GetResourceStubAssetId(Customer, manifestId).Asset;
         A.CallTo(() => DLCSApiClient.GetCustomerImages(Customer, manifestId, A<CancellationToken>._))
             .Returns(Task.FromResult<IList<JObject>>(
             [
@@ -562,7 +563,7 @@ public class ModifyManifestManifestAdjunctTests : IClassFixture<PresentationAppF
         A.CallTo(() => DLCSApiClient.IngestDeliverables(Customer,
                 A<List<JObject>>.That.Matches(list =>
                     list.Count == 1 &&
-                    list[0][AssetProperties.Id]!.Value<string>() == CanvasPaintingResolver.ManifestStubAssetId(Customer, manifestId).Asset &&
+                    list[0][AssetProperties.Id]!.Value<string>() == ResourceAdjunctInteractions.GetResourceStubAssetId(Customer, manifestId).Asset &&
                     list[0][AssetProperties.Space]!.Value<int>() == 0),
                 false, A<CancellationToken>._))
             .MustHaveHappenedOnceExactly();

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestManifestAdjunctTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestManifestAdjunctTests.cs
@@ -254,21 +254,16 @@ public class ModifyManifestManifestAdjunctTests : IClassFixture<PresentationAppF
         var responseManifest = await response.ReadAsPresentationResponseAsync<PresentationManifest>();
         var manifestId = responseManifest!.Id!.Split('/').Last();
 
-        // Canvas asset batch (space = newly created space)
+        // Canvas asset and stub asset are batched together in one IngestDeliverables call
         A.CallTo(() => DLCSApiClient.IngestDeliverables(Customer,
                 A<List<JObject>>.That.Matches(list =>
-                    list.Count == 1 && list[0][AssetProperties.Id]!.Value<string>() == "canvas-asset"),
+                    list.Count == 2 &&
+                    list.Any(a => a[AssetProperties.Id]!.Value<string>() == "canvas-asset") &&
+                    list.Any(a =>
+                        a[AssetProperties.Id]!.Value<string>() == ResourceAdjunctInteractions.GetResourceStubAssetId(Customer, manifestId).Asset &&
+                        a[AssetProperties.Space]!.Value<int>() == 0)),
                 false, A<CancellationToken>._))
-            .MustHaveHappened();
-
-        // Stub asset batch (space 0)
-        A.CallTo(() => DLCSApiClient.IngestDeliverables(Customer,
-                A<List<JObject>>.That.Matches(list =>
-                    list.Count == 1 &&
-                    list[0][AssetProperties.Id]!.Value<string>() == ResourceAdjunctInteractions.GetResourceStubAssetId(Customer, manifestId).Asset &&
-                    list[0][AssetProperties.Space]!.Value<int>() == 0),
-                false, A<CancellationToken>._))
-            .MustHaveHappened();
+            .MustHaveHappenedOnceExactly();
 
         // Adjunct batch
         A.CallTo(() => DLCSApiClient.IngestDeliverables(Customer,

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestManifestAdjunctTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestManifestAdjunctTests.cs
@@ -509,4 +509,71 @@ public class ModifyManifestManifestAdjunctTests : IClassFixture<PresentationAppF
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
+
+    [Fact]
+    public async Task CreateManifest_WithManifestAdjuncts_ReturnsAdjunctsPopulatedFromDlcs()
+    {
+        // Arrange: create a manifest with adjuncts via POST
+        var (slug, _) = TestIdentifiers.SlugResource();
+        var adjunctId = "mets.xml";
+
+        var postPayload = $$"""
+            {
+                "type": "Manifest",
+                "slug": "{{slug}}",
+                "parent": "http://localhost/{{Customer}}/collections/root",
+                "adjuncts": [
+                    { "id": "{{adjunctId}}", "mediaType": "text/xml" }
+                ]
+            }
+            """;
+
+        var postResponse = await httpClient.AsCustomer().SendAsync(
+            HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Post, $"{Customer}/manifests", postPayload));
+        postResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var manifestId = (await postResponse.ReadAsPresentationResponseAsync<PresentationManifest>())!.Id!.Split('/').Last();
+
+        // Mock DLCS to return the stub asset with adjuncts for the manifest-scoped lookup
+        var stubAssetName = CanvasPaintingResolver.ManifestStubAssetId(manifestId);
+        A.CallTo(() => DLCSApiClient.GetCustomerImages(Customer, manifestId, A<CancellationToken>._))
+            .Returns(Task.FromResult<IList<JObject>>(
+            [
+                JObject.Parse($$"""
+                    {
+                        "@id": "https://localhost/customers/{{Customer}}/spaces/0/images/{{stubAssetName}}",
+                        "id": "{{stubAssetName}}",
+                        "space": 0,
+                        "adjuncts": [{ "id": "{{adjunctId}}", "mediaType": "text/xml" }]
+                    }
+                    """)
+            ]));
+
+        // Act
+        var getResponse = await httpClient.AsCustomer().SendAsync(
+            HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get, $"{Customer}/manifests/{manifestId}"));
+
+        // Assert - 202 because the adjunct batches are still in Ingesting state
+        getResponse.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        var manifest = await getResponse.ReadAsPresentationResponseAsync<PresentationManifest>();
+        manifest!.Adjuncts.Should().HaveCount(1);
+        manifest.Adjuncts![0]["id"]!.Value<string>().Should().Be(adjunctId);
+
+        // Stub asset was sent to DLCS (space 0, adjunctQueue = false)
+        A.CallTo(() => DLCSApiClient.IngestDeliverables(Customer,
+                A<List<JObject>>.That.Matches(list =>
+                    list.Count == 1 &&
+                    list[0][AssetProperties.Id]!.Value<string>() == CanvasPaintingResolver.ManifestStubAssetId(manifestId) &&
+                    list[0][AssetProperties.Space]!.Value<int>() == 0),
+                false, A<CancellationToken>._))
+            .MustHaveHappenedOnceExactly();
+
+        // Adjunct was sent to DLCS (adjunctQueue = true)
+        A.CallTo(() => DLCSApiClient.IngestDeliverables(Customer,
+                A<List<JObject>>.That.Matches(list =>
+                    list.Count == 1 &&
+                    list[0][AdjunctProperties.Id]!.Value<string>() == adjunctId),
+                true, A<CancellationToken>._))
+            .MustHaveHappenedOnceExactly();
+    }
+
 }

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestManifestAdjunctTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestManifestAdjunctTests.cs
@@ -89,13 +89,13 @@ public class ModifyManifestManifestAdjunctTests : IClassFixture<PresentationAppF
         var responseManifest = await response.ReadAsPresentationResponseAsync<PresentationManifest>();
         var manifestId = responseManifest!.Id!.Split('/').Last();
 
-        var expectedStubAssetId = CanvasPaintingResolver.ManifestStubAssetId(manifestId);
+        var expectedManifestAdjunctId = CanvasPaintingResolver.ManifestLevelAdjunctId(manifestId);
 
-        // Stub asset should be created via regular queue (adjunctQueue = false) in space 0
+        // Manifest-level adjunct asset should be created via regular queue (adjunctQueue = false) in space 0
         A.CallTo(() => DLCSApiClient.IngestDeliverables(Customer,
                 A<List<JObject>>.That.Matches(list =>
                     list.Count == 1 &&
-                    list[0][AssetProperties.Id]!.Value<string>() == expectedStubAssetId &&
+                    list[0][AssetProperties.Id]!.Value<string>() == expectedManifestAdjunctId &&
                     list[0][AssetProperties.Space]!.Value<int>() == 0),
                 false, A<CancellationToken>._))
             .MustHaveHappenedOnceExactly();
@@ -264,7 +264,7 @@ public class ModifyManifestManifestAdjunctTests : IClassFixture<PresentationAppF
         A.CallTo(() => DLCSApiClient.IngestDeliverables(Customer,
                 A<List<JObject>>.That.Matches(list =>
                     list.Count == 1 &&
-                    list[0][AssetProperties.Id]!.Value<string>() == CanvasPaintingResolver.ManifestStubAssetId(manifestId) &&
+                    list[0][AssetProperties.Id]!.Value<string>() == CanvasPaintingResolver.ManifestLevelAdjunctId(manifestId) &&
                     list[0][AssetProperties.Space]!.Value<int>() == 0),
                 false, A<CancellationToken>._))
             .MustHaveHappened();
@@ -310,7 +310,7 @@ public class ModifyManifestManifestAdjunctTests : IClassFixture<PresentationAppF
         A.CallTo(() => DLCSApiClient.IngestDeliverables(Customer,
                 A<List<JObject>>.That.Matches(list =>
                     list.Count == 1 &&
-                    list[0][AssetProperties.Id]!.Value<string>() == CanvasPaintingResolver.ManifestStubAssetId(id) &&
+                    list[0][AssetProperties.Id]!.Value<string>() == CanvasPaintingResolver.ManifestLevelAdjunctId(id) &&
                     list[0][AssetProperties.Space]!.Value<int>() == 0),
                 false, A<CancellationToken>._))
             .MustHaveHappenedOnceExactly();
@@ -330,16 +330,16 @@ public class ModifyManifestManifestAdjunctTests : IClassFixture<PresentationAppF
         var (slug, id) = TestIdentifiers.SlugResource();
         var existingAdjunctId = "old-mets.xml";
         var newAdjunctId = "new-mets.xml";
-        var stubAssetId = CanvasPaintingResolver.ManifestStubAssetId(id);
+        var manifestAdjunctId = CanvasPaintingResolver.ManifestLevelAdjunctId(id);
 
-        // Simulate: stub asset exists in DLCS with an existing adjunct
+        // Simulate: manifest-level adjunct asset exists in DLCS with an existing adjunct
         A.CallTo(() => DLCSApiClient.GetCustomerImages(Customer, A<ICollection<string>>._, A<CancellationToken>._))
             .ReturnsLazily((int _, ICollection<string> assetIds, CancellationToken _) =>
                 Task.FromResult<IList<JObject>>(assetIds
-                    .Where(a => a.EndsWith(stubAssetId))
+                    .Where(a => a.EndsWith(manifestAdjunctId))
                     .Select(_ => JObject.Parse($$"""
                         {
-                            "id": "{{stubAssetId}}",
+                            "id": "{{manifestAdjunctId}}",
                             "space": 0,
                             "adjuncts": [{ "id": "{{existingAdjunctId}}" }]
                         }
@@ -398,16 +398,16 @@ public class ModifyManifestManifestAdjunctTests : IClassFixture<PresentationAppF
         // Arrange
         var (slug, id) = TestIdentifiers.SlugResource();
         var existingAdjunctId = "old-mets.xml";
-        var stubAssetId = CanvasPaintingResolver.ManifestStubAssetId(id);
+        var manifestAdjunctId = CanvasPaintingResolver.ManifestLevelAdjunctId(id);
 
-        // Simulate: stub asset exists with existing adjunct
+        // Simulate: manifest-level adjunct asset exists with existing adjunct
         A.CallTo(() => DLCSApiClient.GetCustomerImages(Customer, A<ICollection<string>>._, A<CancellationToken>._))
             .ReturnsLazily((int _, ICollection<string> assetIds, CancellationToken _) =>
                 Task.FromResult<IList<JObject>>(assetIds
-                    .Where(a => a.EndsWith(stubAssetId))
+                    .Where(a => a.EndsWith(manifestAdjunctId))
                     .Select(_ => JObject.Parse($$"""
                         {
-                            "id": "{{stubAssetId}}",
+                            "id": "{{manifestAdjunctId}}",
                             "space": 0,
                             "adjuncts": [{ "id": "{{existingAdjunctId}}" }]
                         }
@@ -533,15 +533,15 @@ public class ModifyManifestManifestAdjunctTests : IClassFixture<PresentationAppF
         postResponse.StatusCode.Should().Be(HttpStatusCode.Created);
         var manifestId = (await postResponse.ReadAsPresentationResponseAsync<PresentationManifest>())!.Id!.Split('/').Last();
 
-        // Mock DLCS to return the stub asset with adjuncts for the manifest-scoped lookup
-        var stubAssetName = CanvasPaintingResolver.ManifestStubAssetId(manifestId);
+        // Mock DLCS to return the manifest-level adjunct asset with adjuncts for the manifest-scoped lookup
+        var manifestAdjunctId = CanvasPaintingResolver.ManifestLevelAdjunctId(manifestId);
         A.CallTo(() => DLCSApiClient.GetCustomerImages(Customer, manifestId, A<CancellationToken>._))
             .Returns(Task.FromResult<IList<JObject>>(
             [
                 JObject.Parse($$"""
                     {
-                        "@id": "https://localhost/customers/{{Customer}}/spaces/0/images/{{stubAssetName}}",
-                        "id": "{{stubAssetName}}",
+                        "@id": "https://localhost/customers/{{Customer}}/spaces/0/images/{{manifestAdjunctId}}",
+                        "id": "{{manifestAdjunctId}}",
                         "space": 0,
                         "adjuncts": [{ "id": "{{adjunctId}}", "mediaType": "text/xml" }]
                     }
@@ -562,7 +562,7 @@ public class ModifyManifestManifestAdjunctTests : IClassFixture<PresentationAppF
         A.CallTo(() => DLCSApiClient.IngestDeliverables(Customer,
                 A<List<JObject>>.That.Matches(list =>
                     list.Count == 1 &&
-                    list[0][AssetProperties.Id]!.Value<string>() == CanvasPaintingResolver.ManifestStubAssetId(manifestId) &&
+                    list[0][AssetProperties.Id]!.Value<string>() == CanvasPaintingResolver.ManifestLevelAdjunctId(manifestId) &&
                     list[0][AssetProperties.Space]!.Value<int>() == 0),
                 false, A<CancellationToken>._))
             .MustHaveHappenedOnceExactly();

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestManifestAdjunctTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestManifestAdjunctTests.cs
@@ -90,7 +90,7 @@ public class ModifyManifestManifestAdjunctTests : IClassFixture<PresentationAppF
         var responseManifest = await response.ReadAsPresentationResponseAsync<PresentationManifest>();
         var manifestId = responseManifest!.Id!.Split('/').Last();
 
-        var expectedManifestAdjunctId = ResourceAdjunctInteractions.GetResourceStubAssetId(Customer, manifestId).Asset;
+        var expectedManifestAdjunctId = ResourceAdjunctInteractions.GetResourceStubAssetId(new PresentationManifest(), Customer, manifestId).Asset;
 
         // Manifest-level adjunct asset should be created via regular queue (adjunctQueue = false) in space 0
         A.CallTo(() => DLCSApiClient.IngestDeliverables(Customer,
@@ -261,7 +261,7 @@ public class ModifyManifestManifestAdjunctTests : IClassFixture<PresentationAppF
                     list.Count == 2 &&
                     list.Any(a => a[AssetProperties.Id]!.Value<string>() == "canvas-asset") &&
                     list.Any(a =>
-                        a[AssetProperties.Id]!.Value<string>() == ResourceAdjunctInteractions.GetResourceStubAssetId(Customer, manifestId).Asset &&
+                        a[AssetProperties.Id]!.Value<string>() == ResourceAdjunctInteractions.GetResourceStubAssetId(new PresentationManifest(), Customer, manifestId).Asset &&
                         a[AssetProperties.Space]!.Value<int>() == 0)),
                 false, A<CancellationToken>._))
             .MustHaveHappenedOnceExactly();
@@ -307,7 +307,7 @@ public class ModifyManifestManifestAdjunctTests : IClassFixture<PresentationAppF
         A.CallTo(() => DLCSApiClient.IngestDeliverables(Customer,
                 A<List<JObject>>.That.Matches(list =>
                     list.Count == 1 &&
-                    list[0][AssetProperties.Id]!.Value<string>() == ResourceAdjunctInteractions.GetResourceStubAssetId(Customer, id).Asset &&
+                    list[0][AssetProperties.Id]!.Value<string>() == ResourceAdjunctInteractions.GetResourceStubAssetId(new PresentationManifest(), Customer, id).Asset &&
                     list[0][AssetProperties.Space]!.Value<int>() == 0),
                 false, A<CancellationToken>._))
             .MustHaveHappenedOnceExactly();
@@ -327,7 +327,7 @@ public class ModifyManifestManifestAdjunctTests : IClassFixture<PresentationAppF
         var (slug, id) = TestIdentifiers.SlugResource();
         var existingAdjunctId = "old-mets.xml";
         var newAdjunctId = "new-mets.xml";
-        var manifestAdjunctId = ResourceAdjunctInteractions.GetResourceStubAssetId(Customer, id).Asset;
+        var manifestAdjunctId = ResourceAdjunctInteractions.GetResourceStubAssetId(new PresentationManifest(), Customer, id).Asset;
 
         // Simulate: manifest-level adjunct asset exists in DLCS with an existing adjunct
         A.CallTo(() => DLCSApiClient.GetCustomerImages(Customer, A<ICollection<string>>._, A<CancellationToken>._))
@@ -395,7 +395,7 @@ public class ModifyManifestManifestAdjunctTests : IClassFixture<PresentationAppF
         // Arrange
         var (slug, id) = TestIdentifiers.SlugResource();
         var existingAdjunctId = "old-mets.xml";
-        var manifestAdjunctId = ResourceAdjunctInteractions.GetResourceStubAssetId(Customer, id).Asset;
+        var manifestAdjunctId = ResourceAdjunctInteractions.GetResourceStubAssetId(new PresentationManifest(), Customer, id).Asset;
 
         // Simulate: manifest-level adjunct asset exists with existing adjunct
         A.CallTo(() => DLCSApiClient.GetCustomerImages(Customer, A<ICollection<string>>._, A<CancellationToken>._))
@@ -531,7 +531,7 @@ public class ModifyManifestManifestAdjunctTests : IClassFixture<PresentationAppF
         var manifestId = (await postResponse.ReadAsPresentationResponseAsync<PresentationManifest>())!.Id!.Split('/').Last();
 
         // Mock DLCS to return the manifest-level adjunct asset with adjuncts for the manifest-scoped lookup
-        var manifestAdjunctId = ResourceAdjunctInteractions.GetResourceStubAssetId(Customer, manifestId).Asset;
+        var manifestAdjunctId = ResourceAdjunctInteractions.GetResourceStubAssetId(new PresentationManifest(), Customer, manifestId).Asset;
         A.CallTo(() => DLCSApiClient.GetCustomerImages(Customer, manifestId, A<CancellationToken>._))
             .Returns(Task.FromResult<IList<JObject>>(
             [
@@ -559,7 +559,7 @@ public class ModifyManifestManifestAdjunctTests : IClassFixture<PresentationAppF
         A.CallTo(() => DLCSApiClient.IngestDeliverables(Customer,
                 A<List<JObject>>.That.Matches(list =>
                     list.Count == 1 &&
-                    list[0][AssetProperties.Id]!.Value<string>() == ResourceAdjunctInteractions.GetResourceStubAssetId(Customer, manifestId).Asset &&
+                    list[0][AssetProperties.Id]!.Value<string>() == ResourceAdjunctInteractions.GetResourceStubAssetId(new PresentationManifest(), Customer, manifestId).Asset &&
                     list[0][AssetProperties.Space]!.Value<int>() == 0),
                 false, A<CancellationToken>._))
             .MustHaveHappenedOnceExactly();

--- a/src/IIIFPresentation/API/Converters/ManifestConverter.cs
+++ b/src/IIIFPresentation/API/Converters/ManifestConverter.cs
@@ -62,9 +62,14 @@ public static class ManifestConverter
             iiifManifest.PaintedResources = enumeratedCanvasPaintings.GetPaintedResources(pathGenerator, assets);
         }
         
+        if (!iiifManifest.Adjuncts.IsNullOrEmpty())
+        {
+            foreach (var adjunct in iiifManifest.Adjuncts!) adjunct.Remove(AssetProperties.Asset);
+        }
+
         iiifManifest.EnsurePresentation3Context();
         iiifManifest.EnsureContext(PresentationJsonLdContext.Context);
-        
+
         return iiifManifest;
     }
 

--- a/src/IIIFPresentation/API/Features/Common/Helpers/ResourceAdjunctInteractions.cs
+++ b/src/IIIFPresentation/API/Features/Common/Helpers/ResourceAdjunctInteractions.cs
@@ -1,3 +1,4 @@
+using Models.API.Manifest;
 using Models.DLCS;
 using Newtonsoft.Json.Linq;
 using Services.Manifests.Model;
@@ -17,17 +18,16 @@ public static class ResourceAdjunctInteractions
 
     /// <summary>
     /// Builds an <see cref="AdjunctInteraction"/> for the given stub asset and adjunct list.
-    /// Returns null if <paramref name="adjuncts"/> is null (treat as "no change").
+    /// Returns null if <see cref="PresentationManifest.Adjuncts"/> is null (treat as "no change").
     /// Note: stamps <see cref="AssetProperties.Asset"/> onto each adjunct JObject in-place.
     /// </summary>
-    public static AdjunctInteraction? GetAdjunctInteraction(List<JObject>? adjuncts, int customerId, 
-        string resourceId)
+    public static AdjunctInteraction? GetAdjunctInteraction(PresentationManifest presentationManifest, int customerId)
     {
-        if (adjuncts == null) return null;
+        if (presentationManifest.Adjuncts == null) return null;
 
-        var stubAssetId = GetResourceStubAssetId(customerId, resourceId);
+        var stubAssetId = GetResourceStubAssetId(customerId, presentationManifest.Id!);
 
-        var hydratedAdjuncts = adjuncts
+        var hydratedAdjuncts = presentationManifest.Adjuncts
             .Select(a =>
             {
                 a[AssetProperties.Asset] = stubAssetId.ToString();

--- a/src/IIIFPresentation/API/Features/Common/Helpers/ResourceAdjunctInteractions.cs
+++ b/src/IIIFPresentation/API/Features/Common/Helpers/ResourceAdjunctInteractions.cs
@@ -1,0 +1,40 @@
+using Models.DLCS;
+using Newtonsoft.Json.Linq;
+using Services.Manifests.Model;
+
+namespace API.Features.Common.Helpers;
+
+/// <summary>
+/// Generates adjunct interactions for resource level adjuncts
+/// </summary>
+public static class ResourceAdjunctInteractions
+{
+    /// <summary>
+    /// The <see cref="AssetId"/> for the manifest-level stub asset in space 0, given the resources's internal id.
+    /// </summary>
+    public static AssetId GetResourceStubAssetId(int customerId, string resourceId) =>
+        new(customerId, 0, $"Manifest_{resourceId}");
+
+    /// <summary>
+    /// Builds an <see cref="AdjunctInteraction"/> for the given stub asset and adjunct list.
+    /// Returns null if <paramref name="adjuncts"/> is null (treat as "no change").
+    /// Note: stamps <see cref="AssetProperties.Asset"/> onto each adjunct JObject in-place.
+    /// </summary>
+    public static AdjunctInteraction? GetAdjunctInteraction(List<JObject>? adjuncts, int customerId, 
+        string resourceId)
+    {
+        if (adjuncts == null) return null;
+
+        var stubAssetId = GetResourceStubAssetId(customerId, resourceId);
+
+        var hydratedAdjuncts = adjuncts
+            .Select(a =>
+            {
+                a[AssetProperties.Asset] = stubAssetId.ToString();
+                return a;
+            })
+            .ToList();
+
+        return new AdjunctInteraction { AssetId = stubAssetId, Adjuncts = hydratedAdjuncts };
+    }
+}

--- a/src/IIIFPresentation/API/Features/Common/Helpers/ResourceAdjunctInteractions.cs
+++ b/src/IIIFPresentation/API/Features/Common/Helpers/ResourceAdjunctInteractions.cs
@@ -1,8 +1,7 @@
+using Core.Helpers;
 using IIIF.Presentation.V3;
 using Models.API.Manifest;
-using Models.Database.General;
 using Models.DLCS;
-using Newtonsoft.Json.Linq;
 using Services.Manifests.Model;
 
 namespace API.Features.Common.Helpers;
@@ -27,6 +26,7 @@ public static class ResourceAdjunctInteractions
     /// </summary>
     public static AdjunctInteraction? GetAdjunctInteraction(PresentationManifest presentationManifest, int customerId)
     {
+        // We only check for null here, as an empty list signals we want to delete all adjuncts
         if (presentationManifest.Adjuncts == null) return null;
 
         var stubAssetId = GetResourceStubAssetId(presentationManifest, customerId, presentationManifest.Id!);

--- a/src/IIIFPresentation/API/Features/Common/Helpers/ResourceAdjunctInteractions.cs
+++ b/src/IIIFPresentation/API/Features/Common/Helpers/ResourceAdjunctInteractions.cs
@@ -1,4 +1,6 @@
+using IIIF.Presentation.V3;
 using Models.API.Manifest;
+using Models.Database.General;
 using Models.DLCS;
 using Newtonsoft.Json.Linq;
 using Services.Manifests.Model;
@@ -10,11 +12,13 @@ namespace API.Features.Common.Helpers;
 /// </summary>
 public static class ResourceAdjunctInteractions
 {
+    public const int StubAssetSpace = 0;
+    
     /// <summary>
     /// The <see cref="AssetId"/> for the manifest-level stub asset in space 0, given the resources's internal id.
     /// </summary>
-    public static AssetId GetResourceStubAssetId(int customerId, string resourceId) =>
-        new(customerId, 0, $"Manifest_{resourceId}");
+    public static AssetId GetResourceStubAssetId(ResourceBase resource, int customerId, string resourceId) =>
+        new(customerId, StubAssetSpace, $"{resource.Type}_{resourceId}");
 
     /// <summary>
     /// Builds an <see cref="AdjunctInteraction"/> for the given stub asset and adjunct list.
@@ -25,7 +29,7 @@ public static class ResourceAdjunctInteractions
     {
         if (presentationManifest.Adjuncts == null) return null;
 
-        var stubAssetId = GetResourceStubAssetId(customerId, presentationManifest.Id!);
+        var stubAssetId = GetResourceStubAssetId(presentationManifest, customerId, presentationManifest.Id!);
 
         var hydratedAdjuncts = presentationManifest.Adjuncts
             .Select(a =>

--- a/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingResolver.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingResolver.cs
@@ -29,11 +29,11 @@ public class CanvasPaintingResolver(
     /// </summary>
     /// <returns>Tuple of either error OR newly created </returns>
     public async Task<ParsedManifestResult> GenerateCanvasPaintings(
-        int customerId, PresentationManifest presentationManifest, string manifestId, CancellationToken cancellationToken = default)
+        int customerId, PresentationManifest presentationManifest, CancellationToken cancellationToken = default)
     {
         try
         {
-            var manifestParseResult = await ParseManifest(customerId, presentationManifest, null, manifestId);
+            var manifestParseResult = await ParseManifest(customerId, presentationManifest);
             if (manifestParseResult.Error != null) return ParsedManifestResult.Failure(manifestParseResult.Error);
 
             Debug.Assert(manifestParseResult.CanvasPaintings is not null, "manifestParseResult.CanvasPaintings is not null");
@@ -66,7 +66,7 @@ public class CanvasPaintingResolver(
     public async Task<ParsedManifestResult> UpdateCanvasPaintings(int customerId, PresentationManifest presentationManifest,
         DbManifest existingManifest, CancellationToken cancellationToken = default)
     {
-        var manifestParseResult = await ParseManifest(customerId, presentationManifest, existingManifest.Id, existingManifest.Id);
+        var manifestParseResult = await ParseManifest(customerId, presentationManifest);
         if (manifestParseResult.Error != null) return ParsedManifestResult.Failure(manifestParseResult.Error);
         
         existingManifest.CanvasPaintings ??= [];
@@ -246,12 +246,12 @@ public class CanvasPaintingResolver(
     }
     
     private async Task<ManifestParseResult> ParseManifest(int customerId,
-        PresentationManifest presentationManifest, string? existingManifestId, string manifestId)
+        PresentationManifest presentationManifest)
     {
         try
         {
             var paintedResourceCanvasPaintings = (await manifestPaintedResourceParser
-                .ParseToCanvasPainting(presentationManifest, customerId, existingManifestId)).ToList();
+                .ParseToCanvasPainting(presentationManifest, customerId)).ToList();
 
             var itemsCanvasPaintings =
                 manifestItemsParser
@@ -266,8 +266,7 @@ public class CanvasPaintingResolver(
                 .ToList();
 
             var manifestAdjunctInteraction =
-                ResourceAdjunctInteractions.GetAdjunctInteraction(presentationManifest.Adjuncts, customerId,
-                    manifestId);
+                ResourceAdjunctInteractions.GetAdjunctInteraction(presentationManifest, customerId);
             if (manifestAdjunctInteraction != null)
                 adjunctInteractions.Add(manifestAdjunctInteraction);
 

--- a/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingResolver.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingResolver.cs
@@ -7,6 +7,7 @@ using Core.Exceptions;
 using Core.Helpers;
 using Models.API.Manifest;
 using Models.Database;
+using Models.DLCS;
 using Services.Manifests;
 using Services.Manifests.Exceptions;
 using Services.Manifests.Helpers;
@@ -29,11 +30,11 @@ public class CanvasPaintingResolver(
     /// </summary>
     /// <returns>Tuple of either error OR newly created </returns>
     public async Task<ParsedManifestResult> GenerateCanvasPaintings(
-        int customerId, PresentationManifest presentationManifest, CancellationToken cancellationToken = default)
+        int customerId, PresentationManifest presentationManifest, string? manifestId, CancellationToken cancellationToken = default)
     {
         try
         {
-            var manifestParseResult =  await ParseManifest(customerId, presentationManifest, null);
+            var manifestParseResult = await ParseManifest(customerId, presentationManifest, null, manifestId);
             if (manifestParseResult.Error != null) return ParsedManifestResult.Failure(manifestParseResult.Error);
 
             Debug.Assert(manifestParseResult.CanvasPaintings is not null, "manifestParseResult.CanvasPaintings is not null");
@@ -66,7 +67,7 @@ public class CanvasPaintingResolver(
     public async Task<ParsedManifestResult> UpdateCanvasPaintings(int customerId, PresentationManifest presentationManifest,
         DbManifest existingManifest, CancellationToken cancellationToken = default)
     {
-        var manifestParseResult = await ParseManifest(customerId, presentationManifest, existingManifest.Id);
+        var manifestParseResult = await ParseManifest(customerId, presentationManifest, existingManifest.Id, existingManifest.Id);
         if (manifestParseResult.Error != null) return ParsedManifestResult.Failure(manifestParseResult.Error);
         
         existingManifest.CanvasPaintings ??= [];
@@ -245,8 +246,8 @@ public class CanvasPaintingResolver(
         }
     }
     
-    private async Task<ManifestParseResult> ParseManifest(int customerId, 
-        PresentationManifest presentationManifest, string? existingManifestId)
+    private async Task<ManifestParseResult> ParseManifest(int customerId,
+        PresentationManifest presentationManifest, string? existingManifestId, string? manifestId = null)
     {
         try
         {
@@ -260,10 +261,16 @@ public class CanvasPaintingResolver(
             var res = canvasPaintingMerger.CombinePaintedResources(itemsCanvasPaintings,
                 paintedResourceCanvasPaintings, presentationManifest.Items);
 
-            return new ManifestParseResult(null, res, itemsCanvasPaintings.GetItemsWithSuspectedAssets(),
-                paintedResourceCanvasPaintings.Where(cp => cp.AdjunctInteraction != null)
-                    .Select(cp => cp.AdjunctInteraction!)
-                    .ToList());
+            var adjunctInteractions = paintedResourceCanvasPaintings
+                .Where(cp => cp.AdjunctInteraction != null)
+                .Select(cp => cp.AdjunctInteraction!)
+                .ToList();
+
+            var manifestAdjunctInteraction = GetManifestAdjunctInteraction(customerId, presentationManifest, manifestId);
+            if (manifestAdjunctInteraction != null)
+                adjunctInteractions.Add(manifestAdjunctInteraction);
+
+            return new ManifestParseResult(null, res, itemsCanvasPaintings.GetItemsWithSuspectedAssets(), adjunctInteractions);
         }
         catch (InvalidCanvasIdException cpId)
         {
@@ -305,6 +312,30 @@ public class CanvasPaintingResolver(
             return new ManifestParseResult(UpsertErrorHelper.PaintableAssetError<PresentationManifest>(paintableAssetException.Message));
         }
     }
+
+    private static AdjunctInteraction? GetManifestAdjunctInteraction(int customerId,
+        PresentationManifest presentationManifest, string? manifestId)
+    {
+        if (presentationManifest.Adjuncts == null || manifestId == null) return null;
+
+        var stubAssetId = new AssetId(customerId, 0, ManifestStubAssetId(manifestId));
+        var stubAssetIdString = stubAssetId.ToString();
+
+        var hydratedAdjuncts = presentationManifest.Adjuncts
+            .Select(a =>
+            {
+                a[AssetProperties.Asset] = stubAssetIdString;
+                return a;
+            })
+            .ToList();
+
+        return new AdjunctInteraction { AssetId = stubAssetId, Adjuncts = hydratedAdjuncts };
+    }
+
+    /// <summary>
+    /// The asset id for the manifest-level stub asset in space 0, given the manifest's internal id.
+    /// </summary>
+    public static string ManifestStubAssetId(string manifestId) => $"Manifest_{manifestId}";
 
     private class ManifestParseResult(
         PresUpdateResult? error = null,

--- a/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingResolver.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingResolver.cs
@@ -247,7 +247,7 @@ public class CanvasPaintingResolver(
     }
     
     private async Task<ManifestParseResult> ParseManifest(int customerId,
-        PresentationManifest presentationManifest, string? existingManifestId, string? manifestId = null)
+        PresentationManifest presentationManifest, string? existingManifestId, string manifestId)
     {
         try
         {
@@ -318,11 +318,11 @@ public class CanvasPaintingResolver(
     /// Note: stamps <see cref="AssetProperties.Asset"/> onto each adjunct JObject in-place.
     /// </summary>
     private static AdjunctInteraction? GetManifestAdjunctInteraction(int customerId,
-        PresentationManifest presentationManifest, string? manifestId)
+        PresentationManifest presentationManifest, string manifestId)
     {
-        if (presentationManifest.Adjuncts == null || manifestId == null) return null;
+        if (presentationManifest.Adjuncts == null) return null;
 
-        var manifestAdjunctId = new AssetId(customerId, 0, ManifestLevelAdjunctId(manifestId));
+        var manifestAdjunctId = ManifestStubAssetId(customerId, manifestId);
 
         var hydratedAdjuncts = presentationManifest.Adjuncts
             .Select(a =>
@@ -336,9 +336,10 @@ public class CanvasPaintingResolver(
     }
 
     /// <summary>
-    /// The asset id for the manifest-level adjunct carrier asset in space 0, given the manifest's internal id.
+    /// The <see cref="AssetId"/> for the manifest-level stub asset in space 0, given the manifest's internal id.
     /// </summary>
-    public static string ManifestLevelAdjunctId(string manifestId) => $"Manifest_{manifestId}";
+    public static AssetId ManifestStubAssetId(int customerId, string manifestId) =>
+        new(customerId, 0, $"Manifest_{manifestId}");
 
     private class ManifestParseResult(
         PresUpdateResult? error = null,

--- a/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingResolver.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingResolver.cs
@@ -30,7 +30,7 @@ public class CanvasPaintingResolver(
     /// </summary>
     /// <returns>Tuple of either error OR newly created </returns>
     public async Task<ParsedManifestResult> GenerateCanvasPaintings(
-        int customerId, PresentationManifest presentationManifest, string? manifestId, CancellationToken cancellationToken = default)
+        int customerId, PresentationManifest presentationManifest, string manifestId, CancellationToken cancellationToken = default)
     {
         try
         {
@@ -313,29 +313,32 @@ public class CanvasPaintingResolver(
         }
     }
 
+    /// <summary>
+    /// Builds a manifest-level <see cref="AdjunctInteraction"/> for any adjuncts on the manifest request.
+    /// Note: stamps <see cref="AssetProperties.Asset"/> onto each adjunct JObject in-place.
+    /// </summary>
     private static AdjunctInteraction? GetManifestAdjunctInteraction(int customerId,
         PresentationManifest presentationManifest, string? manifestId)
     {
         if (presentationManifest.Adjuncts == null || manifestId == null) return null;
 
-        var stubAssetId = new AssetId(customerId, 0, ManifestStubAssetId(manifestId));
-        var stubAssetIdString = stubAssetId.ToString();
+        var manifestAdjunctId = new AssetId(customerId, 0, ManifestLevelAdjunctId(manifestId));
 
         var hydratedAdjuncts = presentationManifest.Adjuncts
             .Select(a =>
             {
-                a[AssetProperties.Asset] = stubAssetIdString;
+                a[AssetProperties.Asset] = manifestAdjunctId.ToString();
                 return a;
             })
             .ToList();
 
-        return new AdjunctInteraction { AssetId = stubAssetId, Adjuncts = hydratedAdjuncts };
+        return new AdjunctInteraction { AssetId = manifestAdjunctId, Adjuncts = hydratedAdjuncts };
     }
 
     /// <summary>
-    /// The asset id for the manifest-level stub asset in space 0, given the manifest's internal id.
+    /// The asset id for the manifest-level adjunct carrier asset in space 0, given the manifest's internal id.
     /// </summary>
-    public static string ManifestStubAssetId(string manifestId) => $"Manifest_{manifestId}";
+    public static string ManifestLevelAdjunctId(string manifestId) => $"Manifest_{manifestId}";
 
     private class ManifestParseResult(
         PresUpdateResult? error = null,

--- a/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingResolver.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingResolver.cs
@@ -7,7 +7,6 @@ using Core.Exceptions;
 using Core.Helpers;
 using Models.API.Manifest;
 using Models.Database;
-using Models.DLCS;
 using Services.Manifests;
 using Services.Manifests.Exceptions;
 using Services.Manifests.Helpers;
@@ -266,7 +265,9 @@ public class CanvasPaintingResolver(
                 .Select(cp => cp.AdjunctInteraction!)
                 .ToList();
 
-            var manifestAdjunctInteraction = GetManifestAdjunctInteraction(customerId, presentationManifest, manifestId);
+            var manifestAdjunctInteraction =
+                ResourceAdjunctInteractions.GetAdjunctInteraction(presentationManifest.Adjuncts, customerId,
+                    manifestId);
             if (manifestAdjunctInteraction != null)
                 adjunctInteractions.Add(manifestAdjunctInteraction);
 
@@ -313,33 +314,6 @@ public class CanvasPaintingResolver(
         }
     }
 
-    /// <summary>
-    /// Builds a manifest-level <see cref="AdjunctInteraction"/> for any adjuncts on the manifest request.
-    /// Note: stamps <see cref="AssetProperties.Asset"/> onto each adjunct JObject in-place.
-    /// </summary>
-    private static AdjunctInteraction? GetManifestAdjunctInteraction(int customerId,
-        PresentationManifest presentationManifest, string manifestId)
-    {
-        if (presentationManifest.Adjuncts == null) return null;
-
-        var manifestAdjunctId = ManifestStubAssetId(customerId, manifestId);
-
-        var hydratedAdjuncts = presentationManifest.Adjuncts
-            .Select(a =>
-            {
-                a[AssetProperties.Asset] = manifestAdjunctId.ToString();
-                return a;
-            })
-            .ToList();
-
-        return new AdjunctInteraction { AssetId = manifestAdjunctId, Adjuncts = hydratedAdjuncts };
-    }
-
-    /// <summary>
-    /// The <see cref="AssetId"/> for the manifest-level stub asset in space 0, given the manifest's internal id.
-    /// </summary>
-    public static AssetId ManifestStubAssetId(int customerId, string manifestId) =>
-        new(customerId, 0, $"Manifest_{manifestId}");
 
     private class ManifestParseResult(
         PresUpdateResult? error = null,

--- a/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
@@ -130,7 +130,7 @@ public class DlcsManifestCoordinator(
     {
         var assets = GetAssetJObjectList(request.PresentationManifest.PaintedResources);
 
-        if (!request.CreateSpace && assets.Count <= 0 && previousManifestAssetIds.IsNullOrEmpty())
+        if (!request.CreateSpace && assets.Count <= 0 && previousManifestAssetIds.IsNullOrEmpty() && adjunctInteractions.Count == 0)
         {
             logger.LogDebug("No assets or space required, DLCS integrations not required");
             return DlcsInteractionResult.NoInteraction;
@@ -241,6 +241,12 @@ public class DlcsManifestCoordinator(
             // ExistingAdjunctIds may already be set for assets checked against DLCS in FindAssetsThatRequireAdditionalWork;
             // this call fills in any that were missed (e.g. assets that were already known and skipped the IIIF-CS check)
             await EnrichExistingAdjunctIds(request, adjunctInteractions, cancellationToken);
+
+            // Ensure stub assets (space 0) exist before ingesting their adjuncts
+            var stubAssetError = await EnsureStubAssetsExist(request.CustomerId, manifestId, adjunctInteractions,
+                collectedBatches, cancellationToken);
+            if (stubAssetError != null) return new DlcsInteractionResult(stubAssetError, spaceId);
+
             // remove any adjuncts in IIIF-CS that are no longer in the manifest
             await DeleteUnusedAdjuncts(request.CustomerId, adjunctInteractions, cancellationToken);
 
@@ -255,6 +261,35 @@ public class DlcsManifestCoordinator(
         }
 
         return null;
+    }
+
+    private async Task<EntityResult?> EnsureStubAssetsExist(int customerId, string manifestId,
+        List<AdjunctInteraction> adjunctInteractions, List<Batch> collectedBatches, CancellationToken cancellationToken)
+    {
+        // Manifest-level stub assets live in space 0; ExistingAdjunctIds == null means the asset was not found in DLCS
+        var missingStubAssets = adjunctInteractions
+            .Where(a => a.AssetId.Space == 0 && a.ExistingAdjunctIds == null)
+            .ToList();
+
+        if (missingStubAssets.Count == 0) return null;
+
+        var stubAssetJObjects = missingStubAssets
+            .Select(a => new JObject
+            {
+                [AssetProperties.Id] = a.AssetId.Asset,
+                [AssetProperties.Space] = 0,
+                [AssetProperties.Manifests] = new JArray(manifestId)
+            })
+            .ToList();
+
+        var result = await IngestDeliverables(customerId, manifestId, stubAssetJObjects, DeliverableType.Asset,
+            collectedBatches, cancellationToken);
+
+        // Mark as having no existing adjuncts so DeleteUnusedAdjuncts skips them
+        foreach (var interaction in missingStubAssets)
+            interaction.ExistingAdjunctIds = [];
+
+        return result;
     }
 
     private async Task EnrichExistingAdjunctIds(WriteManifestRequest request, List<AdjunctInteraction> adjunctInteractions,

--- a/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
@@ -266,7 +266,7 @@ public class DlcsManifestCoordinator(
     private async Task<EntityResult?> EnsureManifestAdjunctAssetsExist(int customerId, string manifestId,
         List<AdjunctInteraction> adjunctInteractions, List<Batch> collectedBatches, CancellationToken cancellationToken)
     {
-        var expectedManifestStubAssetId = CanvasPaintingResolver.ManifestStubAssetId(customerId, manifestId);
+        var expectedManifestStubAssetId = ResourceAdjunctInteractions.GetResourceStubAssetId(customerId, manifestId);
         var missingManifestAdjunctAssets = adjunctInteractions
             .Where(a => a.AssetId == expectedManifestStubAssetId && a.ExistingAdjunctIds == null)
             .ToList();

--- a/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
@@ -326,7 +326,7 @@ public class DlcsManifestCoordinator(
                 .ToList();
 
             if (adjunctsToDelete.Count > 0)
-                bulkDelete.Add(new AdjunctAssetIdentifier { Id = adjunctInteraction.AssetId.ToString(), Adjunct = adjunctsToDelete });
+                bulkDelete.Add(new AdjunctAssetIdentifier { Id = adjunctInteraction.AssetId, Adjunct = adjunctsToDelete });
         }
 
         if (bulkDelete.Count > 0)

--- a/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
@@ -210,7 +210,7 @@ public class DlcsManifestCoordinator(
         if (adjunctInteractions.Count > 0)
         {
             await EnrichExistingAdjunctIds(request, adjunctInteractions, cancellationToken);
-            assetsToIngest.AddRange(BuildMissingStubAssetRequests(request.CustomerId, manifestId, adjunctInteractions));
+            assetsToIngest.AddRange(BuildMissingStubAssetRequests(request.CustomerId, manifestId, adjunctInteractions, request.PresentationManifest));
         }
 
         // create batches for assets (including any new stub assets)
@@ -262,9 +262,9 @@ public class DlcsManifestCoordinator(
     }
 
     private static List<DlcsInteractionRequest> BuildMissingStubAssetRequests(int customerId, string manifestId,
-        List<AdjunctInteraction> adjunctInteractions)
+        List<AdjunctInteraction> adjunctInteractions, PresentationManifest manifest)
     {
-        var expectedStubAssetId = ResourceAdjunctInteractions.GetResourceStubAssetId(customerId, manifestId);
+        var expectedStubAssetId = ResourceAdjunctInteractions.GetResourceStubAssetId(manifest, customerId, manifestId);
         var result = new List<DlcsInteractionRequest>();
 
         foreach (var interaction in adjunctInteractions.Where(a => a.AssetId == expectedStubAssetId && a.ExistingAdjunctIds == null))

--- a/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
@@ -206,7 +206,14 @@ public class DlcsManifestCoordinator(
 
         var assetsToIngest = dlcsInteractionRequests.Where(d => d.Ingest != IngestType.NoIngest).ToList();
 
-        // create batches for assets
+        // Enrich adjunct state before batching so missing stub assets can be co-ingested in a single call
+        if (adjunctInteractions.Count > 0)
+        {
+            await EnrichExistingAdjunctIds(request, adjunctInteractions, cancellationToken);
+            assetsToIngest.AddRange(BuildMissingStubAssetRequests(request.CustomerId, manifestId, adjunctInteractions));
+        }
+
+        // create batches for assets (including any new stub assets)
         var collectedBatches = new List<Batch>();
         var batchError = await CreateBatches(request.CustomerId, manifestId, assetsToIngest, collectedBatches,
             cancellationToken);
@@ -238,15 +245,6 @@ public class DlcsManifestCoordinator(
     {
         if (adjunctInteractions.Count > 0)
         {
-            // ExistingAdjunctIds may already be set for assets checked against DLCS in FindAssetsThatRequireAdditionalWork;
-            // this call fills in any that were missed (e.g. assets that were already known and skipped the IIIF-CS check)
-            await EnrichExistingAdjunctIds(request, adjunctInteractions, cancellationToken);
-
-            // Ensure stub assets (space 0) exist before ingesting their adjuncts
-            var manifestAdjunctAssetError = await EnsureManifestAdjunctAssetsExist(request.CustomerId, manifestId, adjunctInteractions,
-                collectedBatches, cancellationToken);
-            if (manifestAdjunctAssetError != null) return new DlcsInteractionResult(manifestAdjunctAssetError, spaceId);
-
             // remove any adjuncts in IIIF-CS that are no longer in the manifest
             await DeleteUnusedAdjuncts(request.CustomerId, adjunctInteractions, cancellationToken);
 
@@ -263,34 +261,29 @@ public class DlcsManifestCoordinator(
         return null;
     }
 
-    private async Task<EntityResult?> EnsureManifestAdjunctAssetsExist(int customerId, string manifestId,
-        List<AdjunctInteraction> adjunctInteractions, List<Batch> collectedBatches, CancellationToken cancellationToken)
+    private static List<DlcsInteractionRequest> BuildMissingStubAssetRequests(int customerId, string manifestId,
+        List<AdjunctInteraction> adjunctInteractions)
     {
-        var expectedManifestStubAssetId = ResourceAdjunctInteractions.GetResourceStubAssetId(customerId, manifestId);
-        var missingManifestAdjunctAssets = adjunctInteractions
-            .Where(a => a.AssetId == expectedManifestStubAssetId && a.ExistingAdjunctIds == null)
-            .ToList();
+        var expectedStubAssetId = ResourceAdjunctInteractions.GetResourceStubAssetId(customerId, manifestId);
+        var result = new List<DlcsInteractionRequest>();
 
-        if (missingManifestAdjunctAssets.Count == 0) return null;
+        foreach (var interaction in adjunctInteractions.Where(a => a.AssetId == expectedStubAssetId && a.ExistingAdjunctIds == null))
+        {
+            result.Add(new DlcsInteractionRequest(
+                new JObject
+                {
+                    [AssetProperties.Id] = interaction.AssetId.Asset,
+                    [AssetProperties.Space] = interaction.AssetId.Space
+                },
+                IngestType.ManifestId,
+                patch: false,
+                interaction.AssetId));
 
-        var manifestAdjunctAssets = missingManifestAdjunctAssets
-            .Select(a => new JObject
-            {
-                [AssetProperties.Id] = a.AssetId.Asset,
-                [AssetProperties.Space] = a.AssetId.Space,
-                [AssetProperties.Manifests] = new JArray { manifestId }
-            })
-            .ToList();
-
-        var error = await IngestDeliverables(customerId, manifestId, manifestAdjunctAssets, DeliverableType.Asset,
-            collectedBatches, cancellationToken);
-        if (error != null) return error;
-        
-        // Manifest-level adjunct asset was just created; it has no pre-existing adjuncts to diff against
-        foreach (var interaction in missingManifestAdjunctAssets)
+            // Stub asset is being created now; it has no pre-existing adjuncts to diff against
             interaction.ExistingAdjunctIds = [];
+        }
 
-        return null;
+        return result;
     }
 
     private async Task EnrichExistingAdjunctIds(WriteManifestRequest request, List<AdjunctInteraction> adjunctInteractions,

--- a/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
@@ -130,7 +130,7 @@ public class DlcsManifestCoordinator(
     {
         var assets = GetAssetJObjectList(request.PresentationManifest.PaintedResources);
 
-        if (!request.CreateSpace && assets.Count <= 0 && previousManifestAssetIds.IsNullOrEmpty() && adjunctInteractions.Count == 0)
+        if (!request.CreateSpace && assets.Count == 0 && previousManifestAssetIds.IsNullOrEmpty() && adjunctInteractions.Count == 0)
         {
             logger.LogDebug("No assets or space required, DLCS integrations not required");
             return DlcsInteractionResult.NoInteraction;
@@ -266,10 +266,9 @@ public class DlcsManifestCoordinator(
     private async Task<EntityResult?> EnsureManifestAdjunctAssetsExist(int customerId, string manifestId,
         List<AdjunctInteraction> adjunctInteractions, List<Batch> collectedBatches, CancellationToken cancellationToken)
     {
-        // Manifest-level adjunct assets are identified by space 0 AND the Manifest_ prefix — space 0 alone is not unique
-        var expectedManifestAdjunctId = CanvasPaintingResolver.ManifestLevelAdjunctId(manifestId);
+        var expectedManifestStubAssetId = CanvasPaintingResolver.ManifestStubAssetId(customerId, manifestId);
         var missingManifestAdjunctAssets = adjunctInteractions
-            .Where(a => a.AssetId.Space == 0 && a.AssetId.Asset == expectedManifestAdjunctId && a.ExistingAdjunctIds == null)
+            .Where(a => a.AssetId == expectedManifestStubAssetId && a.ExistingAdjunctIds == null)
             .ToList();
 
         if (missingManifestAdjunctAssets.Count == 0) return null;
@@ -278,15 +277,15 @@ public class DlcsManifestCoordinator(
             .Select(a => new JObject
             {
                 [AssetProperties.Id] = a.AssetId.Asset,
-                [AssetProperties.Space] = 0,
+                [AssetProperties.Space] = a.AssetId.Space,
                 [AssetProperties.Manifests] = new JArray { manifestId }
             })
             .ToList();
 
-        var result = await IngestDeliverables(customerId, manifestId, manifestAdjunctAssets, DeliverableType.Asset,
+        var error = await IngestDeliverables(customerId, manifestId, manifestAdjunctAssets, DeliverableType.Asset,
             collectedBatches, cancellationToken);
-        if (result != null) return result;
-
+        if (error != null) return error;
+        
         // Manifest-level adjunct asset was just created; it has no pre-existing adjuncts to diff against
         foreach (var interaction in missingManifestAdjunctAssets)
             interaction.ExistingAdjunctIds = [];

--- a/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
@@ -243,9 +243,9 @@ public class DlcsManifestCoordinator(
             await EnrichExistingAdjunctIds(request, adjunctInteractions, cancellationToken);
 
             // Ensure stub assets (space 0) exist before ingesting their adjuncts
-            var stubAssetError = await EnsureStubAssetsExist(request.CustomerId, manifestId, adjunctInteractions,
+            var manifestAdjunctAssetError = await EnsureManifestAdjunctAssetsExist(request.CustomerId, manifestId, adjunctInteractions,
                 collectedBatches, cancellationToken);
-            if (stubAssetError != null) return new DlcsInteractionResult(stubAssetError, spaceId);
+            if (manifestAdjunctAssetError != null) return new DlcsInteractionResult(manifestAdjunctAssetError, spaceId);
 
             // remove any adjuncts in IIIF-CS that are no longer in the manifest
             await DeleteUnusedAdjuncts(request.CustomerId, adjunctInteractions, cancellationToken);
@@ -263,33 +263,35 @@ public class DlcsManifestCoordinator(
         return null;
     }
 
-    private async Task<EntityResult?> EnsureStubAssetsExist(int customerId, string manifestId,
+    private async Task<EntityResult?> EnsureManifestAdjunctAssetsExist(int customerId, string manifestId,
         List<AdjunctInteraction> adjunctInteractions, List<Batch> collectedBatches, CancellationToken cancellationToken)
     {
-        // Manifest-level stub assets live in space 0; ExistingAdjunctIds == null means the asset was not found in DLCS
-        var missingStubAssets = adjunctInteractions
-            .Where(a => a.AssetId.Space == 0 && a.ExistingAdjunctIds == null)
+        // Manifest-level adjunct assets are identified by space 0 AND the Manifest_ prefix — space 0 alone is not unique
+        var expectedManifestAdjunctId = CanvasPaintingResolver.ManifestLevelAdjunctId(manifestId);
+        var missingManifestAdjunctAssets = adjunctInteractions
+            .Where(a => a.AssetId.Space == 0 && a.AssetId.Asset == expectedManifestAdjunctId && a.ExistingAdjunctIds == null)
             .ToList();
 
-        if (missingStubAssets.Count == 0) return null;
+        if (missingManifestAdjunctAssets.Count == 0) return null;
 
-        var stubAssetJObjects = missingStubAssets
+        var manifestAdjunctAssets = missingManifestAdjunctAssets
             .Select(a => new JObject
             {
                 [AssetProperties.Id] = a.AssetId.Asset,
                 [AssetProperties.Space] = 0,
-                [AssetProperties.Manifests] = new JArray(manifestId)
+                [AssetProperties.Manifests] = new JArray { manifestId }
             })
             .ToList();
 
-        var result = await IngestDeliverables(customerId, manifestId, stubAssetJObjects, DeliverableType.Asset,
+        var result = await IngestDeliverables(customerId, manifestId, manifestAdjunctAssets, DeliverableType.Asset,
             collectedBatches, cancellationToken);
+        if (result != null) return result;
 
-        // Mark as having no existing adjuncts so DeleteUnusedAdjuncts skips them
-        foreach (var interaction in missingStubAssets)
+        // Manifest-level adjunct asset was just created; it has no pre-existing adjuncts to diff against
+        foreach (var interaction in missingManifestAdjunctAssets)
             interaction.ExistingAdjunctIds = [];
 
-        return result;
+        return null;
     }
 
     private async Task EnrichExistingAdjunctIds(WriteManifestRequest request, List<AdjunctInteraction> adjunctInteractions,

--- a/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
@@ -130,7 +130,7 @@ public class DlcsManifestCoordinator(
     {
         var assets = GetAssetJObjectList(request.PresentationManifest.PaintedResources);
 
-        if (!request.CreateSpace && assets.Count == 0 && previousManifestAssetIds.IsNullOrEmpty() && adjunctInteractions.Count == 0)
+        if (!HasItems(request, assets, previousManifestAssetIds, adjunctInteractions))
         {
             logger.LogDebug("No assets or space required, DLCS integrations not required");
             return DlcsInteractionResult.NoInteraction;
@@ -365,6 +365,10 @@ public class DlcsManifestCoordinator(
         await dlcsApiClient.UpdateAssetManifest(customerId,
             assetsToRemove.Select(cp => cp.ToString()).ToList(), OperationType.Remove,
     [dbManifestId], cancellationToken);
+
+    private static bool HasItems(WriteManifestRequest request, List<JObject> assets,
+        List<AssetId>? previousManifestAssetIds, List<AdjunctInteraction> adjunctInteractions) =>
+        request.CreateSpace || assets.Count > 0 || !previousManifestAssetIds.IsNullOrEmpty() || adjunctInteractions.Count > 0;
 
     private static List<JObject> GetAssetJObjectList(List<PaintedResource>? paintedResources) =>
         paintedResources?

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestReadService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestReadService.cs
@@ -80,16 +80,7 @@ public class ManifestReadService(
 
         // If the DLCS lookup failed, assets will be null (error already logged in DlcsManifestCoordinator).
         // Return the manifest without manifest-level adjuncts rather than failing the GET.
-        if (assets != null)
-        {
-            // set manifest level adjuncts
-            var manifestAdjunctId = CanvasPaintingResolver.ManifestLevelAdjunctId(dbManifest.Id);
-            var manifestAdjunctAsset = assets.Values.FirstOrDefault(a => a[AssetProperties.Id]?.Value<string>() == manifestAdjunctId);
-            if (manifestAdjunctAsset?[AssetProperties.Adjuncts] is JArray adjunctsArray)
-                manifest.Adjuncts = adjunctsArray.OfType<JObject>()
-                    .Select(a => { a.Remove(AssetProperties.Asset); return a; })
-                    .ToList();
-        }
+        if (assets != null) SetManifestLevelAdjuncts(manifest, assets, customerId, dbManifest.Id);
 
         Guid? etag = dbManifest.Etag;
         if (dbManifest.IsIngesting())
@@ -99,5 +90,18 @@ public class ManifestReadService(
         }
 
         return FetchEntityResult<PresentationManifest>.Success(manifest, etag);
+    }
+
+    private static void SetManifestLevelAdjuncts(PresentationManifest manifest,
+        Dictionary<string, JObject> assets, int customerId, string manifestId)
+    {
+        var stubAssetId = CanvasPaintingResolver.ManifestStubAssetId(customerId, manifestId);
+        var stubAsset = assets.Values.FirstOrDefault(a => a[AssetProperties.Id]?.Value<string>() == stubAssetId.Asset);
+        if (stubAsset?[AssetProperties.Adjuncts] is JArray adjunctsArray)
+        {
+            manifest.Adjuncts = adjunctsArray.OfType<JObject>()
+                .Select(a => { a.Remove(AssetProperties.Asset); return a; })
+                .ToList();
+        }
     }
 }

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestReadService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestReadService.cs
@@ -76,12 +76,13 @@ public class ManifestReadService(
                 "Unable to read and deserialize manifest from storage");
 
         var assets = await getAssets;
-        manifest = manifest.SetGeneratedFields(dbManifest, pathGenerator, settingsBasedPathGenerator, assets,
-            m => Enumerable.Single(m.Hierarchy!, h => h.Canonical));
 
         // If the DLCS lookup failed, assets will be null (error already logged in DlcsManifestCoordinator).
         // Return the manifest without manifest-level adjuncts rather than failing the GET.
         if (assets != null) SetManifestLevelAdjuncts(manifest, assets, customerId, dbManifest.Id);
+
+        manifest = manifest.SetGeneratedFields(dbManifest, pathGenerator, settingsBasedPathGenerator, assets,
+            m => Enumerable.Single(m.Hierarchy!, h => h.Canonical));
 
         Guid? etag = dbManifest.Etag;
         if (dbManifest.IsIngesting())
@@ -100,9 +101,7 @@ public class ManifestReadService(
         var stubAsset = assets.Values.FirstOrDefault(a => a[AssetProperties.Id]?.Value<string>() == stubAssetId.Asset);
         if (stubAsset?[AssetProperties.Adjuncts] is JArray adjunctsArray)
         {
-            manifest.Adjuncts = adjunctsArray.OfType<JObject>()
-                .Select(a => { a.Remove(AssetProperties.Asset); return a; })
-                .ToList();
+            manifest.Adjuncts = adjunctsArray.OfType<JObject>().ToList();
         }
     }
 }

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestReadService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestReadService.cs
@@ -78,12 +78,14 @@ public class ManifestReadService(
         manifest = manifest.SetGeneratedFields(dbManifest, pathGenerator, settingsBasedPathGenerator, assets,
             m => Enumerable.Single(m.Hierarchy!, h => h.Canonical));
 
+        // If the DLCS lookup failed, assets will be null (error already logged in DlcsManifestCoordinator).
+        // Return the manifest without manifest-level adjuncts rather than failing the GET.
         if (assets != null)
         {
             // set manifest level adjuncts
-            var stubAssetName = CanvasPaintingResolver.ManifestStubAssetId(dbManifest.Id);
-            var stubAsset = assets.Values.FirstOrDefault(a => a[AssetProperties.Id]?.Value<string>() == stubAssetName);
-            if (stubAsset?[AssetProperties.Adjuncts] is JArray adjunctsArray)
+            var manifestAdjunctId = CanvasPaintingResolver.ManifestLevelAdjunctId(dbManifest.Id);
+            var manifestAdjunctAsset = assets.Values.FirstOrDefault(a => a[AssetProperties.Id]?.Value<string>() == manifestAdjunctId);
+            if (manifestAdjunctAsset?[AssetProperties.Adjuncts] is JArray adjunctsArray)
                 manifest.Adjuncts = adjunctsArray.OfType<JObject>()
                     .Select(a => { a.Remove(AssetProperties.Asset); return a; })
                     .ToList();

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestReadService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestReadService.cs
@@ -4,10 +4,10 @@ using API.Features.Storage.Helpers;
 using API.Helpers;
 using API.Infrastructure.Requests;
 using AWS.Helpers;
-using DLCS.API;
 using Models.API.Manifest;
 using Models.Database.Collections;
-using Models.Database.General;
+using Models.DLCS;
+using Newtonsoft.Json.Linq;
 using Repository;
 using Repository.Helpers;
 using Repository.Paths;
@@ -68,7 +68,6 @@ public class ManifestReadService(
         // or if not found in "staging", an error was logged and we fall back to "real"
         manifest ??= await iiifS3.ReadIIIFFromS3<PresentationManifest>(dbManifest, false, cancellationToken);
 
-
         dbManifest.Hierarchy.Single().FullPath = await fetchFullPath;
 
         if (manifest == null)
@@ -78,6 +77,17 @@ public class ManifestReadService(
         var assets = await getAssets;
         manifest = manifest.SetGeneratedFields(dbManifest, pathGenerator, settingsBasedPathGenerator, assets,
             m => Enumerable.Single(m.Hierarchy!, h => h.Canonical));
+
+        if (assets != null)
+        {
+            // set manifest level adjuncts
+            var stubAssetName = CanvasPaintingResolver.ManifestStubAssetId(dbManifest.Id);
+            var stubAsset = assets.Values.FirstOrDefault(a => a[AssetProperties.Id]?.Value<string>() == stubAssetName);
+            if (stubAsset?[AssetProperties.Adjuncts] is JArray adjunctsArray)
+                manifest.Adjuncts = adjunctsArray.OfType<JObject>()
+                    .Select(a => { a.Remove(AssetProperties.Asset); return a; })
+                    .ToList();
+        }
 
         Guid? etag = dbManifest.Etag;
         if (dbManifest.IsIngesting())

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestReadService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestReadService.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Immutable;
 using API.Converters;
+using API.Features.Common.Helpers;
 using API.Features.Storage.Helpers;
 using API.Helpers;
 using API.Infrastructure.Requests;
@@ -95,7 +96,7 @@ public class ManifestReadService(
     private static void SetManifestLevelAdjuncts(PresentationManifest manifest,
         Dictionary<string, JObject> assets, int customerId, string manifestId)
     {
-        var stubAssetId = CanvasPaintingResolver.ManifestStubAssetId(customerId, manifestId);
+        var stubAssetId = ResourceAdjunctInteractions.GetResourceStubAssetId(customerId, manifestId);
         var stubAsset = assets.Values.FirstOrDefault(a => a[AssetProperties.Id]?.Value<string>() == stubAssetId.Asset);
         if (stubAsset?[AssetProperties.Adjuncts] is JArray adjunctsArray)
         {

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestReadService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestReadService.cs
@@ -97,7 +97,7 @@ public class ManifestReadService(
     private static void SetManifestLevelAdjuncts(PresentationManifest manifest,
         Dictionary<string, JObject> assets, int customerId, string manifestId)
     {
-        var stubAssetId = ResourceAdjunctInteractions.GetResourceStubAssetId(customerId, manifestId);
+        var stubAssetId = ResourceAdjunctInteractions.GetResourceStubAssetId(manifest, customerId, manifestId);
         var stubAsset = assets.Values.FirstOrDefault(a => a[AssetProperties.Id]?.Value<string>() == stubAssetId.Asset);
         if (stubAsset?[AssetProperties.Adjuncts] is JArray adjunctsArray)
         {

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
@@ -159,12 +159,12 @@ public class ManifestWriteService(
     {
         using (logger.BeginScope("Creating Manifest for Customer {CustomerId}", request.CustomerId))
         {
-            var resolved = await ResolveCanvasPaintingsAndParentSlug(request, cancellationToken: cancellationToken);
-            if (resolved.Error != null) return resolved.Error;
-
-            // Ensure we have a manifestId
+            // Generate manifest ID before canvas painting resolution so it's available for stub asset naming
             manifestId ??= await GenerateUniqueManifestId(request, cancellationToken);
             if (manifestId == null) return UpsertErrorHelper.CannotGenerateUniqueId<PresentationManifest>();
+
+            var resolved = await ResolveCanvasPaintingsAndParentSlug(request, manifestId, cancellationToken: cancellationToken);
+            if (resolved.Error != null) return resolved.Error;
 
             // Carry out any DLCS interactions and update canvas paintings
             var dlcsResult = await HandleDlcsInteractions(request, manifestId, resolved.ParsedManifestResult!,
@@ -255,7 +255,7 @@ public class ManifestWriteService(
     private async Task<ResolvedManifestData> ResolveCanvasPaintingsAndParentSlug(WriteManifestRequest request,
         string? manifestId = null, DbManifest? existingManifest = null, CancellationToken cancellationToken = default)
     {
-        var (canvasError, canvasPaintingRecords) = await ResolveCanvasPaintings(request, existingManifest, cancellationToken);
+        var (canvasError, canvasPaintingRecords) = await ResolveCanvasPaintings(request, existingManifest, manifestId, cancellationToken);
         if (canvasError != null) return ResolvedManifestData.Failure(canvasError);
 
         var (slugError, parsedParentSlug) = await ParseParentSlug(request, manifestId, cancellationToken);
@@ -265,13 +265,13 @@ public class ManifestWriteService(
     }
 
     private async Task<(PresUpdateResult? error, ParsedManifestResult? records)> ResolveCanvasPaintings(
-        WriteManifestRequest request, DbManifest? existingManifest, CancellationToken cancellationToken)
+        WriteManifestRequest request, DbManifest? existingManifest, string? manifestId, CancellationToken cancellationToken)
     {
         var isCreate = existingManifest == null;
-        
+
         var result = isCreate
             ? await canvasPaintingResolver.GenerateCanvasPaintings(request.CustomerId, request.PresentationManifest,
-                cancellationToken)
+                manifestId, cancellationToken)
             : await canvasPaintingResolver.UpdateCanvasPaintings(request.CustomerId, request.PresentationManifest,
                 existingManifest!, cancellationToken);
         return result.Error != null ? (result.Error, null) : (null, result);

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
@@ -253,7 +253,7 @@ public class ManifestWriteService(
     }
 
     private async Task<ResolvedManifestData> ResolveCanvasPaintingsAndParentSlug(WriteManifestRequest request,
-        string? manifestId = null, DbManifest? existingManifest = null, CancellationToken cancellationToken = default)
+        string manifestId, DbManifest? existingManifest = null, CancellationToken cancellationToken = default)
     {
         var (canvasError, canvasPaintingRecords) = await ResolveCanvasPaintings(request, existingManifest, manifestId, cancellationToken);
         if (canvasError != null) return ResolvedManifestData.Failure(canvasError);
@@ -265,13 +265,13 @@ public class ManifestWriteService(
     }
 
     private async Task<(PresUpdateResult? error, ParsedManifestResult? records)> ResolveCanvasPaintings(
-        WriteManifestRequest request, DbManifest? existingManifest, string? manifestId, CancellationToken cancellationToken)
+        WriteManifestRequest request, DbManifest? existingManifest, string manifestId, CancellationToken cancellationToken)
     {
         var isCreate = existingManifest == null;
 
         var result = isCreate
             ? await canvasPaintingResolver.GenerateCanvasPaintings(request.CustomerId, request.PresentationManifest,
-                manifestId!, cancellationToken)
+                manifestId, cancellationToken)
             : await canvasPaintingResolver.UpdateCanvasPaintings(request.CustomerId, request.PresentationManifest,
                 existingManifest!, cancellationToken);
         return result.Error != null ? (result.Error, null) : (null, result);

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
@@ -163,6 +163,7 @@ public class ManifestWriteService(
             manifestId ??= await GenerateUniqueManifestId(request, cancellationToken);
             if (manifestId == null) return UpsertErrorHelper.CannotGenerateUniqueId<PresentationManifest>();
 
+            request.PresentationManifest.Id = manifestId;
             var resolved = await ResolveCanvasPaintingsAndParentSlug(request, manifestId, cancellationToken: cancellationToken);
             if (resolved.Error != null) return resolved.Error;
 
@@ -172,7 +173,7 @@ public class ManifestWriteService(
             if (dlcsResult.Error != null) return dlcsResult.Error;
 
             var (error, dbManifest) =
-                await CreateDatabaseRecord(request, resolved.ParsedParentSlug!, manifestId, dlcsResult.InteractionResult!.SpaceId,
+                await CreateDatabaseRecord(request, resolved.ParsedParentSlug!, dlcsResult.InteractionResult!.SpaceId,
                     dlcsResult.CanvasPaintings, cancellationToken);
             if (error != null) return error;
 
@@ -194,6 +195,7 @@ public class ManifestWriteService(
         {
             var existingAssetIds = existingManifest.CanvasPaintings?.Where(cp => cp.AssetId != null)
                 .Select(cp => cp.AssetId!).ToList();
+            request.PresentationManifest.Id = request.ManifestId;
             var resolved = await ResolveCanvasPaintingsAndParentSlug(request, request.ManifestId, existingManifest, cancellationToken);
             if (resolved.Error != null) return resolved.Error;
 
@@ -255,7 +257,7 @@ public class ManifestWriteService(
     private async Task<ResolvedManifestData> ResolveCanvasPaintingsAndParentSlug(WriteManifestRequest request,
         string manifestId, DbManifest? existingManifest = null, CancellationToken cancellationToken = default)
     {
-        var (canvasError, canvasPaintingRecords) = await ResolveCanvasPaintings(request, existingManifest, manifestId, cancellationToken);
+        var (canvasError, canvasPaintingRecords) = await ResolveCanvasPaintings(request, existingManifest, cancellationToken);
         if (canvasError != null) return ResolvedManifestData.Failure(canvasError);
 
         var (slugError, parsedParentSlug) = await ParseParentSlug(request, manifestId, cancellationToken);
@@ -265,13 +267,13 @@ public class ManifestWriteService(
     }
 
     private async Task<(PresUpdateResult? error, ParsedManifestResult? records)> ResolveCanvasPaintings(
-        WriteManifestRequest request, DbManifest? existingManifest, string manifestId, CancellationToken cancellationToken)
+        WriteManifestRequest request, DbManifest? existingManifest, CancellationToken cancellationToken)
     {
         var isCreate = existingManifest == null;
 
         var result = isCreate
             ? await canvasPaintingResolver.GenerateCanvasPaintings(request.CustomerId, request.PresentationManifest,
-                manifestId, cancellationToken)
+                cancellationToken)
             : await canvasPaintingResolver.UpdateCanvasPaintings(request.CustomerId, request.PresentationManifest,
                 existingManifest!, cancellationToken);
         return result.Error != null ? (result.Error, null) : (null, result);
@@ -309,13 +311,13 @@ public class ManifestWriteService(
     }
 
     private async Task<(PresUpdateResult?, DbManifest?)> CreateDatabaseRecord(WriteManifestRequest request,
-        ParsedParentSlug parsedParentSlug, string manifestId, int? spaceId, 
+        ParsedParentSlug parsedParentSlug, int? spaceId, 
         List<Models.Database.CanvasPainting> canvasPaintings, CancellationToken cancellationToken)
     {
         var timeStamp = DateTime.UtcNow;
         var dbManifest = new DbManifest
         {
-            Id = manifestId,
+            Id = request.PresentationManifest.Id!,
             CustomerId = request.CustomerId,
             Created = timeStamp,
             Modified = timeStamp,

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
@@ -271,7 +271,7 @@ public class ManifestWriteService(
 
         var result = isCreate
             ? await canvasPaintingResolver.GenerateCanvasPaintings(request.CustomerId, request.PresentationManifest,
-                manifestId, cancellationToken)
+                manifestId!, cancellationToken)
             : await canvasPaintingResolver.UpdateCanvasPaintings(request.CustomerId, request.PresentationManifest,
                 existingManifest!, cancellationToken);
         return result.Error != null ? (result.Error, null) : (null, result);

--- a/src/IIIFPresentation/API/Features/Manifest/Validators/PresentationManifestValidator.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/Validators/PresentationManifestValidator.cs
@@ -17,6 +17,7 @@ public class PresentationManifestValidator : AbstractValidator<PresentationManif
     {
         servicesSettings = servicesOptions.Value;
         When(m => !m.PaintedResources.IsNullOrEmpty(), PaintedResourcesValidation);
+        When(m => m.Adjuncts is { Count: > 0 }, ManifestAdjunctsValidation);
         RuleFor(c => c).SetValidator(new PresentationValidator());
         
         RuleFor(m => m.Items)
@@ -82,6 +83,13 @@ public class PresentationManifestValidator : AbstractValidator<PresentationManif
                 "'static_width' and 'static_height' have to be both set or both absent within a 'canvasPainting'");
      }
     
+    // Validation rules for manifest-level adjuncts
+    private void ManifestAdjunctsValidation()
+    {
+        RuleForEach(m => m.Adjuncts)
+            .SetValidator(new AdjunctValidator(servicesSettings));
+    }
+
     // Validation rules specific to Adjuncts only
     private void AdjunctsValidation()
     {

--- a/src/IIIFPresentation/API/Features/Manifest/Validators/PresentationManifestValidator.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/Validators/PresentationManifestValidator.cs
@@ -17,7 +17,7 @@ public class PresentationManifestValidator : AbstractValidator<PresentationManif
     {
         servicesSettings = servicesOptions.Value;
         When(m => !m.PaintedResources.IsNullOrEmpty(), PaintedResourcesValidation);
-        When(m => m.Adjuncts is { Count: > 0 }, ManifestAdjunctsValidation);
+        When(m => !m.Adjuncts.IsNullOrEmpty(), ManifestAdjunctsValidation);
         RuleFor(c => c).SetValidator(new PresentationValidator());
         
         RuleFor(m => m.Items)

--- a/src/IIIFPresentation/API/Features/Manifest/Validators/PresentationManifestValidator.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/Validators/PresentationManifestValidator.cs
@@ -87,6 +87,10 @@ public class PresentationManifestValidator : AbstractValidator<PresentationManif
     private void ManifestAdjunctsValidation()
     {
         RuleForEach(m => m.Adjuncts)
+            .Must(a => !a.ContainsKey(AssetProperties.Asset))
+            .WithMessage("Manifest-level adjuncts must not include an 'asset' property; it is set by the system");
+
+        RuleForEach(m => m.Adjuncts)
             .SetValidator(new AdjunctValidator(servicesSettings));
     }
 

--- a/src/IIIFPresentation/DLCS.Tests/API/DlcsApiClientTests.cs
+++ b/src/IIIFPresentation/DLCS.Tests/API/DlcsApiClientTests.cs
@@ -572,8 +572,8 @@ public class DlcsApiClientTests
 
         var adjuncts = new List<AdjunctAssetIdentifier>
         {
-            new() { Id = "asset1", Adjunct = ["a", "b"] },
-            new() { Id = "asset2", Adjunct = ["c"] }
+            new() { Id = new AssetId(customerId, 1, "asset1"), Adjunct = ["a", "b"] },
+            new() { Id = new AssetId(customerId, 1, "asset2"), Adjunct = ["c"] }
         };
 
         await sut.DeleteAdjuncts(customerId, adjuncts, CancellationToken.None);
@@ -600,8 +600,8 @@ public class DlcsApiClientTests
 
         var adjuncts = new List<AdjunctAssetIdentifier>
         {
-            new() { Id = "asset1", Adjunct = ["a", "b", "c"] },
-            new() { Id = "asset2", Adjunct = ["d", "e", "f"] }
+            new() { Id = new AssetId(customerId, 1, "asset1"), Adjunct = ["a", "b", "c"] },
+            new() { Id = new AssetId(customerId, 1, "asset2"), Adjunct = ["d", "e", "f"] }
         };
 
         await sut.DeleteAdjuncts(customerId, adjuncts, CancellationToken.None);
@@ -623,7 +623,7 @@ public class DlcsApiClientTests
         var sut = GetClient(stub);
 
         Func<Task> action = () => sut.DeleteAdjuncts(customerId,
-            [new AdjunctAssetIdentifier { Id = "asset1", Adjunct = ["a"] }],
+            [new AdjunctAssetIdentifier { Id = new AssetId(customerId, 1, "asset1"), Adjunct = ["a"] }],
             CancellationToken.None);
 
         await action.Should().ThrowAsync<DlcsException>()
@@ -649,7 +649,7 @@ public class DlcsApiClientTests
 
         var adjuncts = new List<AdjunctAssetIdentifier>
         {
-            new() { Id = "asset1", Adjunct = ["a", "b", "c", "d"] }
+            new() { Id = new AssetId(customerId, 1, "asset1"), Adjunct = ["a", "b", "c", "d"] }
         };
 
         await sut.DeleteAdjuncts(customerId, adjuncts, CancellationToken.None);

--- a/src/IIIFPresentation/DLCS.Tests/API/DlcsApiClientTests.cs
+++ b/src/IIIFPresentation/DLCS.Tests/API/DlcsApiClientTests.cs
@@ -555,6 +555,30 @@ public class DlcsApiClientTests
 
 
     [Fact]
+    public async Task DeleteAdjuncts_SerializesIdAsString_NotObject()
+    {
+        using var stub = new ApiStub();
+        const int customerId = 5;
+        var capturedBody = string.Empty;
+
+        stub.Request(HttpMethod.Post).IfRoute($"/customers/{customerId}/deleteAdjuncts")
+            .Response((request, _) =>
+            {
+                capturedBody = request.Body.ReadAsStringAsync().Result;
+                return string.Empty;
+            }).StatusCode(204);
+
+        var sut = GetClient(stub);
+
+        await sut.DeleteAdjuncts(customerId,
+            [new AdjunctAssetIdentifier { Id = new AssetId(customerId, 1, "asset1"), Adjunct = ["a"] }],
+            CancellationToken.None);
+
+        capturedBody.Should().Contain($"\"{customerId}/1/asset1\"");
+        capturedBody.Should().NotContain("\"customer\"");
+    }
+
+    [Fact]
     public async Task DeleteAdjuncts_MakesSingleRequest_WhenTotalAdjunctCountWithinLimit()
     {
         using var stub = new ApiStub();

--- a/src/IIIFPresentation/DLCS.Tests/API/DlcsApiClientTests.cs
+++ b/src/IIIFPresentation/DLCS.Tests/API/DlcsApiClientTests.cs
@@ -731,6 +731,9 @@ public class DlcsApiClientTests
         {
             BaseAddress = new Uri(stub.Address)
         };
+        // Stubbery doesn't support HTTP/1.1 keep-alive across multiple requests; force connection-close
+        // so each request gets a fresh connection and avoids ResponseEnded on the second call
+        httpClient.DefaultRequestHeaders.ConnectionClose = true;
 
         var options = Options.Create(new DlcsSettings()
         {

--- a/src/IIIFPresentation/DLCS.Tests/Converters/AssetIdConverterTests.cs
+++ b/src/IIIFPresentation/DLCS.Tests/Converters/AssetIdConverterTests.cs
@@ -1,0 +1,55 @@
+using System.Text.Json;
+using DLCS.Converters;
+using Models.DLCS;
+
+namespace DLCS.Tests.Converters;
+
+public class AssetIdConverterTests
+{
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        Converters = { new AssetIdConverter() }
+    };
+
+    [Fact]
+    public void Write_SerializesAsString()
+    {
+        var assetId = new AssetId(5, 1, "my-asset");
+
+        var json = JsonSerializer.Serialize(assetId, Options);
+
+        json.Should().Be("\"5/1/my-asset\"");
+    }
+
+    [Fact]
+    public void Read_DeserializesFromString()
+    {
+        var result = JsonSerializer.Deserialize<AssetId>("\"5/1/my-asset\"", Options);
+
+        result.Should().NotBeNull();
+        result!.Customer.Should().Be(5);
+        result.Space.Should().Be(1);
+        result.Asset.Should().Be("my-asset");
+    }
+
+    [Fact]
+    public void RoundTrip_PreservesValue()
+    {
+        var original = new AssetId(2, 10, "some-image");
+
+        var json = JsonSerializer.Serialize(original, Options);
+        var result = JsonSerializer.Deserialize<AssetId>(json, Options);
+
+        result.Should().Be(original);
+    }
+
+    [Fact]
+    public void Write_UsedAsProperty_SerializesIdAsString()
+    {
+        var obj = new { Id = new AssetId(3, 0, "test") };
+
+        var json = JsonSerializer.Serialize(obj, Options);
+
+        json.Should().Contain("\"3/0/test\"");
+    }
+}

--- a/src/IIIFPresentation/DLCS.Tests/Converters/AssetIdConverterTests.cs
+++ b/src/IIIFPresentation/DLCS.Tests/Converters/AssetIdConverterTests.cs
@@ -52,4 +52,12 @@ public class AssetIdConverterTests
 
         json.Should().Contain("\"3/0/test\"");
     }
+
+    [Fact]
+    public void Read_InvalidString_Throws()
+    {
+        Action act = () => JsonSerializer.Deserialize<AssetId>("\"not-an-asset-id\"", Options);
+
+        act.Should().Throw<AssetIdException>();
+    }
 }

--- a/src/IIIFPresentation/DLCS/API/DlcsHttpContent.cs
+++ b/src/IIIFPresentation/DLCS/API/DlcsHttpContent.cs
@@ -82,7 +82,7 @@ internal static class DlcsHttpContent
 
             if (error != null)
             {
-                return new DlcsException(error.Description, response.StatusCode);
+                return new DlcsException(error.Description ?? "Unknown error", response.StatusCode);
             }
 
             throw new DlcsException("Unable to process error condition", response.StatusCode);

--- a/src/IIIFPresentation/DLCS/API/DlcsHttpContent.cs
+++ b/src/IIIFPresentation/DLCS/API/DlcsHttpContent.cs
@@ -20,7 +20,7 @@ internal static class DlcsHttpContent
     private static readonly JsonSerializerOptions JsonSerializerOptions = new(JsonSerializerDefaults.Web)
     {
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-        Converters = { new JTokenConverter() }
+        Converters = { new JTokenConverter(), new AssetIdConverter() }
     };
         
     /// <summary>

--- a/src/IIIFPresentation/DLCS/Converters/AssetIdConverter.cs
+++ b/src/IIIFPresentation/DLCS/Converters/AssetIdConverter.cs
@@ -1,0 +1,14 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Models.DLCS;
+
+namespace DLCS.Converters;
+
+public class AssetIdConverter : JsonConverter<AssetId>
+{
+    public override AssetId Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        => AssetId.FromString(reader.GetString()!);
+
+    public override void Write(Utf8JsonWriter writer, AssetId value, JsonSerializerOptions options)
+        => writer.WriteStringValue(value.ToString());
+}

--- a/src/IIIFPresentation/DLCS/DLCS.csproj
+++ b/src/IIIFPresentation/DLCS/DLCS.csproj
@@ -16,6 +16,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\Core\Core.csproj" />
+      <ProjectReference Include="..\Models\Models.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/IIIFPresentation/DLCS/Models/AdjunctAssetIdentifier.cs
+++ b/src/IIIFPresentation/DLCS/Models/AdjunctAssetIdentifier.cs
@@ -1,4 +1,6 @@
-﻿namespace DLCS.Models;
+﻿using Models.DLCS;
+
+namespace DLCS.Models;
 
 /// <summary>
 /// Class used to allow for IIIF-CS calls that need just a list of adjunct id's attached to an asset
@@ -7,9 +9,9 @@
 public class AdjunctAssetIdentifier
 {
     /// <summary>
-    /// This is the string representation of an asset id i.e.: "{customer}/{space}/{id}"
+    /// The asset id for these adjuncts
     /// </summary>
-    public required string Id { get; set; }
+    public required AssetId Id { get; set; }
 
     /// <summary>
     /// This is a list of adjunct id's

--- a/src/IIIFPresentation/Models/API/Manifest/PresentationManifest.cs
+++ b/src/IIIFPresentation/Models/API/Manifest/PresentationManifest.cs
@@ -22,11 +22,16 @@ public class PresentationManifest : IIIF.Presentation.V3.Manifest, IPresentation
     public List<PaintedResource>? PaintedResources { get; set; }
 
     [JsonProperty(Order = 13)] public string? Space { get; set; }
-    
+
+    /// <summary>
+    /// Manifest-level adjuncts to be associated with this manifest via a stub asset.
+    /// </summary>
+    [JsonProperty(Order = 14)] public List<JObject>? Adjuncts { get; set; }
+
     /// <summary>
     /// Contains details of the ingestion progress
     /// </summary>
-    [JsonProperty(Order = 14)] public IngestingAssets? Ingesting { get; set; }
+    [JsonProperty(Order = 15)] public IngestingAssets? Ingesting { get; set; }
 
     [JsonIgnore] public string? FullPath { get; set; }
     

--- a/src/IIIFPresentation/Services.Tests/Manifests/ManifestPaintedResourceParserTests.cs
+++ b/src/IIIFPresentation/Services.Tests/Manifests/ManifestPaintedResourceParserTests.cs
@@ -132,6 +132,7 @@ public class ManifestPaintedResourceParserTests
     {
         var manifest = new PresentationManifest
         {
+            Id = TestIdentifiers.Id(),
             PaintedResources =
             [
                 new PaintedResource
@@ -150,8 +151,8 @@ public class ManifestPaintedResourceParserTests
                 }
             ]
         };
-        
-        Func<Task> parseAction = async () => await sut.ParseToCanvasPainting(manifest, CustomerId, TestIdentifiers.Id());
+
+        Func<Task> parseAction = async () => await sut.ParseToCanvasPainting(manifest, CustomerId);
         var expected =
             new CanvasPaintingValidationException([(ExistingCanvasId, "Id used in one of your other manifests")]);
         var throwInfo = await parseAction.Should().ThrowAsync<CanvasPaintingValidationException>();
@@ -163,6 +164,7 @@ public class ManifestPaintedResourceParserTests
     {
         var manifest = new PresentationManifest
         {
+            Id = ExistingManifestId,
             PaintedResources =
             [
                 new PaintedResource
@@ -181,8 +183,8 @@ public class ManifestPaintedResourceParserTests
                 }
             ]
         };
-        
-        Func<Task> parseAction = async () => await sut.ParseToCanvasPainting(manifest, CustomerId, ExistingManifestId);
+
+        Func<Task> parseAction = async () => await sut.ParseToCanvasPainting(manifest, CustomerId);
 
         await parseAction.Should().NotThrowAsync();
     }
@@ -192,9 +194,10 @@ public class ManifestPaintedResourceParserTests
     {
         // Based on https://github.com/dlcs/docs/blob/wip-skeleton/public/manifest-builder/database.py#L90-L99
         var fullCanvasId = $"http://localhost/{CustomerId}/canvases/{ExistingCanvasId}";
-        
+
         var manifest = new PresentationManifest
         {
+            Id = TestIdentifiers.Id(),
             PaintedResources =
             [
                 new PaintedResource
@@ -262,22 +265,23 @@ public class ManifestPaintedResourceParserTests
             ]
         };
         
-        Func<Task> parseAction = async () => await sut.ParseToCanvasPainting(manifest, CustomerId, TestIdentifiers.Id());
+        Func<Task> parseAction = async () => await sut.ParseToCanvasPainting(manifest, CustomerId);
         var expected =
             new CanvasPaintingValidationException([(ExistingCanvasId, "Id used in one of your other manifests")]);
         var throwInfo = await parseAction.Should().ThrowAsync<CanvasPaintingValidationException>();
         throwInfo.Which.Errors.Should().BeEquivalentTo(expected.Errors);
     }
-    
+
     [Fact]
     public async Task Parse_MultiImage_SomeDuplicatedCanvasId_Throws_CanvasPaintingValidationException()
     {
         // Based on https://github.com/dlcs/docs/blob/wip-skeleton/public/manifest-builder/database.py#L90-L99
         var duplicatedId = $"http://localhost/{CustomerId}/canvases/{ExistingCanvasId}";
         var otherId = $"http://localhost/{CustomerId}/canvases/{TestIdentifiers.Id()}";
-        
+
         var manifest = new PresentationManifest
         {
+            Id = TestIdentifiers.Id(),
             PaintedResources =
             [
                 new PaintedResource
@@ -345,7 +349,7 @@ public class ManifestPaintedResourceParserTests
             ]
         };
         
-        Func<Task> parseAction = async () => await sut.ParseToCanvasPainting(manifest, CustomerId, TestIdentifiers.Id());
+        Func<Task> parseAction = async () => await sut.ParseToCanvasPainting(manifest, CustomerId);
         var expected =
             new CanvasPaintingValidationException([(ExistingCanvasId, "Id used in one of your other manifests")]);
         var throwInfo = await parseAction.Should().ThrowAsync<CanvasPaintingValidationException>();

--- a/src/IIIFPresentation/Services/Manifests/ManifestPaintedResourceParser.cs
+++ b/src/IIIFPresentation/Services/Manifests/ManifestPaintedResourceParser.cs
@@ -30,7 +30,7 @@ public class ManifestPaintedResourceParser(
     private readonly PathSettings settings = options.Value;
     
     public async Task<IEnumerable<InterimCanvasPainting>> ParseToCanvasPainting(PresentationManifest presentationManifest,
-        int customerId, string? existingManifestId = null)
+        int customerId)
     {
         if (presentationManifest.PaintedResources.IsNullOrEmpty()) return [];
 
@@ -38,7 +38,7 @@ public class ManifestPaintedResourceParser(
         var canvasPaintings = new List<InterimCanvasPainting>();
 
         using var logScope = logger.BeginScope("Manifest {ManifestId}", presentationManifest.Id);
-        
+
         var count = 0;
         foreach (var paintedResource in paintedResources)
         {
@@ -58,7 +58,7 @@ public class ManifestPaintedResourceParser(
             canvasPaintings.Add(cp);
         }
 
-        await CheckInterimCanvasIds(canvasPaintings, customerId, existingManifestId);
+        await CheckInterimCanvasIds(canvasPaintings, customerId, presentationManifest.Id);
 
         return canvasPaintings;
     }


### PR DESCRIPTION
## What does this change?

Resolves #594

This PR allows manifest level adjuncts to be added to manifests using the new top-level `adjuncts` property like so:

```json
{
    "type": "Manifest",
    "slug": "test-manifest-level-adjuncts",
    "parent": "root",
    "adjuncts": [
                    { 
                        "id": "external",
                        "externalId": "https://external.example/image/mets.xml",
                        "@type": "Dataset",
                        "mediaType": "text/xml",
                        "iiifLink": "seeAlso"
                    },
    ],
}
```

This should then cause the corresponding `adjuncts` field to be filled out on the response.  Additionally, this PR takes advantage of the existing adjuncts code, so the calculation of the diff works the same way as the existing adjuncts code.


Finally, this PR modifies the `AdjunctAssetIdentifier` to use an `AssetId` instead of a `string`  so that it's clearer. 

## Protagonist Dependency

> [!NOTE]
> This PR requires a new version of Protagonist which hasn't been released yet, but is likely to be `1.13.0`
