### PR TITLE
Fix duplicate adjuncts not being allowed through to the DLCS

### DIFF
--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
@@ -46,7 +46,7 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
     {
         dbContext = storageFixture.DbFixture.DbContext;
         amazonS3 = storageFixture.LocalStackFixture.AWSS3ClientFactory();
-        
+
         // Always return Space 999 when call to create space
         A.CallTo(() => DLCSApiClient.CreateSpace(Customer, A<string>._, A<CancellationToken>._))
             .Returns(new Space { Id = NewlyCreatedSpace, Name = "test" });
@@ -1073,7 +1073,7 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
      {
          // Regression: same asset on multiple canvas paintings caused one AdjunctInteraction per painting,
          // so the flat adjunct list sent to DLCS contained duplicates and DLCS rejected the batch.
-         var (assetId, slug) = TestIdentifiers.SlugResource();
+         var (assetId, _, slug, adjunctId) = TestIdentifiers.SlugResourceAssetAdjunct();
          var batchId = TestIdentifiers.BatchId();
 
          var manifest = $$"""
@@ -1090,7 +1090,7 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
                                           "mediaType": "image/jpg",
                                           "adjuncts": [
                                               {
-                                                  "id": "adjunct-1",
+                                                  "id": "{{adjunctId}}",
                                                   "profile": "https://example.org/profile/a"
                                               }
                                           ]
@@ -1104,7 +1104,7 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
                                           "mediaType": "image/jpg",
                                           "adjuncts": [
                                               {
-                                                  "id": "adjunct-1",
+                                                  "id": "{{adjunctId}}",
                                                   "profile": "https://example.org/profile/a"
                                               }
                                           ]
@@ -1129,7 +1129,7 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
 
          // Adjunct must be sent exactly once — deduplication by AssetId prevents sending it once per canvas painting
          A.CallTo(() => DLCSApiClient.IngestDeliverables(Customer,
-                 A<List<JObject>>.That.Matches(list => list.Count == 1 && list[0][AdjunctProperties.Id]!.Value<string>() == "adjunct-1"),
+                 A<List<JObject>>.That.Matches(list => list.Count == 1 && list[0][AdjunctProperties.Id]!.Value<string>() == adjunctId),
                  true, A<CancellationToken>._))
              .MustHaveHappenedOnceExactly();
      }

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestAssetCreationTests.cs
@@ -1069,6 +1069,72 @@ public class ModifyManifestAssetCreationTests : IClassFixture<PresentationAppFac
      }
 
      [Fact]
+     public async Task CreateManifest_SendsAdjunctOnceTooDlcs_WhenSameAssetAppearsMultipleTimesWithIdenticalAdjuncts()
+     {
+         // Regression: same asset on multiple canvas paintings caused one AdjunctInteraction per painting,
+         // so the flat adjunct list sent to DLCS contained duplicates and DLCS rejected the batch.
+         var (assetId, slug) = TestIdentifiers.SlugResource();
+         var batchId = TestIdentifiers.BatchId();
+
+         var manifest = $$"""
+                          {
+                              "type": "Manifest",
+                              "slug": "{{slug}}",
+                              "parent": "http://localhost/{{Customer}}/collections/root",
+                              "paintedResources": [
+                                  {
+                                      "asset": {
+                                          "id": "{{assetId}}",
+                                          "space": {{NewlyCreatedSpace}},
+                                          "batch": "{{batchId}}",
+                                          "mediaType": "image/jpg",
+                                          "adjuncts": [
+                                              {
+                                                  "id": "adjunct-1",
+                                                  "profile": "https://example.org/profile/a"
+                                              }
+                                          ]
+                                      }
+                                  },
+                                  {
+                                      "asset": {
+                                          "id": "{{assetId}}",
+                                          "space": {{NewlyCreatedSpace}},
+                                          "batch": "{{batchId}}",
+                                          "mediaType": "image/jpg",
+                                          "adjuncts": [
+                                              {
+                                                  "id": "adjunct-1",
+                                                  "profile": "https://example.org/profile/a"
+                                              }
+                                          ]
+                                      }
+                                  }
+                              ]
+                          }
+                          """;
+
+         var adjunctBatchId = TestIdentifiers.BatchId();
+         A.CallTo(() => DLCSApiClient.IngestDeliverables(Customer, A<List<JObject>>._, true, A<CancellationToken>._))
+             .Returns(Task.FromResult(new List<Batch> { new() { ResourceId = adjunctBatchId.ToString(), Submitted = DateTime.Now } }));
+
+         var requestMessage =
+             HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Post, $"{Customer}/manifests", manifest);
+
+         // Act
+         var response = await httpClient.AsCustomer().SendAsync(requestMessage);
+
+         // Assert
+         response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+         // Adjunct must be sent exactly once — deduplication by AssetId prevents sending it once per canvas painting
+         A.CallTo(() => DLCSApiClient.IngestDeliverables(Customer,
+                 A<List<JObject>>.That.Matches(list => list.Count == 1 && list[0][AdjunctProperties.Id]!.Value<string>() == "adjunct-1"),
+                 true, A<CancellationToken>._))
+             .MustHaveHappenedOnceExactly();
+     }
+
+     [Fact]
      public async Task CreateManifest_Accepted_WhenMultipleAssetsWithSameAssetIdHaveIdenticalAdjunctsInDifferentOrder()
      {
          // Arrange

--- a/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingResolver.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingResolver.cs
@@ -264,9 +264,12 @@ public class CanvasPaintingResolver(
             var res = canvasPaintingMerger.CombinePaintedResources(itemsCanvasPaintings,
                 paintedResourceCanvasPaintings, presentationManifest.Items);
 
+            // DistinctBy AssetId is safe here: AssetDuplicateValidator has already rejected any case where
+            // the same asset appears more than once with differing adjuncts, so duplicates are always identical.
             var adjunctInteractions = paintedResourceCanvasPaintings
                 .Where(cp => cp.AdjunctInteraction != null)
                 .Select(cp => cp.AdjunctInteraction!)
+                .DistinctBy(a => a.AssetId)
                 .ToList();
 
             var manifestAdjunctInteraction =


### PR DESCRIPTION
## What does this change?

Resolves #603

This PR fixes an issue where a valid duplicated adjunct was failing to pass the DLCS checks for duplicated adjuncts.  It does this by effectively stripping duplicates from the payload so that they will be correctly ingested

