### PR TITLE
Retry completion messages on more occasions

### DIFF
--- a/src/IIIFPresentation/AWS.Tests/SQS/QueueMessageTests.cs
+++ b/src/IIIFPresentation/AWS.Tests/SQS/QueueMessageTests.cs
@@ -41,7 +41,7 @@ public class QueueMessageTests
         };
 
         // Act
-        var queueMessage = new QueueMessage(body, attributeValues, messageId);
+        var queueMessage = new QueueMessage(body, attributeValues, [], messageId);
 
         // Assert
         queueMessage.Body.Should().Be(body);
@@ -63,7 +63,7 @@ public class QueueMessageTests
         var attributeValues = new Dictionary<string, MessageAttributeValue>();
 
         // Act
-        var queueMessage = new QueueMessage(body, attributeValues, messageId);
+        var queueMessage = new QueueMessage(body, attributeValues, [], messageId);
 
         // Assert
         queueMessage.Body.Should().Be(body);
@@ -85,7 +85,7 @@ public class QueueMessageTests
         };
 
         // Act
-        var queueMessage = new QueueMessage(body, attributeValues, messageId);
+        var queueMessage = new QueueMessage(body, attributeValues, [], messageId);
 
         // Assert
         queueMessage.Attributes.Keys.Should().ContainInOrder("Z_Attr", "A_Attr", "M_Attr");
@@ -104,10 +104,56 @@ public class QueueMessageTests
         };
 
         // Act
-        var queueMessage = new QueueMessage(body, attributeValues, messageId);
+        var queueMessage = new QueueMessage(body, attributeValues, [], messageId);
 
         // Assert
         queueMessage.Attributes.Should().Contain("Attr1", "Value1");
         queueMessage.Attributes["AttrWithNullValue"].Should().BeNull();
+    }
+
+    [Fact]
+    public void Constructor_WithMessageAttributeValues_SetsApproximateReceiveCount()
+    {
+        // Arrange
+        const string body = "Test message body";
+        const string messageId = "test-message-id";
+        var systemAttributes = new Dictionary<string, string>
+        {
+            { "ApproximateReceiveCount", "3" }
+        };
+
+        // Act
+        var queueMessage = new QueueMessage(body, [], systemAttributes, messageId);
+
+        // Assert
+        queueMessage.ApproximateReceiveCount.Should().Be(3);
+    }
+
+    [Fact]
+    public void Constructor_WithMessageAttributeValues_ApproximateReceiveCountDefaultsToZero_WhenNotPresent()
+    {
+        // Arrange
+        const string body = "Test message body";
+        const string messageId = "test-message-id";
+
+        // Act
+        var queueMessage = new QueueMessage(body, [], [], messageId);
+
+        // Assert
+        queueMessage.ApproximateReceiveCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void Constructor_WithStringAttributes_ApproximateReceiveCountDefaultsToZero()
+    {
+        // Arrange
+        const string body = "Test message body";
+        const string messageId = "test-message-id";
+
+        // Act
+        var queueMessage = new QueueMessage(body, new Dictionary<string, string>(), messageId);
+
+        // Assert
+        queueMessage.ApproximateReceiveCount.Should().Be(0);
     }
 }

--- a/src/IIIFPresentation/AWS/SQS/QueueAttributes.cs
+++ b/src/IIIFPresentation/AWS/SQS/QueueAttributes.cs
@@ -1,0 +1,9 @@
+namespace AWS.SQS;
+
+/// <summary>
+/// Known SQS queue attributes
+/// </summary>
+internal static class QueueAttributes
+{
+    public const string ApproximateReceiveCount = "ApproximateReceiveCount";
+}

--- a/src/IIIFPresentation/AWS/SQS/QueueMessage.cs
+++ b/src/IIIFPresentation/AWS/SQS/QueueMessage.cs
@@ -17,11 +17,15 @@ public class QueueMessage
     /// <remarks>
     /// This only maps StringValues from attributes, it won't handle other types (BinaryValue or MemoryStream)
     /// </remarks>
-    public QueueMessage(string body, Dictionary<string, MessageAttributeValue> attributes, string messageId)
+    public QueueMessage(string body, Dictionary<string, MessageAttributeValue> attributes,
+        Dictionary<string, string> messageAttributes, string messageId)
     {
         Body = body;
         Attributes = attributes.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.StringValue);
         MessageId = messageId;
+        ApproximateReceiveCount = messageAttributes.TryGetValue(QueueAttributes.ApproximateReceiveCount, out var count)
+            ? int.Parse(count)
+            : 0;
     }
 
     public string Body { get; }
@@ -29,4 +33,6 @@ public class QueueMessage
     public Dictionary<string, string> Attributes { get; }
 
     public string MessageId { get; }
+
+    public int ApproximateReceiveCount { get; }
 }

--- a/src/IIIFPresentation/AWS/SQS/SqsListener.cs
+++ b/src/IIIFPresentation/AWS/SQS/SqsListener.cs
@@ -91,6 +91,7 @@ public class SqsListener
             WaitTimeSeconds = options.SQS.WaitTimeSecs,
             MaxNumberOfMessages = options.SQS.MaxNumberOfMessages,
             MessageAttributeNames = [".*"], // Include all custom message attributes
+            MessageSystemAttributeNames = [QueueAttributes.ApproximateReceiveCount], // Include the number of times received
         }, cancellationToken);
 
     private async Task<bool> HandleMessage<T>(string queueUrl, Message message, CancellationToken cancellationToken)
@@ -98,7 +99,8 @@ public class SqsListener
     {
         try
         {
-            var queueMessage = new QueueMessage(GetJsonPayload(message), message.MessageAttributes, message.MessageId);
+            var queueMessage = new QueueMessage(GetJsonPayload(message), message.MessageAttributes, message.Attributes,
+                message.MessageId);
 
             // create a new scope to avoid issues with Scoped dependencies
             using var listenerScope = serviceScopeFactory.CreateScope();

--- a/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionMessageHandlerTests.cs
+++ b/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionMessageHandlerTests.cs
@@ -86,11 +86,29 @@ public class BatchCompletionMessageHandlerTests
         (await sut.HandleMessage(message, CancellationToken.None)).Should().BeFalse();
     }
 
-    [Fact]
-    public async Task HandleMessage_DoesNotUpdateAnything_WhenBatchNotTracked()
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    public async Task HandleMessage_ReturnsFalse_WhenBatchNotTracked_AndBelowRetryThreshold(int approximateReceiveCount)
     {
-        // Arrange
-        var message = QueueHelper.CreateQueueMessage(572246, CustomerId);
+        // Arrange - batch unknown, message should be retried
+        var message = QueueHelper.CreateQueueMessage(572246, CustomerId, approximateReceiveCount: approximateReceiveCount);
+
+        // Act and Assert
+        (await sut.HandleMessage(message, CancellationToken.None)).Should().BeFalse();
+        A.CallTo(() =>
+                dlcsClient.RetrieveAssetsForManifest(A<int>._, A<string>._, A<CancellationToken>._))
+            .MustNotHaveHappened();
+    }
+
+    [Theory]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(10)]
+    public async Task HandleMessage_ReturnsTrue_WhenBatchNotTracked_AndAboveRetryThreshold(int approximateReceiveCount)
+    {
+        // Arrange - batch unknown but already retried enough, discard the message
+        var message = QueueHelper.CreateQueueMessage(572246, CustomerId, approximateReceiveCount: approximateReceiveCount);
 
         // Act and Assert
         (await sut.HandleMessage(message, CancellationToken.None)).Should().BeTrue();
@@ -396,8 +414,8 @@ public class BatchCompletionMessageHandlerTests
         // Act
         var result = await sut.HandleMessage(message, CancellationToken.None);
 
-        // Assert - message is handled successfully (true) but batch is NOT retrieved/updated due to type mismatch
-        result.Should().BeTrue("Message processed successfully");
+        // Assert - batch not found (type mismatch), so message is retried (false) on first receive
+        result.Should().BeFalse("Batch not found due to type mismatch; message will be retried");
         A.CallTo(() => dlcsClient.RetrieveAssetsForManifest(A<int>._, A<string>._, A<CancellationToken>._))
             .MustNotHaveHappened();
         var batch = dbContext.Batches.Single(b => b.Id == batchId);

--- a/src/IIIFPresentation/BackgroundHandler.Tests/Helpers/QueueHelper.cs
+++ b/src/IIIFPresentation/BackgroundHandler.Tests/Helpers/QueueHelper.cs
@@ -1,4 +1,5 @@
-﻿using AWS.SQS;
+﻿using Amazon.SQS.Model;
+using AWS.SQS;
 using Models.Database.General;
 
 namespace BackgroundHandler.Tests.Helpers;
@@ -6,7 +7,7 @@ namespace BackgroundHandler.Tests.Helpers;
 public static class QueueHelper
 {
     public static QueueMessage CreateQueueMessage(int batchId, int customerId, DateTime? finished = null,
-        DeliverableType deliverableType = DeliverableType.Asset)
+        DeliverableType deliverableType = DeliverableType.Asset, int approximateReceiveCount = 0)
     {
         var batchMessage = $@"
 {{
@@ -19,9 +20,14 @@ public static class QueueHelper
     ""submitted"":""2024-12-19T21:03:31.57Z"",
     ""finished"":""{finished ?? DateTime.UtcNow:yyyy-MM-ddTHH:mm:ssK}""
 }}";
-        return new QueueMessage(batchMessage, new Dictionary<string, string>
+        var messageAttributes = new Dictionary<string, MessageAttributeValue>
         {
-            ["Type"] = deliverableType == DeliverableType.Asset ? "Batch" : "AdjunctBatch"
-        }, "foo");
+            ["Type"] = new MessageAttributeValue { StringValue = deliverableType == DeliverableType.Asset ? "Batch" : "AdjunctBatch" }
+        };
+        var systemAttributes = new Dictionary<string, string>
+        {
+            ["ApproximateReceiveCount"] = approximateReceiveCount.ToString()
+        };
+        return new QueueMessage(batchMessage, messageAttributes, systemAttributes, "foo");
     }
 }

--- a/src/IIIFPresentation/BackgroundHandler/BatchCompletion/BatchCompletionMessageHandler.cs
+++ b/src/IIIFPresentation/BackgroundHandler/BatchCompletion/BatchCompletionMessageHandler.cs
@@ -26,8 +26,7 @@ public class BatchCompletionMessageHandler(
                 
                 customerIdProvider.SetCustomerId(batchCompletionMessage.Customer);
                 
-                await TryUpdateManifest(batchCompletionMessage, cancellationToken);
-                return true;
+                return await TryUpdateManifest(batchCompletionMessage, message.ApproximateReceiveCount, cancellationToken);
             }
             catch (Exception ex)
             {
@@ -38,7 +37,7 @@ public class BatchCompletionMessageHandler(
         return false;
     }
 
-    private async Task TryUpdateManifest(BatchCompletionMessage batchCompletionMessage, CancellationToken cancellationToken)
+    private async Task<bool> TryUpdateManifest(BatchCompletionMessage batchCompletionMessage, int approximateReceiveCount, CancellationToken cancellationToken)
     {
         // Load batch the incoming message is referring to
         var batch = await dbContext.Batches.Include(b => b.Manifest)
@@ -46,12 +45,19 @@ public class BatchCompletionMessageHandler(
             .SingleOrDefaultAsync(
                 b => b.Id == batchCompletionMessage.Id && b.DeliverableType == batchCompletionMessage.DeliverableType,
                 cancellationToken);
-        
-        // batch isn't tracked by presentation, so nothing to do
-        if (batch == null) return;
+
+        // batch isn't tracked by presentation - allow a few retries in case of a timing issue
+        if (batch == null)
+        {
+            var discard = approximateReceiveCount >= 2;
+            logger.LogTrace(
+                "Batch {BatchId} not found in presentation. ApproximateReceiveCount:{Count}. {Action}",
+                batchCompletionMessage.Id, approximateReceiveCount, discard ? "Discarding" : "Will retry");
+            return discard;
+        }
 
         var sw = Stopwatch.StartNew();
-        
+
         // Other batches haven't completed, so can't populate Manifest until all are complete
         if (await dbContext.Batches.AnyAsync(b => b.ManifestId == batch.ManifestId &&
                                                   b.Status != BatchStatus.Completed &&
@@ -76,14 +82,14 @@ public class BatchCompletionMessageHandler(
                     logger.LogInformation(
                         "Batch:{BatchId}, customer:{CustomerId}, manifest:{ManifestId} already completed",
                         batch.Id, batch.CustomerId, batch.ManifestId);
-                    return;
+                    return true;
                 }
             }
             catch (Exception e)
             {
                 logger.LogError(e, "Error updating completing batch {BatchId} for manifest {ManifestId}", batch.Id,
                     batch.ManifestId);
-                throw;
+                return false;
             }
         }
 
@@ -91,6 +97,7 @@ public class BatchCompletionMessageHandler(
         logger.LogInformation(
             "Updating batch:{BatchId}, customer:{CustomerId}, manifest:{ManifestId}. Completed in {Elapsed}ms",
             batch.Id, batch.CustomerId, batch.ManifestId, sw.ElapsedMilliseconds);
+        return true;
     }
     
     private static BatchCompletionMessage DeserializeMessage(QueueMessage message, ILogger logger)


### PR DESCRIPTION
Resolves #604 

## What does this change?

Handle potential timing issues around quickly completed batches by retrying some messages.

* Request `ApproximateReceiveCount` when fetching messages + store against `QueueMessage`
* If Batch not in DB, retry if this is >= 2. The max retry count is 3 but this allows 1 or 2 retries, the _Approximate_ nature of attribute will be +/- 1 so this allows some wiggle. The reason for doing this is to avoid genuine "we don't care" messages hitting DLQ.

This will result in slightly more churn in SQS queue, and therefore db hits, but at levels of batches completed this will be small.