### PR TITLE
Handle unknown props for Manifests and Collections

### DIFF
--- a/src/IIIFPresentation/API.Tests/Integration/ModifyCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyCollectionTests.cs
@@ -2429,6 +2429,8 @@ $$"""
 
         var collection = @"{
    ""type"": ""Collection"",
+   ""slug"": ""should-be-stripped"",
+   ""parent"": ""should-also-be-stripped"",
    ""behavior"": [
        ""public-iiif"", ""auto-advance""
    ],
@@ -2498,5 +2500,7 @@ $$"""
         s3Manifest.Id.Should().EndWith(fromDatabase.Id, "Stored Id is flat path");
         (s3Manifest.Context as string).Should()
             .Be("http://iiif.io/api/presentation/3/context.json", "Context set automatically");
+        s3Manifest.AdditionalProperties?.Keys.Should()
+            .NotIntersectWith(PresentationCollection.PresentationPropertyKeys);
     }
 }

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestCreateTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestCreateTests.cs
@@ -708,6 +708,8 @@ public class ModifyManifestCreateTests : IClassFixture<PresentationAppFactory<Pr
         s3Manifest.Id.Should().EndWith(id);
         (s3Manifest.Context as string).Should()
             .Be("http://iiif.io/api/presentation/3/context.json", "Context set automatically");
+        s3Manifest.AdditionalProperties?.Keys.Should()
+            .NotIntersectWith(PresentationManifest.PresentationPropertyKeys);
     }
 
     [Fact]

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestUpdateTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestUpdateTests.cs
@@ -386,8 +386,10 @@ public class ModifyManifestUpdateTests : IClassFixture<PresentationAppFactory<Pr
         s3Manifest.Id.Should().EndWith(dbManifest.Id);
         (s3Manifest.Context as string).Should()
             .Be("http://iiif.io/api/presentation/3/context.json", "Context set automatically");
+        s3Manifest.AdditionalProperties?.Keys.Should()
+            .NotIntersectWith(PresentationManifest.PresentationPropertyKeys);
     }
-    
+
     [Fact]
     public async Task PutFlatId_Update_IgnoringId()
     {

--- a/src/IIIFPresentation/API/API.csproj
+++ b/src/IIIFPresentation/API/API.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.10.0" />
-        <PackageReference Include="iiif-net" Version="0.4.0" />
+        <PackageReference Include="iiif-net" Version="0.4.1" />
         <PackageReference Include="JsonDiffPatch.Net" Version="2.5.0" />
         <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.8" />

--- a/src/IIIFPresentation/API/API.csproj
+++ b/src/IIIFPresentation/API/API.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.10.0" />
-        <PackageReference Include="iiif-net" Version="0.3.12" />
+        <PackageReference Include="iiif-net" Version="0.4.0" />
         <PackageReference Include="JsonDiffPatch.Net" Version="2.5.0" />
         <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.8" />

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
@@ -11,7 +11,6 @@ using Core.Auth;
 using Core.IIIF;
 using DLCS.Exceptions;
 using IIIF.Presentation.V3;
-using IIIF.Serialisation;
 using Models.API.General;
 using Models.API.Manifest;
 using Models.Database;
@@ -20,6 +19,7 @@ using Models.Database.General;
 using Repository;
 using Repository.Helpers;
 using Repository.Paths;
+using Services;
 using Services.Manifests.AWS;
 using Services.Manifests.Helpers;
 using Services.Manifests.Model;
@@ -411,7 +411,7 @@ public class ManifestWriteService(
     private async Task<List<Canvas>?> SaveToS3(DbManifest dbManifest, WriteManifestRequest request, bool hasAssets,
         bool canBeBuiltUpfront, CancellationToken cancellationToken)
     {
-        var iiifManifest = request.RawRequestBody.FromJson<IIIF.Presentation.V3.Manifest>();
+        var iiifManifest = request.RawRequestBody.ToManifest();
         
         if (canBeBuiltUpfront && hasAssets)
         {

--- a/src/IIIFPresentation/API/Features/Storage/Helpers/RequestBodyX.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Helpers/RequestBodyX.cs
@@ -1,8 +1,9 @@
 ﻿using API.Features.Storage.Models;
 using Core.IIIF;
 using IIIF;
-using IIIF.Serialisation;
+using IIIF.Presentation.V3;
 using Models.API;
+using Services;
 
 namespace API.Features.Storage.Helpers;
 
@@ -16,17 +17,17 @@ public static class RequestBodyX
     /// <returns>
     /// A response showing whether there were errors in the conversion, and the converted collection
     /// </returns>
-    public static TryConvertIIIFResult<T> ConvertCollectionToIIIF<T>(this string requestBody, ILogger logger) where T : JsonLdBase
+    public static TryConvertIIIFResult<Collection> ConvertCollectionToIIIF(this string requestBody, ILogger logger)
     {
         try
         {
-            var collection = requestBody.FromJson<T>();
-            return TryConvertIIIFResult<T>.Success(collection);
+            var collection = requestBody.ToCollection();
+            return TryConvertIIIFResult<Collection>.Success(collection!);
         }
         catch (Exception ex)
         {
             logger.LogError(ex, "An error occurred while attempting to validate the collection as IIIF");
-            return TryConvertIIIFResult<T>.Failure();
+            return TryConvertIIIFResult<Collection>.Failure();
         }
     }
 
@@ -34,7 +35,7 @@ public static class RequestBodyX
     /// Attempts to deserialize a <see cref="IPresentation"/> resource.
     ///
     /// As this populates an <see cref="IPresentation"/> resource it needs to be instantiated prior to population, which
-    /// leads to this method being more forgiving than <see cref="ConvertCollectionToIIIF{T}"/>
+    /// leads to this method being more forgiving than <see cref="ConvertCollectionToIIIF"/>
     /// </summary>
     /// <param name="requestBody">The raw request body to convert</param>
     /// <param name="logger"></param>

--- a/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
@@ -57,7 +57,7 @@ public class CreateCollectionHandler(
         TryConvertIIIFResult<IIIF.Presentation.V3.Collection>? iiifCollection = null;
         if (!isStorageCollection)
         {
-            iiifCollection = request.RawRequestBody.ConvertCollectionToIIIF<IIIF.Presentation.V3.Collection>(logger);
+            iiifCollection = request.RawRequestBody.ConvertCollectionToIIIF(logger);
             if (iiifCollection.Error) return UpsertErrorHelper.CannotValidateIIIF<PresentationCollection>();
         }
         

--- a/src/IIIFPresentation/API/Features/Storage/Requests/PostHierarchicalCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/PostHierarchicalCollection.cs
@@ -43,7 +43,7 @@ public class PostHierarchicalCollectionHandler(
     public async Task<ModifyEntityResult<Collection, ModifyCollectionType>> Handle(PostHierarchicalCollection request,
         CancellationToken cancellationToken)
     {
-        var convertResult = request.RawRequestBody.ConvertCollectionToIIIF<Collection>(logger);
+        var convertResult = request.RawRequestBody.ConvertCollectionToIIIF(logger);
         if (convertResult.Error) return UpsertErrorHelper.CannotValidateIIIF<Collection>();
         var collectionFromBody = convertResult.ConvertedIIIF!;
         

--- a/src/IIIFPresentation/API/Features/Storage/Requests/UpsertCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/UpsertCollection.cs
@@ -61,7 +61,7 @@ public class UpsertCollectionHandler(
         TryConvertIIIFResult<IIIF.Presentation.V3.Collection>? iiifCollection = null;
         if (!isStorageCollection)
         {
-            iiifCollection = request.RawRequestBody.ConvertCollectionToIIIF<IIIF.Presentation.V3.Collection>(logger);
+            iiifCollection = request.RawRequestBody.ConvertCollectionToIIIF(logger);
             if (iiifCollection.Error) return UpsertErrorHelper.CannotValidateIIIF<PresentationCollection>();
         }
         var databaseCollection =

--- a/src/IIIFPresentation/Core/Core.csproj
+++ b/src/IIIFPresentation/Core/Core.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="iiif-net" Version="0.4.0" />
+      <PackageReference Include="iiif-net" Version="0.4.1" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     </ItemGroup>

--- a/src/IIIFPresentation/Core/Core.csproj
+++ b/src/IIIFPresentation/Core/Core.csproj
@@ -7,9 +7,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="iiif-net" Version="0.3.12" />
+      <PackageReference Include="iiif-net" Version="0.4.0" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
-      <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+      <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     </ItemGroup>
 
 </Project>

--- a/src/IIIFPresentation/Models/API/Collection/PresentationCollection.cs
+++ b/src/IIIFPresentation/Models/API/Collection/PresentationCollection.cs
@@ -3,6 +3,12 @@ namespace Models.API.Collection;
 
 public class PresentationCollection : IIIF.Presentation.V3.Collection, IPresentation
 {
+    public static readonly string[] PresentationPropertyKeys =
+    [
+        "slug", "publicId", "flatId", "parent", "itemsOrder", "totalItems",
+        "created", "modified", "createdBy", "modifiedBy", "tags", "totals", "view"
+    ];
+
     public string? PublicId { get; set; }
     public string? FlatId { get; set; }
     

--- a/src/IIIFPresentation/Models/API/Collection/PresentationCollection.cs
+++ b/src/IIIFPresentation/Models/API/Collection/PresentationCollection.cs
@@ -3,6 +3,10 @@ namespace Models.API.Collection;
 
 public class PresentationCollection : IIIF.Presentation.V3.Collection, IPresentation
 {
+    /// <summary>
+    /// A collection of properties that are not part of the IIIF Presentation API spec and are custom to the
+    /// IIIF-Presentation.
+    /// </summary>
     public static readonly string[] PresentationPropertyKeys =
     [
         "slug", "publicId", "flatId", "parent", "itemsOrder", "totalItems",

--- a/src/IIIFPresentation/Models/API/Manifest/PresentationManifest.cs
+++ b/src/IIIFPresentation/Models/API/Manifest/PresentationManifest.cs
@@ -6,6 +6,13 @@ namespace Models.API.Manifest;
 
 public class PresentationManifest : IIIF.Presentation.V3.Manifest, IPresentation
 {
+    public static readonly string[] PresentationPropertyKeys =
+    [
+        "slug", "publicId", "parent", "created", "modified",
+        "createdBy", "modifiedBy", "flatId", "paintedResources", "space", "ingesting",
+        "fullPath", "currentlyIngesting"
+    ];
+
     [JsonProperty(Order = 6)] public string? Slug { get; set; }
     [JsonProperty(Order = 7)] public string? PublicId { get; set; }
     [JsonProperty(Order = 8)] public string? Parent { get; set; }

--- a/src/IIIFPresentation/Models/API/Manifest/PresentationManifest.cs
+++ b/src/IIIFPresentation/Models/API/Manifest/PresentationManifest.cs
@@ -13,7 +13,7 @@ public class PresentationManifest : IIIF.Presentation.V3.Manifest, IPresentation
     public static readonly string[] PresentationPropertyKeys =
     [
         "slug", "publicId", "parent", "created", "modified",
-        "createdBy", "modifiedBy", "flatId", "paintedResources", "space", "ingesting",
+        "createdBy", "modifiedBy", "flatId", "paintedResources", "space", "adjuncts", "ingesting",
         "fullPath", "currentlyIngesting"
     ];
 

--- a/src/IIIFPresentation/Models/API/Manifest/PresentationManifest.cs
+++ b/src/IIIFPresentation/Models/API/Manifest/PresentationManifest.cs
@@ -6,6 +6,10 @@ namespace Models.API.Manifest;
 
 public class PresentationManifest : IIIF.Presentation.V3.Manifest, IPresentation
 {
+    /// <summary>
+    /// A collection of properties that are not part of the IIIF Presentation API spec and are custom to the
+    /// IIIF-Presentation.
+    /// </summary>
     public static readonly string[] PresentationPropertyKeys =
     [
         "slug", "publicId", "parent", "created", "modified",

--- a/src/IIIFPresentation/Models/Models.csproj
+++ b/src/IIIFPresentation/Models/Models.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="iiif-net" Version="0.3.12" />
+      <PackageReference Include="iiif-net" Version="0.4.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/IIIFPresentation/Models/Models.csproj
+++ b/src/IIIFPresentation/Models/Models.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="iiif-net" Version="0.4.0" />
+      <PackageReference Include="iiif-net" Version="0.4.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/IIIFPresentation/Repository/Repository.csproj
+++ b/src/IIIFPresentation/Repository/Repository.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="EFCore.NamingConventions" Version="8.0.3" />
-        <PackageReference Include="iiif-net" Version="0.4.0" />
+        <PackageReference Include="iiif-net" Version="0.4.1" />
         <PackageReference Include="MediatR" Version="12.4.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.4" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />

--- a/src/IIIFPresentation/Repository/Repository.csproj
+++ b/src/IIIFPresentation/Repository/Repository.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="EFCore.NamingConventions" Version="8.0.3" />
-        <PackageReference Include="iiif-net" Version="0.3.12" />
+        <PackageReference Include="iiif-net" Version="0.4.0" />
         <PackageReference Include="MediatR" Version="12.4.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.4" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />

--- a/src/IIIFPresentation/Services.Tests/IIIFSerialisationXTests.cs
+++ b/src/IIIFPresentation/Services.Tests/IIIFSerialisationXTests.cs
@@ -24,7 +24,8 @@ public class IIIFSerialisationXTests
                      "flatId": "flat-1",
                      "paintedResources": [],
                      "space": "space-1",
-                     "ingesting": null
+                     "ingesting": null,
+                     "adjuncts": []
                    }
                    """;
 
@@ -42,6 +43,7 @@ public class IIIFSerialisationXTests
         result.AdditionalProperties.Should().NotContainKey("paintedResources");
         result.AdditionalProperties.Should().NotContainKey("space");
         result.AdditionalProperties.Should().NotContainKey("ingesting");
+        result.AdditionalProperties.Should().NotContainKey("adjuncts");
     }
 
     [Fact]
@@ -190,7 +192,7 @@ public class IIIFSerialisationXTests
 
     [Fact]
     public void ToManifest_PresentationPropertyKeys_CoversAllPresentationManifestProperties()
-        => PresentationManifest.PresentationPropertyKeys.Should().HaveCount(13);
+        => PresentationManifest.PresentationPropertyKeys.Should().HaveCount(14);
 
     [Fact]
     public void ToCollection_PresentationPropertyKeys_CoversAllPresentationCollectionProperties()

--- a/src/IIIFPresentation/Services.Tests/IIIFSerialisationXTests.cs
+++ b/src/IIIFPresentation/Services.Tests/IIIFSerialisationXTests.cs
@@ -1,0 +1,198 @@
+using IIIF.Serialisation;
+using Models.API.Collection;
+using Models.API.Manifest;
+
+namespace Services.Tests;
+
+public class IIIFSerialisationXTests
+{
+    [Fact]
+    public void ToManifest_StripsAllPresentationPropertyKeys()
+    {
+        var json = """
+                   {
+                     "@context": "http://iiif.io/api/presentation/3/context.json",
+                     "id": "https://example.org/manifest/1",
+                     "type": "Manifest",
+                     "slug": "test-slug",
+                     "publicId": "pub-1",
+                     "parent": "parent-id",
+                     "created": "2024-01-01T00:00:00Z",
+                     "modified": "2024-01-01T00:00:00Z",
+                     "createdBy": "user",
+                     "modifiedBy": "user",
+                     "flatId": "flat-1",
+                     "paintedResources": [],
+                     "space": "space-1",
+                     "ingesting": null
+                   }
+                   """;
+
+        var result = json.ToManifest();
+
+        result.Should().NotBeNull();
+        result!.AdditionalProperties.Should().NotContainKey("slug");
+        result.AdditionalProperties.Should().NotContainKey("publicId");
+        result.AdditionalProperties.Should().NotContainKey("parent");
+        result.AdditionalProperties.Should().NotContainKey("created");
+        result.AdditionalProperties.Should().NotContainKey("modified");
+        result.AdditionalProperties.Should().NotContainKey("createdBy");
+        result.AdditionalProperties.Should().NotContainKey("modifiedBy");
+        result.AdditionalProperties.Should().NotContainKey("flatId");
+        result.AdditionalProperties.Should().NotContainKey("paintedResources");
+        result.AdditionalProperties.Should().NotContainKey("space");
+        result.AdditionalProperties.Should().NotContainKey("ingesting");
+    }
+
+    [Fact]
+    public void ToManifest_PreservesUnknownCustomProperties()
+    {
+        var json = """
+                   {
+                     "@context": "http://iiif.io/api/presentation/3/context.json",
+                     "id": "https://example.org/manifest/1",
+                     "type": "Manifest",
+                     "slug": "test-slug",
+                     "myCustomProp": "keep-me"
+                   }
+                   """;
+
+        var result = json.ToManifest();
+
+        result.Should().NotBeNull();
+        result!.AdditionalProperties.Should().NotContainKey("slug");
+        result.AdditionalProperties.Should().ContainKey("myCustomProp");
+    }
+
+    [Fact]
+    public void ToManifest_PreservesStandardManifestProperties()
+    {
+        var json = """
+                   {
+                     "@context": "http://iiif.io/api/presentation/3/context.json",
+                     "id": "https://example.org/manifest/1",
+                     "type": "Manifest",
+                     "label": {"en": ["Test Manifest"]},
+                     "slug": "test-slug"
+                   }
+                   """;
+
+        var result = json.ToManifest();
+
+        result.Should().NotBeNull();
+        result!.Id.Should().Be("https://example.org/manifest/1");
+        result.Label.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void ToCollection_StripsAllPresentationPropertyKeys()
+    {
+        var json = """
+                   {
+                     "@context": "http://iiif.io/api/presentation/3/context.json",
+                     "id": "https://example.org/collection/1",
+                     "type": "Collection",
+                     "slug": "test-slug",
+                     "publicId": "pub-1",
+                     "flatId": "flat-1",
+                     "parent": "parent-id",
+                     "itemsOrder": 1,
+                     "totalItems": 5,
+                     "created": "2024-01-01T00:00:00Z",
+                     "modified": "2024-01-01T00:00:00Z",
+                     "createdBy": "user",
+                     "modifiedBy": "user",
+                     "tags": "tag1,tag2",
+                     "totals": null,
+                     "view": null
+                   }
+                   """;
+
+        var result = json.ToCollection();
+
+        result.Should().NotBeNull();
+        result!.AdditionalProperties.Should().NotContainKey("slug");
+        result.AdditionalProperties.Should().NotContainKey("publicId");
+        result.AdditionalProperties.Should().NotContainKey("flatId");
+        result.AdditionalProperties.Should().NotContainKey("parent");
+        result.AdditionalProperties.Should().NotContainKey("itemsOrder");
+        result.AdditionalProperties.Should().NotContainKey("totalItems");
+        result.AdditionalProperties.Should().NotContainKey("created");
+        result.AdditionalProperties.Should().NotContainKey("modified");
+        result.AdditionalProperties.Should().NotContainKey("createdBy");
+        result.AdditionalProperties.Should().NotContainKey("modifiedBy");
+        result.AdditionalProperties.Should().NotContainKey("tags");
+        result.AdditionalProperties.Should().NotContainKey("totals");
+        result.AdditionalProperties.Should().NotContainKey("view");
+    }
+
+    [Fact]
+    public void ToCollection_PreservesUnknownCustomProperties()
+    {
+        var json = """
+                   {
+                     "@context": "http://iiif.io/api/presentation/3/context.json",
+                     "id": "https://example.org/collection/1",
+                     "type": "Collection",
+                     "slug": "test-slug",
+                     "myCustomProp": "keep-me"
+                   }
+                   """;
+
+        var result = json.ToCollection();
+
+        result.Should().NotBeNull();
+        result!.AdditionalProperties.Should().NotContainKey("slug");
+        result.AdditionalProperties.Should().ContainKey("myCustomProp");
+    }
+
+    [Fact]
+    public void ToManifest_StrippedPropertiesAbsentFromSerialisation()
+    {
+        var json = """
+                   {
+                     "@context": "http://iiif.io/api/presentation/3/context.json",
+                     "id": "https://example.org/manifest/1",
+                     "type": "Manifest",
+                     "slug": "test-slug",
+                     "parent": "parent-id"
+                   }
+                   """;
+
+        var result = json.ToManifest();
+        var serialised = result!.AsJson();
+
+        serialised.Should().NotContain("\"slug\"");
+        serialised.Should().NotContain("\"parent\"");
+        serialised.Should().Contain("\"id\"");
+    }
+
+    [Fact]
+    public void ToCollection_StrippedPropertiesAbsentFromSerialisation()
+    {
+        var json = """
+                   {
+                     "@context": "http://iiif.io/api/presentation/3/context.json",
+                     "id": "https://example.org/collection/1",
+                     "type": "Collection",
+                     "slug": "test-slug",
+                     "parent": "parent-id"
+                   }
+                   """;
+
+        var result = json.ToCollection();
+        var serialised = result!.AsJson();
+
+        serialised.Should().NotContain("\"slug\"");
+        serialised.Should().NotContain("\"parent\"");
+        serialised.Should().Contain("\"id\"");
+    }
+
+    [Fact]
+    public void ToManifest_PresentationPropertyKeys_CoversAllPresentationManifestProperties()
+        => PresentationManifest.PresentationPropertyKeys.Should().HaveCount(13);
+
+    [Fact]
+    public void ToCollection_PresentationPropertyKeys_CoversAllPresentationCollectionProperties()
+        => PresentationCollection.PresentationPropertyKeys.Should().HaveCount(13);
+}

--- a/src/IIIFPresentation/Services/IIIFSerialisationX.cs
+++ b/src/IIIFPresentation/Services/IIIFSerialisationX.cs
@@ -1,0 +1,33 @@
+using IIIF.Presentation.V3;
+using IIIF.Serialisation;
+using Models.API.Collection;
+using Models.API.Manifest;
+
+namespace Services;
+
+public static class IIIFSerialisationX
+{
+    /// <summary>
+    /// Get serialised <see cref="IIIF.Presentation.V3.Manifest"/> from JSON string, removing IIIF Presentation
+    /// specific properties
+    /// </summary>
+    public static Manifest? ToManifest(this string json)
+    {
+        var manifest = json
+            .FromJson<Manifest>()
+            ?.WithoutAdditionalProperties(PresentationManifest.PresentationPropertyKeys);
+        return manifest;
+    }
+
+    /// <summary>
+    /// Get serialised <see cref="IIIF.Presentation.V3.Collection"/> from JSON string, removing IIIF Presentation
+    /// specific properties
+    /// </summary>
+    public static Collection? ToCollection(this string json)
+    {
+        var collection = json
+            .FromJson<Collection>()
+            ?.WithoutAdditionalProperties(PresentationCollection.PresentationPropertyKeys);
+        return collection;
+    }
+}

--- a/src/IIIFPresentation/Services/IIIFSerialisationX.cs
+++ b/src/IIIFPresentation/Services/IIIFSerialisationX.cs
@@ -14,8 +14,8 @@ public static class IIIFSerialisationX
     public static Manifest? ToManifest(this string json)
     {
         var manifest = json
-            .FromJson<Manifest>()
-            ?.WithoutAdditionalProperties(PresentationManifest.PresentationPropertyKeys);
+            .FromJson<Manifest>()?
+            .WithoutAdditionalProperties(PresentationManifest.PresentationPropertyKeys);
         return manifest;
     }
 
@@ -26,8 +26,8 @@ public static class IIIFSerialisationX
     public static Collection? ToCollection(this string json)
     {
         var collection = json
-            .FromJson<Collection>()
-            ?.WithoutAdditionalProperties(PresentationCollection.PresentationPropertyKeys);
+            .FromJson<Collection>()?
+            .WithoutAdditionalProperties(PresentationCollection.PresentationPropertyKeys);
         return collection;
     }
 }

--- a/src/IIIFPresentation/Services/Services.csproj
+++ b/src/IIIFPresentation/Services/Services.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="iiif-net" Version="0.3.12" />
+      <PackageReference Include="iiif-net" Version="0.4.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/IIIFPresentation/Services/Services.csproj
+++ b/src/IIIFPresentation/Services/Services.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="iiif-net" Version="0.4.0" />
+      <PackageReference Include="iiif-net" Version="0.4.1" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## What does this change?

Resolves #588

Upgrades iiif-net from `0.3.12` to `0.4.1` and fixes a regression introduced by the new version.

iiif-net [`0.4.0`](https://github.com/digirati-co-uk/iiif-net/releases/tag/v0.4.0) adds `AdditionalProperties` (a `Dictionary<string, JToken>`) to `JsonLdBase` via Newtonsoft's `[JsonExtensionData]`. This means that when a user submits a manifest or collection containing `PresentationManifest`/`PresentationCollection`-specific fields (`slug`, `parent`, `paintedResources`, etc) and the request body is deserialised as plain `Manifest`/`Collection`, those fields now land in `AdditionalProperties` and are re-serialised when `AsJson()` is called — polluting the IIIF resource stored in S3.

Fix was to strip the known presentation-layer keys at deserialisation time, before the object reaches any S3 write path.

* `PresentationManifest` and `PresentationCollection` each gain a `static readonly string[] PresentationPropertyKeys` listing their JSON property names.
* Two extension methods `ToManifest()` and `ToCollection()` in `Services` deserialise and immediately strip those keys using iiif-net's `WithoutAdditionalProperties()`. Unknown custom properties the user added are preserved.
* `ManifestWriteService` uses `ToManifest()` instead of `FromJson<Manifest>()` directly.
* `ConvertCollectionToIIIF` in `RequestBodyX` is de-generified (all callers used `Collection`) and now calls `ToCollection()` internally, covering all collection write paths (`CreateCollection`, `UpsertCollection`, `PostHierarchicalCollection`).
* Unit tests in `IIIFSerialisationXTests` cover stripping, custom-property preservation, and round-trip serialisation. Integration tests assert that the S3-stored manifest/collection contains none of the presentation property keys.