### PR TITLE
Reject distinct adjuncts across duplicate assets

### DIFF
--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
@@ -11,6 +11,7 @@ using IIIF.Presentation.V3.Annotation;
 using IIIF.Presentation.V3.Content;
 using IIIF.Presentation.V3.Strings;
 using IIIF.Serialisation;
+using JsonDiffPatchDotNet;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Net.Http.Headers;
@@ -18,6 +19,7 @@ using Models.API.General;
 using Models.API.Manifest;
 using Models.Database.General;
 using Models.DLCS;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Repository;
 using Test.Helpers;
@@ -837,10 +839,129 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
          response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
          var errorResponse = await response.ReadAsPresentationResponseAsync<Error>();
          errorResponse!.Detail.Should()
-             .Be($"Asset {Customer}/{NewlyCreatedSpace}/{assetId} is specified multiple times, but has conflicting data - diff: {{\"batch\":[\"{batchId}\",\"DoesNotMatch\"]}}");
+             .Be($"Asset {Customer}/-1/{assetId} is specified multiple times, but has conflicting data - diff: {{\"batch\":[\"{batchId}\",\"DoesNotMatch\"]}}");
          errorResponse.ErrorTypeUri.Should().Be("http://localhost/errors/ModifyCollectionType/AssetsDoNotMatch");
      }
-     
+
+     [Fact]
+     public async Task CreateManifest_BadRequest_WhenMultipleAssetsWithSameAssetIdHaveDifferentAdjuncts()
+     {
+         // Arrange
+         var (assetId, slug) = TestIdentifiers.SlugResource();
+         var batchId = TestIdentifiers.BatchId();
+
+         var manifest = $$"""
+                          {
+                              "type": "Manifest",
+                              "slug": "{{slug}}",
+                              "parent": "http://localhost/{{Customer}}/collections/root",
+                              "paintedResources": [
+                                  {
+                                      "asset": {
+                                          "id": "{{assetId}}",
+                                          "space": {{NewlyCreatedSpace}},
+                                          "batch": "{{batchId}}",
+                                          "mediaType": "image/jpg",
+                                          "adjuncts": [
+                                              {
+                                                  "id": "adjunct-1",
+                                                  "profile": "https://example.org/profile/a"
+                                              }
+                                          ]
+                                      }
+                                  },
+                                  {
+                                      "asset": {
+                                          "id": "{{assetId}}",
+                                          "space": {{NewlyCreatedSpace}},
+                                          "batch": "{{batchId}}",
+                                          "mediaType": "image/jpg",
+                                          "adjuncts": [
+                                              {
+                                                  "id": "adjunct-1",
+                                                  "profile": "https://example.org/profile/b"
+                                              }
+                                          ]
+                                      }
+                                  }
+                              ]
+                          }
+                          """;
+
+         var requestMessage =
+             HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Post, $"{Customer}/manifests", manifest);
+
+         // Act
+         var response = await httpClient.AsCustomer().SendAsync(requestMessage);
+
+         // Assert
+         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+         var errorResponse = await response.ReadAsPresentationResponseAsync<Error>();
+         var assetKey = $"{Customer}/{NewlyCreatedSpace}/{assetId}";
+         var firstAdjuncts = new JArray(JObject.Parse($$"""{"id":"adjunct-1","profile":"https://example.org/profile/a","asset":"{{assetKey}}"}"""));
+         var secondAdjuncts = new JArray(JObject.Parse($$"""{"id":"adjunct-1","profile":"https://example.org/profile/b","asset":"{{assetKey}}"}"""));
+         var expectedDiff = JsonConvert.SerializeObject(new JsonDiffPatch().Diff(firstAdjuncts, secondAdjuncts));
+         errorResponse!.Detail.Should()
+             .Be($"Asset {assetKey} is specified multiple times with different adjuncts - diff: {expectedDiff}");
+         errorResponse.ErrorTypeUri.Should().Be("http://localhost/errors/ModifyCollectionType/AssetsAdjunctsDoNotMatch");
+     }
+
+     [Fact]
+     public async Task CreateManifest_BadRequest_WhenMultipleAssetsWithSameAssetIdOnlyOneHasAdjuncts()
+     {
+         // Arrange
+         var (assetId, slug) = TestIdentifiers.SlugResource();
+         var batchId = TestIdentifiers.BatchId();
+
+         var manifest = $$"""
+                          {
+                              "type": "Manifest",
+                              "slug": "{{slug}}",
+                              "parent": "http://localhost/{{Customer}}/collections/root",
+                              "paintedResources": [
+                                  {
+                                      "asset": {
+                                          "id": "{{assetId}}",
+                                          "space": {{NewlyCreatedSpace}},
+                                          "batch": "{{batchId}}",
+                                          "mediaType": "image/jpg",
+                                          "adjuncts": [
+                                              {
+                                                  "id": "adjunct-1",
+                                                  "profile": "https://example.org/profile/a"
+                                              }
+                                          ]
+                                      }
+                                  },
+                                  {
+                                      "asset": {
+                                          "id": "{{assetId}}",
+                                          "space": {{NewlyCreatedSpace}},
+                                          "batch": "{{batchId}}",
+                                          "mediaType": "image/jpg"
+                                      }
+                                  }
+                              ]
+                          }
+                          """;
+
+         var requestMessage =
+             HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Post, $"{Customer}/manifests", manifest);
+
+         // Act
+         var response = await httpClient.AsCustomer().SendAsync(requestMessage);
+
+         // Assert
+         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+         var errorResponse = await response.ReadAsPresentationResponseAsync<Error>();
+         var assetKey = $"{Customer}/{NewlyCreatedSpace}/{assetId}";
+         var firstAdjuncts = new JArray(JObject.Parse($$"""{"id":"adjunct-1","profile":"https://example.org/profile/a","asset":"{{assetKey}}"}"""));
+         var expectedDiff = JsonConvert.SerializeObject(new JsonDiffPatch().Diff(firstAdjuncts, new JArray()));
+         errorResponse!.Detail.Should()
+             .Be($"Asset {assetKey} is specified multiple times with different adjuncts - diff: {expectedDiff}");
+         errorResponse.ErrorTypeUri.Should().Be("http://localhost/errors/ModifyCollectionType/AssetsAdjunctsDoNotMatch");
+     }
+
      [Fact]
      public async Task CreateManifest_CorrectlyOrdersAssetRequests_WhenCanvasPaintingSetsOrder()
      {

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
@@ -961,6 +961,55 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
      }
 
      [Fact]
+     public async Task CreateManifest_BadRequest_WhenMultipleAssetsWithSameAssetIdOneHasNullAdjunctsOtherHasEmptyAdjuncts()
+     {
+         // Arrange
+         var (assetId, slug) = TestIdentifiers.SlugResource();
+         var batchId = TestIdentifiers.BatchId();
+
+         var manifest = $$"""
+                          {
+                              "type": "Manifest",
+                              "slug": "{{slug}}",
+                              "parent": "http://localhost/{{Customer}}/collections/root",
+                              "paintedResources": [
+                                  {
+                                      "asset": {
+                                          "id": "{{assetId}}",
+                                          "space": {{NewlyCreatedSpace}},
+                                          "batch": "{{batchId}}",
+                                          "mediaType": "image/jpg"
+                                      }
+                                  },
+                                  {
+                                      "asset": {
+                                          "id": "{{assetId}}",
+                                          "space": {{NewlyCreatedSpace}},
+                                          "batch": "{{batchId}}",
+                                          "mediaType": "image/jpg",
+                                          "adjuncts": []
+                                      }
+                                  }
+                              ]
+                          }
+                          """;
+
+         var requestMessage =
+             HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Post, $"{Customer}/manifests", manifest);
+
+         // Act
+         var response = await httpClient.AsCustomer().SendAsync(requestMessage);
+
+         // Assert
+         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+         var errorResponse = await response.ReadAsPresentationResponseAsync<Error>();
+         var assetKey = $"{Customer}/{NewlyCreatedSpace}/{assetId}";
+         errorResponse!.Detail.Should()
+             .StartWith($"Asset {assetKey} is specified multiple times with different adjuncts - diff: ");
+         errorResponse.ErrorTypeUri.Should().Be("http://localhost/errors/ModifyCollectionType/AssetsAdjunctsDoNotMatch");
+     }
+
+     [Fact]
      public async Task CreateManifest_Accepted_WhenMultipleAssetsWithSameAssetIdHaveIdenticalAdjuncts()
      {
          // Arrange

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
@@ -11,7 +11,6 @@ using IIIF.Presentation.V3.Annotation;
 using IIIF.Presentation.V3.Content;
 using IIIF.Presentation.V3.Strings;
 using IIIF.Serialisation;
-using JsonDiffPatchDotNet;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Net.Http.Headers;
@@ -839,7 +838,7 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
          response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
          var errorResponse = await response.ReadAsPresentationResponseAsync<Error>();
          errorResponse!.Detail.Should()
-             .Be($"Asset {Customer}/-1/{assetId} is specified multiple times, but has conflicting data - diff: {{\"batch\":[\"{batchId}\",\"DoesNotMatch\"]}}");
+             .Be($"Asset {Customer}/{assetId} is specified multiple times, but has conflicting data - diff: {{\"batch\":[\"{batchId}\",\"DoesNotMatch\"]}}");
          errorResponse.ErrorTypeUri.Should().Be("http://localhost/errors/ModifyCollectionType/AssetsDoNotMatch");
      }
 
@@ -898,11 +897,11 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
          response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
          var errorResponse = await response.ReadAsPresentationResponseAsync<Error>();
          var assetKey = $"{Customer}/{NewlyCreatedSpace}/{assetId}";
-         var firstAdjuncts = new JArray(JObject.Parse($$"""{"id":"adjunct-1","profile":"https://example.org/profile/a","asset":"{{assetKey}}"}"""));
-         var secondAdjuncts = new JArray(JObject.Parse($$"""{"id":"adjunct-1","profile":"https://example.org/profile/b","asset":"{{assetKey}}"}"""));
-         var expectedDiff = JsonConvert.SerializeObject(new JsonDiffPatch().Diff(firstAdjuncts, secondAdjuncts));
          errorResponse!.Detail.Should()
-             .Be($"Asset {assetKey} is specified multiple times with different adjuncts - diff: {expectedDiff}");
+             .StartWith($"Asset {assetKey} is specified multiple times with different adjuncts - diff: ")
+             .And.Contain("profile")
+             .And.Contain("https://example.org/profile/a")
+             .And.Contain("https://example.org/profile/b");
          errorResponse.ErrorTypeUri.Should().Be("http://localhost/errors/ModifyCollectionType/AssetsAdjunctsDoNotMatch");
      }
 
@@ -955,11 +954,124 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
          response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
          var errorResponse = await response.ReadAsPresentationResponseAsync<Error>();
          var assetKey = $"{Customer}/{NewlyCreatedSpace}/{assetId}";
-         var firstAdjuncts = new JArray(JObject.Parse($$"""{"id":"adjunct-1","profile":"https://example.org/profile/a","asset":"{{assetKey}}"}"""));
-         var expectedDiff = JsonConvert.SerializeObject(new JsonDiffPatch().Diff(firstAdjuncts, new JArray()));
          errorResponse!.Detail.Should()
-             .Be($"Asset {assetKey} is specified multiple times with different adjuncts - diff: {expectedDiff}");
+             .StartWith($"Asset {assetKey} is specified multiple times with different adjuncts - diff: ")
+             .And.Contain("adjunct-1");
          errorResponse.ErrorTypeUri.Should().Be("http://localhost/errors/ModifyCollectionType/AssetsAdjunctsDoNotMatch");
+     }
+
+     [Fact]
+     public async Task CreateManifest_Accepted_WhenMultipleAssetsWithSameAssetIdHaveIdenticalAdjuncts()
+     {
+         // Arrange
+         var (assetId, slug) = TestIdentifiers.SlugResource();
+         var batchId = TestIdentifiers.BatchId();
+
+         var manifest = $$"""
+                          {
+                              "type": "Manifest",
+                              "slug": "{{slug}}",
+                              "parent": "http://localhost/{{Customer}}/collections/root",
+                              "paintedResources": [
+                                  {
+                                      "asset": {
+                                          "id": "{{assetId}}",
+                                          "space": {{NewlyCreatedSpace}},
+                                          "batch": "{{batchId}}",
+                                          "mediaType": "image/jpg",
+                                          "adjuncts": [
+                                              {
+                                                  "id": "adjunct-1",
+                                                  "profile": "https://example.org/profile/a"
+                                              }
+                                          ]
+                                      }
+                                  },
+                                  {
+                                      "asset": {
+                                          "id": "{{assetId}}",
+                                          "space": {{NewlyCreatedSpace}},
+                                          "batch": "{{batchId}}",
+                                          "mediaType": "image/jpg",
+                                          "adjuncts": [
+                                              {
+                                                  "id": "adjunct-1",
+                                                  "profile": "https://example.org/profile/a"
+                                              }
+                                          ]
+                                      }
+                                  }
+                              ]
+                          }
+                          """;
+
+         var adjunctBatchId = TestIdentifiers.BatchId();
+         A.CallTo(() => DLCSApiClient.IngestDeliverables(Customer, A<List<JObject>>._, true, A<CancellationToken>._))
+             .Returns(Task.FromResult(new List<Batch> { new() { ResourceId = adjunctBatchId.ToString(), Submitted = DateTime.Now } }));
+
+         var requestMessage =
+             HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Post, $"{Customer}/manifests", manifest);
+
+         // Act
+         var response = await httpClient.AsCustomer().SendAsync(requestMessage);
+
+         // Assert — duplicate de-duped, request accepted
+         response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+     }
+
+     [Fact]
+     public async Task CreateManifest_Accepted_WhenMultipleAssetsWithSameAssetIdHaveIdenticalAdjunctsInDifferentOrder()
+     {
+         // Arrange
+         var (assetId, slug) = TestIdentifiers.SlugResource();
+         var batchId = TestIdentifiers.BatchId();
+
+         var manifest = $$"""
+                          {
+                              "type": "Manifest",
+                              "slug": "{{slug}}",
+                              "parent": "http://localhost/{{Customer}}/collections/root",
+                              "paintedResources": [
+                                  {
+                                      "asset": {
+                                          "id": "{{assetId}}",
+                                          "space": {{NewlyCreatedSpace}},
+                                          "batch": "{{batchId}}",
+                                          "mediaType": "image/jpg",
+                                          "adjuncts": [
+                                              { "id": "adjunct-1", "profile": "https://example.org/profile/a" },
+                                              { "id": "adjunct-2", "profile": "https://example.org/profile/b" }
+                                          ]
+                                      }
+                                  },
+                                  {
+                                      "asset": {
+                                          "id": "{{assetId}}",
+                                          "space": {{NewlyCreatedSpace}},
+                                          "batch": "{{batchId}}",
+                                          "mediaType": "image/jpg",
+                                          "adjuncts": [
+                                              { "id": "adjunct-2", "profile": "https://example.org/profile/b" },
+                                              { "id": "adjunct-1", "profile": "https://example.org/profile/a" }
+                                          ]
+                                      }
+                                  }
+                              ]
+                          }
+                          """;
+
+         var adjunctBatchId = TestIdentifiers.BatchId();
+         A.CallTo(() => DLCSApiClient.IngestDeliverables(Customer, A<List<JObject>>._, true, A<CancellationToken>._))
+             .Returns(Task.FromResult(new List<Batch> { new() { ResourceId = adjunctBatchId.ToString(), Submitted = DateTime.Now } }));
+
+         var requestMessage =
+             HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Post, $"{Customer}/manifests", manifest);
+
+         // Act
+         var response = await httpClient.AsCustomer().SendAsync(requestMessage);
+
+         // Assert — adjunct order is not significant; identical content should be accepted
+         response.StatusCode.Should().Be(HttpStatusCode.Accepted);
      }
 
      [Fact]

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetUpdateTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetUpdateTests.cs
@@ -2886,4 +2886,72 @@ public class ModifyManifestAssetUpdateTests : IClassFixture<PresentationAppFacto
         canvasPainting.AssetId!.ToString().Should()
             .Be($"{Customer}/{finalSpace}/{assetId}", "asset id updated to point at new space");
     }
+
+    [Fact]
+    public async Task UpdateManifest_BadRequest_WhenMultipleAssetsWithSameAssetIdHaveDifferentAdjuncts()
+    {
+        // Arrange
+        var (slug, id, assetId) = TestIdentifiers.SlugResourceAsset();
+        var batchId = TestIdentifiers.BatchId();
+
+        var testManifest = await dbContext.Manifests.AddTestManifest(id: id, slug: slug,
+            batchId: batchId, ingested: true, spaceId: NewlyCreatedSpace);
+        await dbContext.SaveChangesAsync();
+
+        var payload = $$"""
+                        {
+                            "type": "Manifest",
+                            "slug": "{{slug}}",
+                            "parent": "http://localhost/{{Customer}}/collections/root",
+                            "paintedResources": [
+                                {
+                                    "asset": {
+                                        "id": "{{assetId}}",
+                                        "space": {{NewlyCreatedSpace}},
+                                        "batch": "{{batchId}}",
+                                        "mediaType": "image/jpg",
+                                        "adjuncts": [
+                                            {
+                                                "id": "adjunct-1",
+                                                "profile": "https://example.org/profile/a"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "asset": {
+                                        "id": "{{assetId}}",
+                                        "space": {{NewlyCreatedSpace}},
+                                        "batch": "{{batchId}}",
+                                        "mediaType": "image/jpg",
+                                        "adjuncts": [
+                                            {
+                                                "id": "adjunct-1",
+                                                "profile": "https://example.org/profile/b"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                        """;
+
+        var requestMessage =
+            HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Put, $"{Customer}/manifests/{id}",
+                payload, dbContext.GetETag(testManifest));
+
+        // Act
+        var response = await httpClient.AsCustomer().SendAsync(requestMessage);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var errorResponse = await response.ReadAsPresentationResponseAsync<Error>();
+        var assetKey = $"{Customer}/{NewlyCreatedSpace}/{assetId}";
+        errorResponse!.Detail.Should()
+            .StartWith($"Asset {assetKey} is specified multiple times with different adjuncts - diff: ")
+            .And.Contain("profile")
+            .And.Contain("https://example.org/profile/a")
+            .And.Contain("https://example.org/profile/b");
+        errorResponse.ErrorTypeUri.Should().Be("http://localhost/errors/ModifyCollectionType/AssetsAdjunctsDoNotMatch");
+    }
 }

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetUpdateTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetUpdateTests.cs
@@ -2954,4 +2954,58 @@ public class ModifyManifestAssetUpdateTests : IClassFixture<PresentationAppFacto
             .And.Contain("https://example.org/profile/b");
         errorResponse.ErrorTypeUri.Should().Be("http://localhost/errors/ModifyCollectionType/AssetsAdjunctsDoNotMatch");
     }
+
+    [Fact]
+    public async Task UpdateManifest_BadRequest_WhenMultipleAssetsWithSameAssetIdOneHasNullAdjunctsOtherHasEmptyAdjuncts()
+    {
+        // Arrange
+        var (slug, id, assetId) = TestIdentifiers.SlugResourceAsset();
+        var batchId = TestIdentifiers.BatchId();
+
+        var testManifest = await dbContext.Manifests.AddTestManifest(id: id, slug: slug,
+            batchId: batchId, ingested: true, spaceId: NewlyCreatedSpace);
+        await dbContext.SaveChangesAsync();
+
+        var payload = $$"""
+                        {
+                            "type": "Manifest",
+                            "slug": "{{slug}}",
+                            "parent": "http://localhost/{{Customer}}/collections/root",
+                            "paintedResources": [
+                                {
+                                    "asset": {
+                                        "id": "{{assetId}}",
+                                        "space": {{NewlyCreatedSpace}},
+                                        "batch": "{{batchId}}",
+                                        "mediaType": "image/jpg"
+                                    }
+                                },
+                                {
+                                    "asset": {
+                                        "id": "{{assetId}}",
+                                        "space": {{NewlyCreatedSpace}},
+                                        "batch": "{{batchId}}",
+                                        "mediaType": "image/jpg",
+                                        "adjuncts": []
+                                    }
+                                }
+                            ]
+                        }
+                        """;
+
+        var requestMessage =
+            HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Put, $"{Customer}/manifests/{id}",
+                payload, dbContext.GetETag(testManifest));
+
+        // Act
+        var response = await httpClient.AsCustomer().SendAsync(requestMessage);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var errorResponse = await response.ReadAsPresentationResponseAsync<Error>();
+        var assetKey = $"{Customer}/{NewlyCreatedSpace}/{assetId}";
+        errorResponse!.Detail.Should()
+            .StartWith($"Asset {assetKey} is specified multiple times with different adjuncts - diff: ");
+        errorResponse.ErrorTypeUri.Should().Be("http://localhost/errors/ModifyCollectionType/AssetsAdjunctsDoNotMatch");
+    }
 }

--- a/src/IIIFPresentation/API/Features/Common/Helpers/UpsertErrorHelper.cs
+++ b/src/IIIFPresentation/API/Features/Common/Helpers/UpsertErrorHelper.cs
@@ -130,6 +130,18 @@ public static class UpsertErrorHelper
         where TCollection : JsonLdBase
         => ModifyEntityResult<TCollection, ModifyCollectionType>.Failure($"The {field} has a customer id that does not match the customer id found on the calling URL",
             ModifyCollectionType.CustomerIdDoesNotMatchCaller, WriteResult.BadRequest);
+
+    public static ModifyEntityResult<TCollection, ModifyCollectionType> AssetAdjunctsDoNotMatch<TCollection>(string assetId, string diff)
+        where TCollection : JsonLdBase
+        => ModifyEntityResult<TCollection, ModifyCollectionType>.Failure(
+            $"Asset {assetId} is specified multiple times with different adjuncts - diff: {diff}",
+            ModifyCollectionType.AssetsAdjunctsDoNotMatch, WriteResult.BadRequest);
+
+    public static ModifyEntityResult<TCollection, ModifyCollectionType> AssetsDataDoesNotMatch<TCollection>(string assetId, string diff)
+        where TCollection : JsonLdBase
+        => ModifyEntityResult<TCollection, ModifyCollectionType>.Failure(
+            $"Asset {assetId} is specified multiple times, but has conflicting data - diff: {diff}",
+            ModifyCollectionType.AssetsDoNotMatch, WriteResult.BadRequest);
     
     private static string CollectionType(bool isStorageCollection)
     {

--- a/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingResolver.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingResolver.cs
@@ -257,11 +257,8 @@ public class CanvasPaintingResolver(
             var paintedResourceCanvasPaintings = (await manifestPaintedResourceParser
                 .ParseToCanvasPainting(presentationManifest, customerId)).ToList();
 
-            var adjunctError = ValidateDuplicateAdjuncts(paintedResourceCanvasPaintings);
-            if (adjunctError != null) return new ManifestParseResult(adjunctError);
-
-            var assetError = ValidateDuplicateAssets(paintedResourceCanvasPaintings, presentationManifest.PaintedResources);
-            if (assetError != null) return new ManifestParseResult(assetError);
+            var duplicateError = ValidateDuplicates(paintedResourceCanvasPaintings, presentationManifest.PaintedResources);
+            if (duplicateError != null) return new ManifestParseResult(duplicateError);
 
             var itemsCanvasPaintings =
                 manifestItemsParser
@@ -323,23 +320,50 @@ public class CanvasPaintingResolver(
         }
     }
 
-    private static PresUpdateResult? ValidateDuplicateAdjuncts(List<InterimCanvasPainting> paintedResourceCanvasPaintings)
+    private static PresUpdateResult? ValidateDuplicates(
+        List<InterimCanvasPainting> paintedResourceCanvasPaintings,
+        List<PaintedResource>? paintedResources)
     {
-        var seen = new Dictionary<string, List<JObject>?>();
+        // check assets for duplicates
+        if (paintedResources != null)
+        {
+            var seenAssets = new Dictionary<string, JObject>();
+            foreach (var pr in paintedResources.Where(pr => pr.Asset != null))
+            {
+                var assetId = pr.Asset![AssetProperties.Id]?.Value<string>();
+                if (assetId == null) continue;
 
+                // Include space so that the same asset ID in different spaces is not treated as a conflict
+                var space = pr.Asset[AssetProperties.Space]?.Value<int>() ?? SpaceHelper.DefaultSpaceForLaterPopulation;
+                var dedupKey = $"{space}/{assetId}";
+
+                if (!seenAssets.TryAdd(dedupKey, pr.Asset!))
+                {
+                    var existing = seenAssets[dedupKey];
+                    if (!JToken.DeepEquals(existing, pr.Asset!))
+                    {
+                        var cp = paintedResourceCanvasPaintings.FirstOrDefault(c => c.SuspectedAssetId == assetId);
+                        return UpsertErrorHelper.AssetsDataDoesNotMatch<PresentationManifest>(
+                            cp != null ? BuildAssetKey(cp) : assetId,
+                            SerializeDiff(existing, pr.Asset!));
+                    }
+                }
+            }
+        }
+
+        // check adjuncts for duplicates
+        var seenAdjuncts = new Dictionary<string, List<JObject>?>();
         foreach (var cp in paintedResourceCanvasPaintings.Where(cp => cp.SuspectedAssetId != null))
         {
             var key = BuildAssetKey(cp);
             var adjuncts = cp.AdjunctInteraction?.Adjuncts;
 
-            if (!seen.TryAdd(key, adjuncts))
+            if (!seenAdjuncts.TryAdd(key, adjuncts))
             {
-                var existing = seen[key];
+                var existing = seenAdjuncts[key];
                 if (!AdjunctsEqual(existing, adjuncts))
-                {
-                    var diff = new JsonDiffPatch().Diff(new JArray(existing ?? []), new JArray(adjuncts ?? []));
-                    return UpsertErrorHelper.AssetAdjunctsDoNotMatch<PresentationManifest>(key, JsonConvert.SerializeObject(diff));
-                }
+                    return UpsertErrorHelper.AssetAdjunctsDoNotMatch<PresentationManifest>(key,
+                        SerializeDiff(new JArray(existing ?? []), new JArray(adjuncts ?? [])));
             }
         }
 
@@ -358,38 +382,8 @@ public class CanvasPaintingResolver(
             && JToken.DeepEquals(j, match));
     }
 
-    private static PresUpdateResult? ValidateDuplicateAssets(
-        List<InterimCanvasPainting> paintedResourceCanvasPaintings,
-        List<PaintedResource>? paintedResources)
-    {
-        if (paintedResources == null) return null;
-
-        var seen = new Dictionary<string, JObject>();
-
-        foreach (var pr in paintedResources.Where(pr => pr.Asset != null))
-        {
-            var assetId = pr.Asset![AssetProperties.Id]?.Value<string>();
-            if (assetId == null) continue;
-
-            // Include space so that the same asset ID in different spaces is not treated as a conflict
-            var space = pr.Asset[AssetProperties.Space]?.Value<int>() ?? SpaceHelper.DefaultSpaceForLaterPopulation;
-            var dedupKey = $"{space}/{assetId}";
-
-            if (!seen.TryAdd(dedupKey, pr.Asset!))
-            {
-                var existing = seen[dedupKey];
-                if (!JToken.DeepEquals(existing, pr.Asset!))
-                {
-                    var cp = paintedResourceCanvasPaintings.FirstOrDefault(c => c.SuspectedAssetId == assetId);
-                    var key = cp != null ? BuildAssetKey(cp) : assetId;
-                    var diff = new JsonDiffPatch().Diff(existing, pr.Asset!);
-                    return UpsertErrorHelper.AssetsDataDoesNotMatch<PresentationManifest>(key, JsonConvert.SerializeObject(diff));
-                }
-            }
-        }
-
-        return null;
-    }
+    private static string SerializeDiff(JToken left, JToken right)
+        => JsonConvert.SerializeObject(new JsonDiffPatch().Diff(left, right));
 
     // Omits the space sentinel from user-facing keys — space is unknown until DLCS interaction
     private static string BuildAssetKey(InterimCanvasPainting cp) =>

--- a/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingResolver.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingResolver.cs
@@ -2,15 +2,12 @@
 using System.Diagnostics;
 using API.Features.Common.Helpers;
 using API.Features.Manifest.Exceptions;
+using API.Features.Manifest.Helpers;
 using API.Infrastructure.IdGenerator;
 using Core.Exceptions;
 using Core.Helpers;
-using JsonDiffPatchDotNet;
 using Models.API.Manifest;
 using Models.Database;
-using Models.DLCS;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Services.Manifests;
 using Services.Manifests.Exceptions;
 using Services.Manifests.Helpers;
@@ -257,7 +254,7 @@ public class CanvasPaintingResolver(
             var paintedResourceCanvasPaintings = (await manifestPaintedResourceParser
                 .ParseToCanvasPainting(presentationManifest, customerId)).ToList();
 
-            var duplicateError = ValidateDuplicates(paintedResourceCanvasPaintings, presentationManifest.PaintedResources);
+            var duplicateError = AssetDuplicateValidator.ValidateDuplicates(paintedResourceCanvasPaintings, presentationManifest.PaintedResources);
             if (duplicateError != null) return new ManifestParseResult(duplicateError);
 
             var itemsCanvasPaintings =
@@ -319,77 +316,6 @@ public class CanvasPaintingResolver(
             return new ManifestParseResult(UpsertErrorHelper.PaintableAssetError<PresentationManifest>(paintableAssetException.Message));
         }
     }
-
-    private static PresUpdateResult? ValidateDuplicates(
-        List<InterimCanvasPainting> paintedResourceCanvasPaintings,
-        List<PaintedResource>? paintedResources)
-    {
-        // check assets for duplicates
-        if (paintedResources != null)
-        {
-            var seenAssets = new Dictionary<string, JObject>();
-            foreach (var pr in paintedResources.Where(pr => pr.Asset != null))
-            {
-                var assetId = pr.Asset![AssetProperties.Id]?.Value<string>();
-                if (assetId == null) continue;
-
-                // Include space so that the same asset ID in different spaces is not treated as a conflict
-                var space = pr.Asset[AssetProperties.Space]?.Value<int>() ?? SpaceHelper.DefaultSpaceForLaterPopulation;
-                var dedupKey = $"{space}/{assetId}";
-
-                if (!seenAssets.TryAdd(dedupKey, pr.Asset!))
-                {
-                    var existing = seenAssets[dedupKey];
-                    if (!JToken.DeepEquals(existing, pr.Asset!))
-                    {
-                        var cp = paintedResourceCanvasPaintings.FirstOrDefault(c => c.SuspectedAssetId == assetId);
-                        return UpsertErrorHelper.AssetsDataDoesNotMatch<PresentationManifest>(
-                            cp != null ? BuildAssetKey(cp) : assetId,
-                            SerializeDiff(existing, pr.Asset!));
-                    }
-                }
-            }
-        }
-
-        // check adjuncts for duplicates
-        var seenAdjuncts = new Dictionary<string, List<JObject>?>();
-        foreach (var cp in paintedResourceCanvasPaintings.Where(cp => cp.SuspectedAssetId != null))
-        {
-            var key = BuildAssetKey(cp);
-            var adjuncts = cp.AdjunctInteraction?.Adjuncts;
-
-            if (!seenAdjuncts.TryAdd(key, adjuncts))
-            {
-                var existing = seenAdjuncts[key];
-                if (!AdjunctsEqual(existing, adjuncts))
-                    return UpsertErrorHelper.AssetAdjunctsDoNotMatch<PresentationManifest>(key,
-                        SerializeDiff(new JArray(existing ?? []), new JArray(adjuncts ?? [])));
-            }
-        }
-
-        return null;
-    }
-
-    // Order-insensitive: adjuncts are matched by id, then deep-compared
-    private static bool AdjunctsEqual(List<JObject>? a, List<JObject>? b)
-    {
-        var left = a ?? [];
-        var right = b ?? [];
-        if (left.Count != right.Count) return false;
-        var leftById = left.ToDictionary(j => j[AdjunctProperties.Id]?.Value<string>() ?? string.Empty);
-        return right.All(j =>
-            leftById.TryGetValue(j[AdjunctProperties.Id]?.Value<string>() ?? string.Empty, out var match)
-            && JToken.DeepEquals(j, match));
-    }
-
-    private static string SerializeDiff(JToken left, JToken right)
-        => JsonConvert.SerializeObject(new JsonDiffPatch().Diff(left, right));
-
-    // Omits the space sentinel from user-facing keys — space is unknown until DLCS interaction
-    private static string BuildAssetKey(InterimCanvasPainting cp) =>
-        cp.SuspectedSpace == null || cp.SuspectedSpace == SpaceHelper.DefaultSpaceForLaterPopulation
-            ? $"{cp.CustomerId}/{cp.SuspectedAssetId}"
-            : $"{cp.CustomerId}/{cp.SuspectedSpace}/{cp.SuspectedAssetId}";
 
     private class ManifestParseResult(
         PresUpdateResult? error = null,

--- a/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingResolver.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingResolver.cs
@@ -5,8 +5,11 @@ using API.Features.Manifest.Exceptions;
 using API.Infrastructure.IdGenerator;
 using Core.Exceptions;
 using Core.Helpers;
+using JsonDiffPatchDotNet;
 using Models.API.Manifest;
 using Models.Database;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Services.Manifests;
 using Services.Manifests.Exceptions;
 using Services.Manifests.Helpers;
@@ -253,6 +256,12 @@ public class CanvasPaintingResolver(
             var paintedResourceCanvasPaintings = (await manifestPaintedResourceParser
                 .ParseToCanvasPainting(presentationManifest, customerId)).ToList();
 
+            var adjunctError = ValidateDuplicateAdjuncts(paintedResourceCanvasPaintings);
+            if (adjunctError != null) return new ManifestParseResult(adjunctError);
+
+            var assetError = ValidateDuplicateAssets(paintedResourceCanvasPaintings, presentationManifest.PaintedResources);
+            if (assetError != null) return new ManifestParseResult(assetError);
+
             var itemsCanvasPaintings =
                 manifestItemsParser
                     .ParseToCanvasPainting(presentationManifest, paintedResourceCanvasPaintings, customerId).ToList();
@@ -313,6 +322,61 @@ public class CanvasPaintingResolver(
         }
     }
 
+    private static PresUpdateResult? ValidateDuplicateAdjuncts(List<InterimCanvasPainting> paintedResourceCanvasPaintings)
+    {
+        var seen = new Dictionary<string, List<JObject>?>();
+
+        foreach (var cp in paintedResourceCanvasPaintings.Where(cp => cp.SuspectedAssetId != null))
+        {
+            var key = $"{cp.CustomerId}/{cp.SuspectedSpace ?? SpaceHelper.DefaultSpaceForLaterPopulation}/{cp.SuspectedAssetId}";
+            var adjuncts = cp.AdjunctInteraction?.Adjuncts;
+
+            if (!seen.TryAdd(key, adjuncts) && !AdjunctsEqual(seen[key], adjuncts))
+            {
+                var existingAdjuncts = seen[key];
+                var diff = new JsonDiffPatch().Diff(
+                    new JArray(existingAdjuncts ?? []),
+                    new JArray(adjuncts ?? []));
+                return UpsertErrorHelper.AssetAdjunctsDoNotMatch<PresentationManifest>(key, JsonConvert.SerializeObject(diff));
+            }
+        }
+
+        return null;
+    }
+
+    private static bool AdjunctsEqual(List<JObject>? a, List<JObject>? b)
+    {
+        if (a == null && b == null) return true;
+        if (a == null || b == null) return false;
+        if (a.Count != b.Count) return false;
+        return a.Zip(b).All(pair => JToken.DeepEquals(pair.First, pair.Second));
+    }
+
+    private static PresUpdateResult? ValidateDuplicateAssets(
+        List<InterimCanvasPainting> paintedResourceCanvasPaintings,
+        List<PaintedResource>? paintedResources)
+    {
+        if (paintedResources == null) return null;
+
+        var assets = new Dictionary<string, JObject>();
+        var paintedResourcesWithAssets = paintedResources.Where(pr => pr.Asset != null);
+
+        foreach (var (cp, pr) in paintedResourceCanvasPaintings.Zip(paintedResourcesWithAssets))
+        {
+            if (cp.SuspectedAssetId == null) continue;
+
+            var key = $"{cp.CustomerId}/{cp.SuspectedSpace ?? SpaceHelper.DefaultSpaceForLaterPopulation}/{cp.SuspectedAssetId}";
+            var asset = pr.Asset!;
+
+            if (!assets.TryAdd(key, asset) && !JToken.DeepEquals(assets[key], asset))
+            {
+                var diff = new JsonDiffPatch().Diff(assets[key], asset);
+                return UpsertErrorHelper.AssetsDataDoesNotMatch<PresentationManifest>(key, JsonConvert.SerializeObject(diff));
+            }
+        }
+
+        return null;
+    }
 
     private class ManifestParseResult(
         PresUpdateResult? error = null,

--- a/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingResolver.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingResolver.cs
@@ -8,6 +8,7 @@ using Core.Helpers;
 using JsonDiffPatchDotNet;
 using Models.API.Manifest;
 using Models.Database;
+using Models.DLCS;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Services.Manifests;
@@ -328,28 +329,33 @@ public class CanvasPaintingResolver(
 
         foreach (var cp in paintedResourceCanvasPaintings.Where(cp => cp.SuspectedAssetId != null))
         {
-            var key = $"{cp.CustomerId}/{cp.SuspectedSpace ?? SpaceHelper.DefaultSpaceForLaterPopulation}/{cp.SuspectedAssetId}";
+            var key = BuildAssetKey(cp);
             var adjuncts = cp.AdjunctInteraction?.Adjuncts;
 
-            if (!seen.TryAdd(key, adjuncts) && !AdjunctsEqual(seen[key], adjuncts))
+            if (!seen.TryAdd(key, adjuncts))
             {
-                var existingAdjuncts = seen[key];
-                var diff = new JsonDiffPatch().Diff(
-                    new JArray(existingAdjuncts ?? []),
-                    new JArray(adjuncts ?? []));
-                return UpsertErrorHelper.AssetAdjunctsDoNotMatch<PresentationManifest>(key, JsonConvert.SerializeObject(diff));
+                var existing = seen[key];
+                if (!AdjunctsEqual(existing, adjuncts))
+                {
+                    var diff = new JsonDiffPatch().Diff(new JArray(existing ?? []), new JArray(adjuncts ?? []));
+                    return UpsertErrorHelper.AssetAdjunctsDoNotMatch<PresentationManifest>(key, JsonConvert.SerializeObject(diff));
+                }
             }
         }
 
         return null;
     }
 
+    // Order-insensitive: adjuncts are matched by id, then deep-compared
     private static bool AdjunctsEqual(List<JObject>? a, List<JObject>? b)
     {
-        if (a == null && b == null) return true;
-        if (a == null || b == null) return false;
-        if (a.Count != b.Count) return false;
-        return a.Zip(b).All(pair => JToken.DeepEquals(pair.First, pair.Second));
+        var left = a ?? [];
+        var right = b ?? [];
+        if (left.Count != right.Count) return false;
+        var leftById = left.ToDictionary(j => j[AdjunctProperties.Id]?.Value<string>() ?? string.Empty);
+        return right.All(j =>
+            leftById.TryGetValue(j[AdjunctProperties.Id]?.Value<string>() ?? string.Empty, out var match)
+            && JToken.DeepEquals(j, match));
     }
 
     private static PresUpdateResult? ValidateDuplicateAssets(
@@ -358,25 +364,38 @@ public class CanvasPaintingResolver(
     {
         if (paintedResources == null) return null;
 
-        var assets = new Dictionary<string, JObject>();
-        var paintedResourcesWithAssets = paintedResources.Where(pr => pr.Asset != null);
+        var seen = new Dictionary<string, JObject>();
 
-        foreach (var (cp, pr) in paintedResourceCanvasPaintings.Zip(paintedResourcesWithAssets))
+        foreach (var pr in paintedResources.Where(pr => pr.Asset != null))
         {
-            if (cp.SuspectedAssetId == null) continue;
+            var assetId = pr.Asset![AssetProperties.Id]?.Value<string>();
+            if (assetId == null) continue;
 
-            var key = $"{cp.CustomerId}/{cp.SuspectedSpace ?? SpaceHelper.DefaultSpaceForLaterPopulation}/{cp.SuspectedAssetId}";
-            var asset = pr.Asset!;
+            // Include space so that the same asset ID in different spaces is not treated as a conflict
+            var space = pr.Asset[AssetProperties.Space]?.Value<int>() ?? SpaceHelper.DefaultSpaceForLaterPopulation;
+            var dedupKey = $"{space}/{assetId}";
 
-            if (!assets.TryAdd(key, asset) && !JToken.DeepEquals(assets[key], asset))
+            if (!seen.TryAdd(dedupKey, pr.Asset!))
             {
-                var diff = new JsonDiffPatch().Diff(assets[key], asset);
-                return UpsertErrorHelper.AssetsDataDoesNotMatch<PresentationManifest>(key, JsonConvert.SerializeObject(diff));
+                var existing = seen[dedupKey];
+                if (!JToken.DeepEquals(existing, pr.Asset!))
+                {
+                    var cp = paintedResourceCanvasPaintings.FirstOrDefault(c => c.SuspectedAssetId == assetId);
+                    var key = cp != null ? BuildAssetKey(cp) : assetId;
+                    var diff = new JsonDiffPatch().Diff(existing, pr.Asset!);
+                    return UpsertErrorHelper.AssetsDataDoesNotMatch<PresentationManifest>(key, JsonConvert.SerializeObject(diff));
+                }
             }
         }
 
         return null;
     }
+
+    // Omits the space sentinel from user-facing keys — space is unknown until DLCS interaction
+    private static string BuildAssetKey(InterimCanvasPainting cp) =>
+        cp.SuspectedSpace == null || cp.SuspectedSpace == SpaceHelper.DefaultSpaceForLaterPopulation
+            ? $"{cp.CustomerId}/{cp.SuspectedAssetId}"
+            : $"{cp.CustomerId}/{cp.SuspectedSpace}/{cp.SuspectedAssetId}";
 
     private class ManifestParseResult(
         PresUpdateResult? error = null,

--- a/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
@@ -9,12 +9,10 @@ using Core.Helpers;
 using DLCS.API;
 using DLCS.Exceptions;
 using DLCS.Models;
-using JsonDiffPatchDotNet;
 using Models.API.General;
 using Models.API.Manifest;
 using Models.Database.General;
 using Models.DLCS;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Repository;
 using Services.Manifests.Helpers;
@@ -402,23 +400,8 @@ public class DlcsManifestCoordinator(
                     break;
             }
 
-            // If can add, move to next one
-            if (assets.TryAdd(dlcsInteractionRequest.AssetId, dlcsInteractionRequest.Asset)) continue;
-            
-            // else already specified
-            logger.LogDebug("Asset {AssetId} has been specified multiple times, validating they match", dlcsInteractionRequest.AssetId);
-            var assetInDictionary = assets[dlcsInteractionRequest.AssetId];
-
-            // if specified with the same data, we can ignore and continue
-            if (JToken.DeepEquals(assetInDictionary, dlcsInteractionRequest.Asset)) continue;
-            
-            // else report failure with details
-            var jsonDiffPatch = new JsonDiffPatch();
-            var diff = jsonDiffPatch.Diff(assetInDictionary, dlcsInteractionRequest.Asset);
-                    
-            return EntityResult.Failure(
-                $"Asset {dlcsInteractionRequest.AssetId} is specified multiple times, but has conflicting data - diff: {JsonConvert.SerializeObject(diff)}",
-                ModifyCollectionType.AssetsDoNotMatch, WriteResult.BadRequest);
+            // Deduplicate — conflicting data is already validated earlier in the pipeline
+            assets.TryAdd(dlcsInteractionRequest.AssetId, dlcsInteractionRequest.Asset);
         }
         
         // `assets` now contain all the assets that should be ingested by DLCS

--- a/src/IIIFPresentation/API/Features/Manifest/Helpers/AssetDuplicateValidator.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/Helpers/AssetDuplicateValidator.cs
@@ -80,6 +80,9 @@ public static class AssetDuplicateValidator
     // Relies on AdjunctValidator having already enforced non-empty ids upstream.
     private static bool AdjunctsEqual(List<JObject>? previous, List<JObject>? current)
     {
+        // makes sure [] and null isn't allowed
+        if (previous is null != current is null) return false;
+        
         var left = previous ?? [];
         var right = current ?? [];
         if (left.Count != right.Count) return false;

--- a/src/IIIFPresentation/API/Features/Manifest/Helpers/AssetDuplicateValidator.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/Helpers/AssetDuplicateValidator.cs
@@ -74,12 +74,16 @@ public static class AssetDuplicateValidator
         return null;
     }
 
-    // Order-insensitive: adjuncts are matched by id, then deep-compared
+    // Compares two adjunct lists without regard to order.
+    // Each adjunct is looked up by its id in the previous list, then deep-compared —
+    // so reordering adjuncts is not treated as a conflict, but any property change is.
+    // Relies on AdjunctValidator having already enforced non-empty ids upstream.
     private static bool AdjunctsEqual(List<JObject>? previous, List<JObject>? current)
     {
         var left = previous ?? [];
         var right = current ?? [];
         if (left.Count != right.Count) return false;
+        // index the previous adjuncts by id for O(n) lookup
         var leftById = left.ToDictionary(j => j.GetRequiredValue<string>(AssetProperties.Id));
         return right.All(j =>
             leftById.TryGetValue(j.GetRequiredValue<string>(AssetProperties.Id), out var match)

--- a/src/IIIFPresentation/API/Features/Manifest/Helpers/AssetDuplicateValidator.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/Helpers/AssetDuplicateValidator.cs
@@ -1,0 +1,97 @@
+using API.Features.Common.Helpers;
+using Core.Helpers;
+using DLCS.Models;
+using JsonDiffPatchDotNet;
+using Models.API.Manifest;
+using Models.DLCS;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Services.Manifests.Helpers;
+using Services.Manifests.Model;
+using PresUpdateResult = API.Infrastructure.Requests.ModifyEntityResult<Models.API.Manifest.PresentationManifest, Models.API.General.ModifyCollectionType>;
+
+namespace API.Features.Manifest.Helpers;
+
+public static class AssetDuplicateValidator
+{
+    public static PresUpdateResult? ValidateDuplicates(
+        List<InterimCanvasPainting> paintedResourceCanvasPaintings,
+        List<PaintedResource>? paintedResources)
+        => ValidateDuplicateAssets(paintedResourceCanvasPaintings, paintedResources)
+           // run the adjunct validator if the asset validator returned no errors
+           ?? ValidateDuplicateAdjuncts(paintedResourceCanvasPaintings);
+
+    private static PresUpdateResult? ValidateDuplicateAssets(
+        List<InterimCanvasPainting> paintedResourceCanvasPaintings,
+        List<PaintedResource>? paintedResources)
+    {
+        if (paintedResources == null) return null;
+
+        var seenAssets = new Dictionary<string, JObject>();
+        foreach (var pr in paintedResources.Where(pr => pr.Asset != null))
+        {
+            var asset = pr.Asset!;
+            var assetId = asset.GetRequiredValue<string>(AssetProperties.Id);
+
+            // Include space so that the same asset ID in different spaces is not treated as a conflict
+            var space = asset[AssetProperties.Space]?.Value<int>() ?? SpaceHelper.DefaultSpaceForLaterPopulation;
+            var dedupKey = $"{space}/{assetId}";
+
+            if (!seenAssets.TryAdd(dedupKey, asset))
+            {
+                var existing = seenAssets[dedupKey];
+                if (!JToken.DeepEquals(existing, asset))
+                {
+                    var cp = paintedResourceCanvasPaintings.FirstOrDefault(c => c.SuspectedAssetId == assetId);
+                    return UpsertErrorHelper.AssetsDataDoesNotMatch<PresentationManifest>(
+                        cp != null ? BuildAssetKey(cp) : assetId,
+                        SerializeDiff(existing, asset));
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static PresUpdateResult? ValidateDuplicateAdjuncts(
+        List<InterimCanvasPainting> paintedResourceCanvasPaintings)
+    {
+        var seenAdjuncts = new Dictionary<string, List<JObject>?>();
+        foreach (var cp in paintedResourceCanvasPaintings.Where(cp => cp.SuspectedAssetId != null))
+        {
+            var key = BuildAssetKey(cp);
+            var adjuncts = cp.AdjunctInteraction?.Adjuncts;
+
+            if (!seenAdjuncts.TryAdd(key, adjuncts))
+            {
+                var existing = seenAdjuncts[key];
+                if (!AdjunctsEqual(existing, adjuncts))
+                    return UpsertErrorHelper.AssetAdjunctsDoNotMatch<PresentationManifest>(key,
+                        SerializeDiff(new JArray(existing ?? []), new JArray(adjuncts ?? [])));
+            }
+        }
+
+        return null;
+    }
+
+    // Order-insensitive: adjuncts are matched by id, then deep-compared
+    private static bool AdjunctsEqual(List<JObject>? previous, List<JObject>? current)
+    {
+        var left = previous ?? [];
+        var right = current ?? [];
+        if (left.Count != right.Count) return false;
+        var leftById = left.ToDictionary(j => j.GetRequiredValue<string>(AssetProperties.Id));
+        return right.All(j =>
+            leftById.TryGetValue(j.GetRequiredValue<string>(AssetProperties.Id), out var match)
+            && JToken.DeepEquals(j, match));
+    }
+
+    private static string SerializeDiff(JToken left, JToken right)
+        => JsonConvert.SerializeObject(new JsonDiffPatch().Diff(left, right));
+
+    // Omits the space sentinel from user-facing keys — space is unknown until DLCS interaction
+    private static string BuildAssetKey(InterimCanvasPainting cp) =>
+        cp.SuspectedSpace == null || cp.SuspectedSpace == SpaceHelper.DefaultSpaceForLaterPopulation
+            ? $"{cp.CustomerId}/{cp.SuspectedAssetId}"
+            : $"{cp.CustomerId}/{cp.SuspectedSpace}/{cp.SuspectedAssetId}";
+}

--- a/src/IIIFPresentation/Models/API/General/ModifyCollectionType.cs
+++ b/src/IIIFPresentation/Models/API/General/ModifyCollectionType.cs
@@ -28,5 +28,6 @@ public enum ModifyCollectionType
     AssetError = 24,
     AssetsDoNotMatch = 25,
     CustomerIdDoesNotMatchCaller = 26,
+    AssetsAdjunctsDoNotMatch = 27,
     Unknown = 1000
 }


### PR DESCRIPTION
## What does this change?

Resolves #596

This PR extends detection of duplicate assets to check for duplicate adjuncts

  ### The pipeline problem

  Adjuncts are part of the asset payload but are not forwarded to DLCS directly — they are extracted
  from the asset `JObject` by `ManifestPaintedResourceParser` during canvas painting resolution,
  stored on `InterimCanvasPainting.AdjunctInteraction`, and **removed** from the raw `Asset` JObject.
  By the time execution reaches `DlcsManifestCoordinator`, the adjuncts are gone and cannot be
  compared. Any adjunct conflict check must therefore happen after parsing but before the coordinator.

Additionally, due to the changes required for detecting duplicate adjuncts, it makes sense to move the detection of duplicate assets into the same location as detection of duplicate adjuncts.

  ### Where the check lives

  The new `ValidateDuplicates` method is called inside `CanvasPaintingResolver.ParseManifest`,
  immediately after `ManifestPaintedResourceParser.ParseToCanvasPainting` returns. At this point both
  data sources are available:

  - `paintedResourceCanvasPaintings` — the parsed canvas paintings, each carrying an
    `AdjunctInteraction` if the asset had adjuncts.
  - `presentationManifest.PaintedResources` — the original `PaintedResource` list, whose `Asset`
    JObjects have had adjuncts stripped but still contain all other asset fields.

  ### What `ValidateDuplicates` does

  The method runs two sequential checks and returns the first error it finds, or `null` if everything
  is valid.  This is a sequential check as there's no single collection that has both the raw JObject asset data and the parsed adjunct interaction data, so the two checks must live in separate loops

  #### Asset data check

  Iterates `paintedResources` directly (avoiding any fragile positional coupling to the canvas
  painting list). It builds a seen-dictionary keyed on `{space}/{assetId}`, where the space comes
  from the asset's own `"space"` field (falling back to the `-1` sentinel for assets without an
  explicit space). Including the space in the key ensures that the same asset ID in two different
  spaces is not treated as a conflict. If the same key is seen twice with non-equal JObjects, it
  returns `AssetsDataDoesNotMatch` (400) with a JSON diff.

  #### Adjunct check

  Iterates `paintedResourceCanvasPaintings`. It builds a seen-dictionary keyed on the user-facing
  asset key produced by `BuildAssetKey`. Comparison uses `AdjunctsEqual`, which is order-insensitive:
  adjuncts are matched by their `"id"` field using a dictionary, then deep-compared with
  `JToken.DeepEquals`. If the same asset appears twice with non-equal adjunct lists, it returns
  `AssetAdjunctsDoNotMatch` (400) with a JSON diff. Identical duplicates (or no adjuncts on either
  side) are silently allowed through.

  Both checks share `SerializeDiff`, a one-liner that runs `JsonDiffPatch` and serialises the result.

  #### `BuildAssetKey`

  Produces user-facing keys for error messages. It omits the space when the space is the `-1`
  sentinel (meaning it hasn't been allocated yet by DLCS), so users never see a meaningless `-1` in
  error output. A key is either `{customerId}/{assetId}` (no space yet) or
  `{customerId}/{space}/{assetId}` (space known).

  ### Changes to `DlcsManifestCoordinator`

  Because conflicting asset data is now caught earlier, `CreateBatches` no longer needs to
  re-validate duplicates. The 15-line block that detected conflicts, computed a diff, and returned an
  error has been replaced with a simple `TryAdd` for de-duplication.

  The `JsonDiffPatchDotNet` and `Newtonsoft.Json` imports that were only needed for the removed block
  have been cleaned up from `DlcsManifestCoordinator`.

  ### New error type

  `ModifyCollectionType.AssetsAdjunctsDoNotMatch = 27` is added to distinguish adjunct conflicts from
  general asset data conflicts (`AssetsDoNotMatch = 25`). The corresponding
  `UpsertErrorHelper.AssetAdjunctsDoNotMatch` factory method follows the existing pattern in that
  class. `UpsertErrorHelper.AssetsDataDoesNotMatch` is also extracted as a factory method (it was
  previously an inline string in `DlcsManifestCoordinator`) so both error shapes are defined in one
  place.
