### PR TITLE
Store Incoming Payloads

### DIFF
--- a/docs/notes/storage-keys.md
+++ b/docs/notes/storage-keys.md
@@ -7,11 +7,13 @@ IIIF-Presentation makes use of S3 to store manifests and collections. These keys
 
 See `BucketHelperX` for code that generates keys.
 
-| Name             | Format                                                | Example                            | Description                                                                                         |
-| ---------------- | ----------------------------------------------------- | ---------------------------------- | --------------------------------------------------------------------------------------------------- |
-| Manifest         | `{Storage}/{Customer}/manifests/{Manifest-Id}`        | `iiif-p/1/manifests/abc123`        | IIIF manifests, whether saved as-is or generated                                                    |
-| Staged Manifest* | `{Storage}/staged/{Customer}/manifests/{Manifest-Id}` | `iiif-p/staged/1/manifests/abc123` | In-flight generated IIIF manifests. Will contain in-complete `"items"` that will be populated later |
-| IIIF Collections | `{Storage}/{Customer}/collections/{Collection-Id}`    | `iiif-p/1/collections/abc123`      | IIIF Collections                                                                                    |
+| Name                     | Format                                                          | Example                                      | Description                                                                                        |
+|--------------------------|-----------------------------------------------------------------|----------------------------------------------|----------------------------------------------------------------------------------------------------|
+| Manifest                 | `{Storage}/{Customer}/manifests/{Manifest-Id}`                  | `iiif-p/1/manifests/abc123`                  | IIIF manifests, whether saved as-is or generated                                                   |
+| Staged Manifest          | `{Storage}/staging/{Customer}/manifests/{Manifest-Id}`          | `iiif-p/staging/1/manifests/abc123`          | In-flight generated IIIF manifests. Will contain in-complete `"items"` that will be populated later |
+| Orignal Manifest Payload | `{Storage}/original/{Customer}/manifests/{Manifest-Id}`         | `iiif-p/original/1/manifests/abc123`         | Stores the original payload if the it'd have been modified by processing                           |
+| Orignal Manifest Payload | `{Storage}/original-staging/{Customer}/manifests/{Manifest-Id}` | `iiif-p/original-staging/1/manifests/abc123` | Stores the payload in the update scenario that requires background handler
+| IIIF Collections         | `{Storage}/{Customer}/collections/{Collection-Id}`              | `iiif-p/1/collections/abc123`                | IIIF Collections                                                                                   |
 
 * `*` indicates that this is a proposed key and not currently used. `/staged/` key will allow easy clean-up of 'stale' in-flight manifests using prefix lifecycle rules.
 

--- a/docs/notes/storage-keys.md
+++ b/docs/notes/storage-keys.md
@@ -7,15 +7,28 @@ IIIF-Presentation makes use of S3 to store manifests and collections. These keys
 
 See `BucketHelperX` for code that generates keys.
 
-| Name                     | Format                                                          | Example                                      | Description                                                                                        |
-|--------------------------|-----------------------------------------------------------------|----------------------------------------------|----------------------------------------------------------------------------------------------------|
-| Manifest                 | `{Storage}/{Customer}/manifests/{Manifest-Id}`                  | `iiif-p/1/manifests/abc123`                  | IIIF manifests, whether saved as-is or generated                                                   |
-| Staged Manifest          | `{Storage}/staging/{Customer}/manifests/{Manifest-Id}`          | `iiif-p/staging/1/manifests/abc123`          | In-flight generated IIIF manifests. Will contain in-complete `"items"` that will be populated later |
-| Orignal Manifest Payload | `{Storage}/original/{Customer}/manifests/{Manifest-Id}`         | `iiif-p/original/1/manifests/abc123`         | Stores the original payload if the it'd have been modified by processing                           |
-| Orignal Manifest Payload | `{Storage}/original-staging/{Customer}/manifests/{Manifest-Id}` | `iiif-p/original-staging/1/manifests/abc123` | Stores the payload in the update scenario that requires background handler
-| IIIF Collections         | `{Storage}/{Customer}/collections/{Collection-Id}`              | `iiif-p/1/collections/abc123`                | IIIF Collections                                                                                   |
+| Name                             | Format                                                          | Example                                      | Description                                                                                         |
+| -------------------------------- | --------------------------------------------------------------- | -------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| Manifest                         | `{Storage}/{Customer}/manifests/{Manifest-Id}`                  | `iiif-p/1/manifests/abc123`                  | IIIF manifests, whether saved as-is or generated                                                    |
+| Original Manifest Payload        | `{Storage}/{Customer}/manifests/{Manifest-Id}/original`         | `iiif-p/1/manifests/abc123/original`         | Stores the original payload if the required modification by processing                              |
+| Staged Manifest                  | `{Storage}/staging/{Customer}/manifests/{Manifest-Id}`          | `iiif-p/staging/1/manifests/abc123`          | In-flight generated IIIF manifests. Will contain in-complete `"items"` that will be populated later |
+| Staged Original Manifest Payload | `{Storage}/staging/{Customer}/manifests/{Manifest-Id}/original` | `iiif-p/staging/1/manifests/abc123/original` | Stores the payload in the update scenario that requires background handler                          |
+| IIIF Collections                 | `{Storage}/{Customer}/collections/{Collection-Id}`              | `iiif-p/1/collections/abc123`                | IIIF Collections                                                                                    |
 
-* `*` indicates that this is a proposed key and not currently used. `/staged/` key will allow easy clean-up of 'stale' in-flight manifests using prefix lifecycle rules.
+## Prefixes
+
+* `/{Customer}/` is the general prefix, keeps all resources for a customer together.
+* `/staging/` groups those resources that are in-flight. These are relatively transient to useful to be able to identify independantly.
+
+## Staging / Original
+
+The Manifest can exist in multiple places (using terminology from above)
+* `Manifest` - final/complete and publicly-servable IIIF Manifest.
+* `Original Manifest Payload` - Manifest body from PUT/POST. This is updated when the processing of a Manifest is complete (ie it's saved to `Manifest`)
+* `Staged Manifest` - in-flight Manifest that needs further work to complete (ie population from Adjuncts, Assets or text-service content).
+* `Staged Original Manifest Payload` - Manifest body from PUT/POST for in-flight Manifest that needs further work.
+
+Manifests can exist in multiple locations at once.
 
 ## Note on IIIF Identities
 

--- a/src/IIIFPresentation/API.Tests/Features/Manifest/ManifestWriteServiceTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Manifest/ManifestWriteServiceTests.cs
@@ -625,7 +625,7 @@ public class ManifestWriteServiceTests
         // UpsertManifestInStorage returns a manifest carrying both user-set and stub values for all
         // three adjunct types, as ManifestMerger would produce after applying ApplyManifestLevelAdjuncts
         A.CallTo(() => manifestStorageManager.UpsertManifestInStorage(
-                A<IIIFManifest>._, A<Models.Database.Collections.Manifest>._, A<CancellationToken>._))
+                A<IIIFManifest>._, A<Models.Database.Collections.Manifest>._, A<string>._, A<CancellationToken>._))
             .ReturnsLazily(() => new IIIFManifest
             {
                 SeeAlso =
@@ -708,7 +708,7 @@ public class ManifestWriteServiceTests
         // ManifestMerger preserves the base manifest's empty lists when the stub canvas has no adjuncts,
         // so UpsertManifestInStorage returns empty (not null) for each adjunct type
         A.CallTo(() => manifestStorageManager.UpsertManifestInStorage(
-                A<IIIFManifest>._, A<Models.Database.Collections.Manifest>._, A<CancellationToken>._))
+                A<IIIFManifest>._, A<Models.Database.Collections.Manifest>._, A<string>._, A<CancellationToken>._))
             .ReturnsLazily(() => new IIIFManifest { SeeAlso = [], Rendering = [], Annotations = [] });
 
         A.CallTo(() => dlcsClient.GetCustomerImages(Customer, A<string>._, A<CancellationToken>._))

--- a/src/IIIFPresentation/API.Tests/Features/Manifest/ManifestWriteServiceTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Manifest/ManifestWriteServiceTests.cs
@@ -801,7 +801,7 @@ public class ManifestWriteServiceTests
         await presentationContext.SaveChangesAsync();
 
         A.CallTo(() => manifestStorageManager.UpsertManifestInStorage(
-                A<IIIFManifest>._, A<Models.Database.Collections.Manifest>._, A<CancellationToken>._))
+                A<IIIFManifest>._, A<Models.Database.Collections.Manifest>._, A<string>._, A<CancellationToken>._))
             .ReturnsLazily(() => new IIIFManifest());
 
         const string existingAdjunctId = "existing-adjunct.xml";
@@ -833,7 +833,7 @@ public class ManifestWriteServiceTests
             .Which.Value<string>("id").Should().Be(existingAdjunctId,
                 "existing adjuncts from the DLCS stub asset must be returned when Adjuncts was null on the request");
         A.CallTo(() => manifestStorageManager.UpsertManifestInStorage(
-                A<IIIFManifest>._, A<Models.Database.Collections.Manifest>._, A<CancellationToken>._))
+                A<IIIFManifest>._, A<Models.Database.Collections.Manifest>._, A<string>._, A<CancellationToken>._))
             .MustHaveHappenedOnceExactly();
     }
 
@@ -862,7 +862,7 @@ public class ManifestWriteServiceTests
         result.Error.Should().BeNull();
         result.Entity.Adjuncts.Should().BeNull("no DLCS content exists so the stub asset has no adjuncts to return");
         A.CallTo(() => manifestStorageManager.UpsertManifestInStorage(
-                A<IIIFManifest>._, A<Models.Database.Collections.Manifest>._, A<CancellationToken>._))
+                A<IIIFManifest>._, A<Models.Database.Collections.Manifest>._, A<string>._, A<CancellationToken>._))
             .MustNotHaveHappened();
     }
 
@@ -887,7 +887,7 @@ public class ManifestWriteServiceTests
             ]));
 
         A.CallTo(() => manifestStorageManager.UpsertManifestInStorage(
-                A<IIIFManifest>._, A<Models.Database.Collections.Manifest>._, A<CancellationToken>._))
+                A<IIIFManifest>._, A<Models.Database.Collections.Manifest>._, A<string>._, A<CancellationToken>._))
             .ReturnsLazily(() => new IIIFManifest());
 
         var manifest = new PresentationManifest { Slug = slug, Adjuncts = [] };
@@ -902,7 +902,7 @@ public class ManifestWriteServiceTests
         result.Error.Should().BeNull();
         result.Entity.Adjuncts.Should().BeEmpty("Adjuncts=[] (explicit clear) is preserved — stub lookup finds no adjuncts so the value is unchanged");
         A.CallTo(() => manifestStorageManager.UpsertManifestInStorage(
-                A<IIIFManifest>._, A<Models.Database.Collections.Manifest>._, A<CancellationToken>._))
+                A<IIIFManifest>._, A<Models.Database.Collections.Manifest>._, A<string>._, A<CancellationToken>._))
             .MustHaveHappenedOnceExactly();
     }
 

--- a/src/IIIFPresentation/API.Tests/Features/Manifest/ManifestWriteServiceTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Manifest/ManifestWriteServiceTests.cs
@@ -174,8 +174,36 @@ public class ManifestWriteServiceTests
         var dbManifest = presentationContext.Manifests.Include(m => m.CanvasPaintings)
             .First(x => x.Id == ingestedManifest.Entity.FlatId);
         dbManifest.CanvasPaintings.Should().HaveCount(2);
+
+        // Saved to staging with an original payload stored - must not attempt to delete any original payload
+        A.CallTo(() => manifestStorageManager.DeleteOriginalPayload(
+            A<Models.Database.Collections.Manifest>._)).MustNotHaveHappened();
     }
-    
+
+    [Fact]
+    public async Task Create_DeletesStaleOriginalPayload_WhenSavedDirectlyWithoutExternalContent()
+    {
+        // Arrange - a plain manifest with no assets or adjuncts is built upfront and saved directly to S3
+        var (slug, resourceId) = TestIdentifiers.SlugResource();
+
+        var manifest = new PresentationManifest
+        {
+            Slug = slug,
+            Items = [new Canvas { Id = "https://base/0/canvases/canvas-1" }]
+        };
+
+        var request = new UpsertManifestRequest(resourceId, null, Customer, manifest, manifest.AsJson(), true);
+
+        // Act
+        var ingestedManifest = await sut.Create(request, CancellationToken.None);
+
+        // Assert
+        ingestedManifest.Should().NotBeNull();
+        ingestedManifest.Error.Should().BeNull();
+        A.CallTo(() => manifestStorageManager.DeleteOriginalPayload(
+            A<Models.Database.Collections.Manifest>._)).MustHaveHappenedOnceExactly();
+    }
+
     [Fact]
     public async Task Create_RecognizesDlcsAsset_WhenMixedItemsAndAssets()
     {

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestReadService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestReadService.cs
@@ -59,14 +59,14 @@ public class ManifestReadService(
         PresentationManifest? manifest = null;
         if (dbManifest.IsIngesting())
         {
-            manifest = await iiifS3.ReadIIIFFromS3<PresentationManifest>(dbManifest, true, cancellationToken);
+            manifest = await iiifS3.ReadIIIFFromS3<PresentationManifest>(dbManifest, BucketLocationType.Staging, cancellationToken);
             if (manifest == null)
                 logger.LogError("Manifest {DbManifestId} IsIngesting but can't read from staging", dbManifest.Id);
         }
 
         // if is not ingesting read from "real" location
         // or if not found in "staging", an error was logged and we fall back to "real"
-        manifest ??= await iiifS3.ReadIIIFFromS3<PresentationManifest>(dbManifest, false, cancellationToken);
+        manifest ??= await iiifS3.ReadIIIFFromS3<PresentationManifest>(dbManifest, BucketLocationType.Default, cancellationToken);
 
         dbManifest.Hierarchy.Single().FullPath = await fetchFullPath;
 

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
@@ -7,6 +7,7 @@ using API.Infrastructure.Helpers;
 using API.Infrastructure.IdGenerator;
 using Core;
 using Core.Auth;
+using Core.Helpers;
 using Core.IIIF;
 using DLCS.Exceptions;
 using Models.API.General;
@@ -408,9 +409,16 @@ public class ManifestWriteService(
     {
         var iiifManifest = request.RawRequestBody.ToManifest();
         
+        // When paintedResources were provided the JSON saved to S3 differs substantially from the original payload,
+        // and we will want to store it. Otherwise, we'll pass null not to store the raw request.
+        var orignalToStore = request.PresentationManifest.PaintedResources.IsNullOrEmpty()
+            ? null
+            : request.RawRequestBody;
+        
         if (canBeBuiltUpfront && hasAssets)
         {
-            var manifest = await manifestStorageManager.UpsertManifestInStorage(iiifManifest, dbManifest, cancellationToken);
+            var manifest = await manifestStorageManager.UpsertManifestInStorage(iiifManifest, dbManifest,
+                orignalToStore, cancellationToken);
             MergeManifestFields(manifest, request.PresentationManifest);
         }
         else
@@ -430,7 +438,7 @@ public class ManifestWriteService(
             }
 
             request.PresentationManifest.Items = iiifManifest.Items;
-            await manifestStorageManager.SaveManifestInStorage(iiifManifest, dbManifest, !canBeBuiltUpfront,
+            await manifestStorageManager.SaveManifestInStorage(iiifManifest, dbManifest, orignalToStore, !canBeBuiltUpfront,
                 cancellationToken);
         }
 

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
@@ -420,8 +420,6 @@ public class ManifestWriteService(
         }
         else
         {
-            // The Manifest can't be built upfront OR it can be built upfront and there are no assets or adjuncts
-            
             // There are assets that aren't tracked by the DLCS, so set provisional canvases while further processing
             // happens in the background handler
             if (hasAssets)
@@ -434,8 +432,15 @@ public class ManifestWriteService(
             }
             
             request.PresentationManifest.Items = iiifManifest.Items;
-            await manifestStorageManager.SaveManifestInStorage(iiifManifest, dbManifest, originalToStore, !canBeBuiltUpfront,
-                cancellationToken);
+            await manifestStorageManager.SaveManifestInStorage(iiifManifest, dbManifest, originalToStore,
+                !canBeBuiltUpfront, cancellationToken);
+
+            // Direct save (built upfront, no external content) with nothing to store as original:
+            // remove any stale original payload left by a previous version of this manifest.
+            if (originalToStore is null)
+            {
+                await manifestStorageManager.DeleteOriginalPayload(dbManifest);
+            }
         }
 
         await dbContext.SaveChangesAsync(cancellationToken);

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
@@ -401,42 +401,40 @@ public class ManifestWriteService(
     private async Task SaveToS3(DbManifest dbManifest, WriteManifestRequest request, bool canBeBuiltUpfront,
         CancellationToken cancellationToken)
     {
-        var iiifManifest = request.RawRequestBody.ToManifest();
-
-        // When paintedResources were provided the JSON saved to S3 differs substantially from the original payload,
-        // and we will want to store it. Otherwise, we'll pass null not to store the raw request.
-        var orignalToStore = request.PresentationManifest.PaintedResources.IsNullOrEmpty()
-            ? null
-            : request.RawRequestBody;
-        
-
+        var iiifManifest = request.RawRequestBody.ToManifest()!;
         var hasAssets = request.PresentationManifest.PaintedResources.HasAsset();
         var hasAdjuncts = request.PresentationManifest.Adjuncts != null;
 
-        if (canBeBuiltUpfront && (hasAssets || hasAdjuncts))
+        // When there is further work to do the JSON saved to S3 differs substantially from the original payload,
+        // and we will want to store it. Otherwise, we'll pass null not to store the raw request.
+        var requiresExternalContent = hasAssets || hasAdjuncts;
+
+        var originalToStore = requiresExternalContent ? request.RawRequestBody : null;
+
+        if (canBeBuiltUpfront && requiresExternalContent)
         {
+            logger.LogDebug("Manifest {Manifest} can be built upfront, after merging", dbManifest.Id);
             var manifest = await manifestStorageManager.UpsertManifestInStorage(iiifManifest, dbManifest,
-                orignalToStore, cancellationToken);
+                originalToStore, cancellationToken);
             MergeManifestFields(manifest, request.PresentationManifest);
         }
         else
         {
+            // The Manifest can't be built upfront OR it can be built upfront and there are no assets or adjuncts
+            
             // There are assets that aren't tracked by the DLCS, so set provisional canvases while further processing
             // happens in the background handler
             if (hasAssets)
             {
-                var canvasPaintings = dbManifest.CanvasPaintings;
+                logger.LogDebug("Manifest {Manifest} receiving ProvisionalCanvases", dbManifest.Id);
+                var canvasPaintings = dbManifest.CanvasPaintings.ThrowIfNull(nameof(dbManifest.CanvasPaintings));
 
-                if (canvasPaintings is not null)
-                {
-                    iiifManifest.Items =
-                        canvasPaintings.GenerateProvisionalCanvases(savedManifestPathGenerator, iiifManifest.Items,
-                            pathRewriteParser);
-                }
+                iiifManifest.Items = canvasPaintings.GenerateProvisionalCanvases(savedManifestPathGenerator,
+                    iiifManifest.Items, pathRewriteParser);
             }
-
+            
             request.PresentationManifest.Items = iiifManifest.Items;
-            await manifestStorageManager.SaveManifestInStorage(iiifManifest, dbManifest, orignalToStore, !canBeBuiltUpfront,
+            await manifestStorageManager.SaveManifestInStorage(iiifManifest, dbManifest, originalToStore, !canBeBuiltUpfront,
                 cancellationToken);
         }
 

--- a/src/IIIFPresentation/API/Features/Manifest/Requests/GetManifestHierarchical.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/Requests/GetManifestHierarchical.cs
@@ -27,17 +27,17 @@ public class GetManifestHierarchicalHandler(
     public async Task<IIIF.Presentation.V3.Manifest?> Handle(GetManifestHierarchical request,
         CancellationToken cancellationToken)
     {
-        var flatId = request.Hierarchy.ManifestId ??
+        var manifest = request.Hierarchy.Manifest ??
                      throw new InvalidOperationException(
                          "The differentiation of requests should prevent this from happening.");
 
-        if (!request.Hierarchy.Manifest!.LastProcessed.HasValue)
+        if (!manifest.LastProcessed.HasValue)
         {
             return null;
         }
 
         var objectFromS3 = await bucketReader.GetObjectFromBucket(
-            new(settings.S3.StorageBucket, BucketHelperX.GetManifestBucketKey(request.Hierarchy.CustomerId, flatId)),
+            new(settings.S3.StorageBucket, manifest.GetResourceBucketKey()),
             cancellationToken);
 
         if (objectFromS3.Stream.IsNull()) return null;

--- a/src/IIIFPresentation/API/Features/Storage/CollectionController.cs
+++ b/src/IIIFPresentation/API/Features/Storage/CollectionController.cs
@@ -41,10 +41,8 @@ public class CollectionController(
 
         var orderByField = this.GetOrderBy(orderBy, orderByDescending, out var descending);
 
-        var entityResult =
-            await Mediator.Send(new GetCollection(customerId, id, Request.Headers.IfNoneMatch.AsETagValues(), page.Value,
-                pageSize.Value, orderByField,
-                descending));
+        var entityResult = await Mediator.Send(new GetCollection(id, Request.Headers.IfNoneMatch.AsETagValues(),
+            page.Value, pageSize.Value, orderByField, descending));
 
         if (entityResult.ETagMatch)
             return new NotModifiedResult(entityResult.ETag!.Value);

--- a/src/IIIFPresentation/API/Features/Storage/Requests/GetCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/GetCollection.cs
@@ -18,7 +18,6 @@ using Services.Manifests.Helpers;
 namespace API.Features.Storage.Requests;
 
 public class GetCollection(
-    int customerId,
     string id,
     IImmutableSet<Guid> eTags,
     int page,
@@ -26,8 +25,6 @@ public class GetCollection(
     string? orderBy = null,
     bool descending = false) : IRequest<FetchEntityResult<PresentationCollection>>
 {
-    public int CustomerId { get; } = customerId;
-
     public string Id { get; } = id;
 
     public IImmutableSet<Guid> IfNoneMatch { get; } = eTags;
@@ -94,7 +91,7 @@ public class GetCollectionHandler(PresentationContext dbContext, IIIIFS3Service 
         }
 
         var s3Collection =
-            await iiifS3.ReadIIIFFromS3<PresentationCollection>(collection.GetResourceBucketKey(),
+            await iiifS3.ReadIIIFFromS3<PresentationCollection>(collection, BucketLocationType.Default,
                 cancellationToken);
 
         if (s3Collection is null) return FetchEntityResult<PresentationCollection>.NotFound();

--- a/src/IIIFPresentation/API/Program.cs
+++ b/src/IIIFPresentation/API/Program.cs
@@ -9,6 +9,7 @@ using API.Infrastructure.Http.CorrelationId;
 using API.Infrastructure.Http.Redirect;
 using API.Paths;
 using API.Settings;
+using Core.Settings;
 using DLCS;
 using FluentValidation;
 using Microsoft.AspNetCore.HttpOverrides;
@@ -45,6 +46,8 @@ builder.Services.AddControllers().AddNewtonsoftJson(options =>
 builder.Services.AddValidatorsFromAssemblyContaining<Program>();
 
 builder.Services.AddOptions<ApiSettings>()
+    .BindConfiguration(string.Empty);
+builder.Services.AddOptions<BehaviourSettings>()
     .BindConfiguration(string.Empty);
 builder.Services.AddOptions<CacheSettings>()
     .BindConfiguration(nameof(CacheSettings));

--- a/src/IIIFPresentation/AWS.Tests/Helpers/BucketHelperTests.cs
+++ b/src/IIIFPresentation/AWS.Tests/Helpers/BucketHelperTests.cs
@@ -5,30 +5,36 @@ namespace AWS.Tests.Helpers;
 
 public class BucketHelperTests
 {
-    [Fact]
-    public void GetResourceBucketKey_Collection_Correct()
+    [Theory]
+    [InlineData(BucketLocationType.Default, "99/collections/parting-ways")]
+    [InlineData(BucketLocationType.Staging, "staging/99/collections/parting-ways")]
+    [InlineData(BucketLocationType.Original, "99/collections/parting-ways/original")]
+    [InlineData(BucketLocationType.OriginalStaging, "staging/99/collections/parting-ways/original")]
+    public void GetResourceBucketKey_Collection_Correct(BucketLocationType locationType, string expected)
     {
         // Arrange
         var collection = new Models.Database.Collections.Collection { CustomerId = 99, Id = "parting-ways" };
-        const string expected = "99/collections/parting-ways";
-        
+
         // Act
-        var actual = collection.GetResourceBucketKey();
-        
+        var actual = collection.GetResourceBucketKey(locationType);
+
         // Assert
         actual.Should().Be(expected);
     }
-    
-    [Fact]
-    public void GetResourceBucketKey_Manifest_Correct()
+
+    [Theory]
+    [InlineData(BucketLocationType.Default, "99/manifests/parting-ways")]
+    [InlineData(BucketLocationType.Staging, "staging/99/manifests/parting-ways")]
+    [InlineData(BucketLocationType.Original, "99/manifests/parting-ways/original")]
+    [InlineData(BucketLocationType.OriginalStaging, "staging/99/manifests/parting-ways/original")]
+    public void GetResourceBucketKey_Manifest_Correct(BucketLocationType locationType, string expected)
     {
         // Arrange
-        var collection = new Models.Database.Collections.Manifest { CustomerId = 99, Id = "parting-ways" };
-        const string expected = "99/manifests/parting-ways";
-        
+        var manifest = new Models.Database.Collections.Manifest { CustomerId = 99, Id = "parting-ways" };
+
         // Act
-        var actual = collection.GetResourceBucketKey();
-        
+        var actual = manifest.GetResourceBucketKey(locationType);
+
         // Assert
         actual.Should().Be(expected);
     }

--- a/src/IIIFPresentation/AWS/Helpers/BucketHelperX.cs
+++ b/src/IIIFPresentation/AWS/Helpers/BucketHelperX.cs
@@ -1,4 +1,4 @@
-﻿using Models.Database.Collections;
+using Models.Database.Collections;
 
 namespace AWS.Helpers;
 
@@ -8,7 +8,7 @@ public static class BucketHelperX
     private const string CollectionsSlug = "collections";
 
     /// <summary>
-    ///     Get key where this resource will be stored in S3
+    /// Get key where this resource will be stored in S3
     /// </summary>
     public static string GetResourceBucketKey<T>(this T hierarchyResource, BucketLocationType locationType = BucketLocationType.Default)
         where T : IHierarchyResource
@@ -17,24 +17,26 @@ public static class BucketHelperX
         return GetResourceBucketKey(hierarchyResource.CustomerId, slug, hierarchyResource.Id, locationType);
     }
 
-    /// <summary>
-    ///     Get key where manifest with given id will be stored in S3 for provided customer
-    /// </summary>
-    public static string GetManifestBucketKey(int customerId, string flatId, BucketLocationType locationType = BucketLocationType.Default)
-        => GetResourceBucketKey(customerId, ManifestsSlug, flatId, locationType);
-
     private static string GetResourceBucketKey(int customerId, string slug, string flatId, BucketLocationType locationType = BucketLocationType.Default)
-        => $"{GetPrefixForLocationType(locationType)}{customerId}/{slug}/{flatId}";
-
-    private static string GetPrefixForLocationType(BucketLocationType locationType) => locationType switch
     {
-        BucketLocationType.Default => string.Empty,
-        BucketLocationType.Staging => "staging/",
-        BucketLocationType.Original => "original/",
-        BucketLocationType.OriginalStaging => "original-staging/",
-        _ => throw new ArgumentOutOfRangeException(nameof(locationType), locationType,
-            "Unknown location type, cannot determine bucket prefix")
-    };
+        var (prefix, suffix) = GetAffixesForLocationType(locationType);
+        return $"{prefix}{customerId}/{slug}/{flatId}{suffix}";
+    }
+
+    private static (string Prefix, string Suffix) GetAffixesForLocationType(BucketLocationType locationType)
+    {
+        const string stagingPrefix = "staging/";
+        const string originalSuffix = "/original";
+        return locationType switch
+        {
+            BucketLocationType.Default => (string.Empty, string.Empty),
+            BucketLocationType.Staging => (stagingPrefix, string.Empty),
+            BucketLocationType.Original => (string.Empty, originalSuffix),
+            BucketLocationType.OriginalStaging => (stagingPrefix, originalSuffix),
+            _ => throw new ArgumentOutOfRangeException(nameof(locationType), locationType,
+                "Unknown location type, cannot determine bucket affixes")
+        };
+    }
 }
 
 /// <summary>
@@ -46,17 +48,17 @@ public enum BucketLocationType
     /// Default, this is the main entity storage
     /// </summary>
     Default,
-    
+
     /// <summary>
     /// If background processing is required, the entity (e.g. manifest) is stored to a staging location until processing finishes
     /// </summary>
     Staging,
-    
+
     /// <summary>
     /// For storing the original payload for any future use
     /// </summary>
     Original,
-    
+
     /// <summary>
     /// For storing the original payload in a background processing scenario
     /// </summary>

--- a/src/IIIFPresentation/AWS/Helpers/BucketHelperX.cs
+++ b/src/IIIFPresentation/AWS/Helpers/BucketHelperX.cs
@@ -10,19 +10,55 @@ public static class BucketHelperX
     /// <summary>
     ///     Get key where this resource will be stored in S3
     /// </summary>
-    public static string GetResourceBucketKey<T>(this T hierarchyResource, bool staging = false)
+    public static string GetResourceBucketKey<T>(this T hierarchyResource, BucketLocationType locationType = BucketLocationType.Default)
         where T : IHierarchyResource
     {
         var slug = hierarchyResource is Manifest ? ManifestsSlug : CollectionsSlug;
-        return GetResourceBucketKey(hierarchyResource.CustomerId, slug, hierarchyResource.Id, staging);
+        return GetResourceBucketKey(hierarchyResource.CustomerId, slug, hierarchyResource.Id, locationType);
     }
 
     /// <summary>
     ///     Get key where manifest with given id will be stored in S3 for provided customer
     /// </summary>
-    public static string GetManifestBucketKey(int customerId, string flatId, bool staging = false)
-        => GetResourceBucketKey(customerId, ManifestsSlug, flatId);
+    public static string GetManifestBucketKey(int customerId, string flatId, BucketLocationType locationType = BucketLocationType.Default)
+        => GetResourceBucketKey(customerId, ManifestsSlug, flatId, locationType);
 
-    private static string GetResourceBucketKey(int customerId, string slug, string flatId, bool staging = false)
-        => $"{(staging ? "staging/" : string.Empty)}{customerId}/{slug}/{flatId}";
+    private static string GetResourceBucketKey(int customerId, string slug, string flatId, BucketLocationType locationType = BucketLocationType.Default)
+        => $"{GetPrefixForLocationType(locationType)}{customerId}/{slug}/{flatId}";
+
+    private static string GetPrefixForLocationType(BucketLocationType locationType) => locationType switch
+    {
+        BucketLocationType.Default => string.Empty,
+        BucketLocationType.Staging => "staging/",
+        BucketLocationType.Original => "original/",
+        BucketLocationType.OriginalStaging => "original-staging/",
+        _ => throw new ArgumentOutOfRangeException(nameof(locationType), locationType,
+            "Unknown location type, cannot determine bucket prefix")
+    };
+}
+
+/// <summary>
+/// Allows determining the correct location of the resource in the S3 for read/write, based on the reason of storing.
+/// </summary>
+public enum BucketLocationType
+{
+    /// <summary>
+    /// Default, this is the main entity storage
+    /// </summary>
+    Default,
+    
+    /// <summary>
+    /// If background processing is required, the entity (e.g. manifest) is stored to a staging location until processing finishes
+    /// </summary>
+    Staging,
+    
+    /// <summary>
+    /// For storing the original payload for any future use
+    /// </summary>
+    Original,
+    
+    /// <summary>
+    /// For storing the original payload in a background processing scenario
+    /// </summary>
+    OriginalStaging
 }

--- a/src/IIIFPresentation/AWS/Helpers/IIIFS3Service.cs
+++ b/src/IIIFPresentation/AWS/Helpers/IIIFS3Service.cs
@@ -29,6 +29,8 @@ public interface IIIIFS3Service
     public Task SaveToS3(IHierarchyResource dbResource, BucketLocationType locationType,
         string iiifJson, CancellationToken cancellationToken);
 
+    public Task DeleteFromS3(IHierarchyResource dbResource, BucketLocationType locationType);
+
     public Task<Stream?> ReadStreamFromS3(IHierarchyResource dbResource,
         BucketLocationType locationType, CancellationToken cancellationToken);
 }
@@ -91,6 +93,16 @@ public class IIIFS3Service(
         var item = new ObjectInBucket(options.CurrentValue.S3.StorageBucket,
             dbResource.GetResourceBucketKey(locationType));
         await bucketWriter.WriteToBucket(item, iiifJson, "application/json", cancellationToken);
+    }
+
+    /// <summary>
+    /// Delete a single resource from S3 at the specified location
+    /// </summary>
+    public Task DeleteFromS3(IHierarchyResource dbResource, BucketLocationType locationType)
+    {
+        var item = new ObjectInBucket(options.CurrentValue.S3.StorageBucket,
+            dbResource.GetResourceBucketKey(locationType));
+        return bucketWriter.DeleteFromBucket(item);
     }
 
     /// <summary>

--- a/src/IIIFPresentation/AWS/Helpers/IIIFS3Service.cs
+++ b/src/IIIFPresentation/AWS/Helpers/IIIFS3Service.cs
@@ -105,10 +105,10 @@ public class IIIFS3Service(
             dbResource.GetResourceBucketKey(fromStaging ? BucketLocationType.Staging : BucketLocationType.Default));
         var deleteTask = bucketWriter.DeleteFromBucket(item);
         
-        if (dbResource.Created >= behaviour.CurrentValue.StoresPayloadsSince)
+        if (behaviour.CurrentValue.ShouldHaveStoredOriginal(dbResource.Created))
         {
             var originalItem =  new ObjectInBucket(options.CurrentValue.S3.StorageBucket,
-                dbResource.GetResourceBucketKey(BucketLocationType.Original));
+                dbResource.GetResourceBucketKey(fromStaging ? BucketLocationType.OriginalStaging : BucketLocationType.Original));
             await bucketWriter.DeleteFromBucket(originalItem);
         }
         

--- a/src/IIIFPresentation/AWS/Helpers/IIIFS3Service.cs
+++ b/src/IIIFPresentation/AWS/Helpers/IIIFS3Service.cs
@@ -15,24 +15,39 @@ namespace AWS.Helpers;
 
 public interface IIIIFS3Service
 {
+    /// <summary>
+    /// Read IIIF resource from S3
+    /// </summary>
     public Task<T?> ReadIIIFFromS3<T>(IHierarchyResource dbResource, BucketLocationType locationType,
         CancellationToken cancellationToken) where T : ResourceBase, new();
 
-    public Task<T?> ReadIIIFFromS3<T>(string bucketKey, CancellationToken cancellationToken)
-        where T : ResourceBase, new();
-
+    /// <summary>
+    /// Write IIIF resource to S3 - ensuring @context and Id set. Saved valud is iiifResource.AsJson()
+    /// </summary>
     public Task SaveIIIFToS3(ResourceBase iiifResource, IHierarchyResource dbResource, string flatId,
         bool saveToStaging, CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Delete IIIF resource from S3
+    /// </summary>
     public Task DeleteIIIFFromS3(IHierarchyResource dbResource, bool fromStaging = false);
 
+    /// <summary>
+    /// Write provided iiifJson string to S3
+    /// </summary>
     public Task SaveToS3(IHierarchyResource dbResource, BucketLocationType locationType,
         string iiifJson, CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Delete a single resource from S3 at the specified location
+    /// </summary>
     public Task DeleteFromS3(IHierarchyResource dbResource, BucketLocationType locationType);
 
-    public Task<Stream?> ReadStreamFromS3(IHierarchyResource dbResource,
-        BucketLocationType locationType, CancellationToken cancellationToken);
+    /// <summary>
+    /// Read IIIF resource from S3 as stream
+    /// </summary>
+    public Task<Stream?> ReadStreamFromS3(IHierarchyResource dbResource, BucketLocationType locationType,
+        CancellationToken cancellationToken);
 }
 
 /// <summary>
@@ -45,39 +60,29 @@ public class IIIFS3Service(
     IOptionsMonitor<AWSSettings> options,
     IOptionsMonitor<BehaviourSettings> behaviour) : IIIIFS3Service
 {
-    public Task<T?> ReadIIIFFromS3<T>(IHierarchyResource dbResource,
-       BucketLocationType locationType, CancellationToken cancellationToken) where T : ResourceBase, new() =>
-        ReadIIIFFromS3<T>(dbResource.GetResourceBucketKey(locationType), cancellationToken);
-    
+    public async Task<T?> ReadIIIFFromS3<T>(IHierarchyResource dbResource,
+        BucketLocationType locationType, CancellationToken cancellationToken) where T : ResourceBase, new()
+    {
+        var bucketKey = dbResource.GetResourceBucketKey(locationType);
+        var stream = await ReadStreamFromS3(bucketKey, cancellationToken);
+        if (stream == null) return null;
+
+        return await stream.ToPresentation<T>(logger: logger);
+    }
+
     public Task<Stream?> ReadStreamFromS3(IHierarchyResource dbResource,
         BucketLocationType locationType, CancellationToken cancellationToken) =>
         ReadStreamFromS3(dbResource.GetResourceBucketKey(locationType), cancellationToken);
 
-    public async Task<T?> ReadIIIFFromS3<T>(string bucketKey,
-        CancellationToken cancellationToken) where T : ResourceBase, new()
-    {
-        var stream = await ReadStreamFromS3(bucketKey, cancellationToken);
-        if (stream == null) return null;
-        
-        return await stream.ToPresentation<T>(logger: logger);
-    }
-    
-    public async Task<Stream?> ReadStreamFromS3(string bucketKey,
+    private async Task<Stream?> ReadStreamFromS3(string bucketKey,
         CancellationToken cancellationToken)
     {
         var item = new ObjectInBucket(options.CurrentValue.S3.StorageBucket, bucketKey);
-        var objectFromBucket = await bucketReader.GetObjectFromBucket(item
-            , cancellationToken);
+        var objectFromBucket = await bucketReader.GetObjectFromBucket(item, cancellationToken);
 
-        if (objectFromBucket.Stream.IsNull())
-            return null;
-
-        return objectFromBucket.Stream;
+        return objectFromBucket.Stream.IsNull() ? null : objectFromBucket.Stream;
     }
     
-    /// <summary>
-    /// Write IIIF resource to S3 - ensuring @context and Id set
-    /// </summary>
     public async Task SaveIIIFToS3(ResourceBase iiifResource, IHierarchyResource dbResource, string flatId,
         bool saveToStaging, CancellationToken cancellationToken)
     {
@@ -89,43 +94,37 @@ public class IIIFS3Service(
 
      public async Task SaveToS3(IHierarchyResource dbResource, BucketLocationType locationType,
         string iiifJson, CancellationToken cancellationToken)
-    {
-        var item = new ObjectInBucket(options.CurrentValue.S3.StorageBucket,
-            dbResource.GetResourceBucketKey(locationType));
+     {
+         var item = new ObjectInBucket(options.CurrentValue.S3.StorageBucket,
+             dbResource.GetResourceBucketKey(locationType));
         await bucketWriter.WriteToBucket(item, iiifJson, "application/json", cancellationToken);
     }
-
-    /// <summary>
-    /// Delete a single resource from S3 at the specified location
-    /// </summary>
+     
     public Task DeleteFromS3(IHierarchyResource dbResource, BucketLocationType locationType)
     {
         var item = new ObjectInBucket(options.CurrentValue.S3.StorageBucket,
             dbResource.GetResourceBucketKey(locationType));
         return bucketWriter.DeleteFromBucket(item);
     }
-
-    /// <summary>
-    /// Delete IIIF resource from S3
-    /// </summary>
+    
     public async Task DeleteIIIFFromS3(IHierarchyResource dbResource, bool fromStaging = false)
     {
         logger.LogDebug("Deleting resource {Customer}:{ResourceId} file from S3{StagingIndicator}",
             dbResource.CustomerId, dbResource.Id, fromStaging ? "[staging]" : string.Empty);
         var item = new ObjectInBucket(options.CurrentValue.S3.StorageBucket,
             dbResource.GetResourceBucketKey(fromStaging ? BucketLocationType.Staging : BucketLocationType.Default));
-        var deleteTask = bucketWriter.DeleteFromBucket(item);
-        
+        var deleteTasks = new List<Task>(2) { bucketWriter.DeleteFromBucket(item) };
+
         if (behaviour.CurrentValue.ShouldHaveStoredOriginal(dbResource.Created))
         {
             var originalItem = new ObjectInBucket(options.CurrentValue.S3.StorageBucket,
                 dbResource.GetResourceBucketKey(fromStaging
                     ? BucketLocationType.OriginalStaging
                     : BucketLocationType.Original));
-            await bucketWriter.DeleteFromBucket(originalItem);
+            deleteTasks.Add(bucketWriter.DeleteFromBucket(originalItem));
         }
         
-        await deleteTask;
+        await Task.WhenAll(deleteTasks);
     }
 
     private static void EnsureIIIFValid(ResourceBase iiifResource, string flatId)

--- a/src/IIIFPresentation/AWS/Helpers/IIIFS3Service.cs
+++ b/src/IIIFPresentation/AWS/Helpers/IIIFS3Service.cs
@@ -2,6 +2,7 @@
 using AWS.S3.Models;
 using AWS.Settings;
 using Core.IIIF;
+using Core.Settings;
 using Core.Streams;
 using IIIF.Presentation;
 using IIIF.Presentation.V3;
@@ -14,7 +15,7 @@ namespace AWS.Helpers;
 
 public interface IIIIFS3Service
 {
-    public Task<T?> ReadIIIFFromS3<T>(IHierarchyResource dbResource, bool fromStaging,
+    public Task<T?> ReadIIIFFromS3<T>(IHierarchyResource dbResource, BucketLocationType locationType,
         CancellationToken cancellationToken) where T : ResourceBase, new();
 
     public Task<T?> ReadIIIFFromS3<T>(string bucketKey, CancellationToken cancellationToken)
@@ -24,6 +25,12 @@ public interface IIIIFS3Service
         bool saveToStaging, CancellationToken cancellationToken);
 
     public Task DeleteIIIFFromS3(IHierarchyResource dbResource, bool fromStaging = false);
+
+    Task SaveToS3(IHierarchyResource dbResource, BucketLocationType locationType,
+        string iiifJson, CancellationToken cancellationToken);
+
+    Task<Stream?> ReadStreamFromS3(IHierarchyResource dbResource,
+        BucketLocationType locationType, CancellationToken cancellationToken);
 }
 
 /// <summary>
@@ -33,15 +40,29 @@ public class IIIFS3Service(
     IBucketWriter bucketWriter,
     IBucketReader bucketReader,
     ILogger<IIIFS3Service> logger,
-    IOptionsMonitor<AWSSettings> options) : IIIIFS3Service
+    IOptionsMonitor<AWSSettings> options,
+    IOptionsMonitor<BehaviourSettings> behaviour) : IIIIFS3Service
 {
     public Task<T?> ReadIIIFFromS3<T>(IHierarchyResource dbResource,
-        bool fromStaging,
-        CancellationToken cancellationToken) where T : ResourceBase, new() =>
-        ReadIIIFFromS3<T>(dbResource.GetResourceBucketKey(fromStaging), cancellationToken);
+       BucketLocationType locationType, CancellationToken cancellationToken) where T : ResourceBase, new() =>
+        ReadIIIFFromS3<T>(dbResource.GetResourceBucketKey(locationType), cancellationToken);
+    
+    public Task<Stream?> ReadStreamFromS3(IHierarchyResource dbResource,
+        BucketLocationType locationType, CancellationToken cancellationToken) =>
+        ReadStreamFromS3(dbResource.GetResourceBucketKey(locationType), cancellationToken);
 
     public async Task<T?> ReadIIIFFromS3<T>(string bucketKey,
         CancellationToken cancellationToken) where T : ResourceBase, new()
+    {
+        var stream = await ReadStreamFromS3(bucketKey, cancellationToken);
+        if (stream == null)
+            return null;
+        
+        return await stream.ToPresentation<T>(logger: logger);
+    }
+    
+    public async Task<Stream?> ReadStreamFromS3(string bucketKey,
+        CancellationToken cancellationToken)
     {
         var item = new ObjectInBucket(options.CurrentValue.S3.StorageBucket, bucketKey);
         var objectFromBucket = await bucketReader.GetObjectFromBucket(item
@@ -50,7 +71,7 @@ public class IIIFS3Service(
         if (objectFromBucket.Stream.IsNull())
             return null;
 
-        return await objectFromBucket.Stream.ToPresentation<T>(logger: logger);
+        return objectFromBucket.Stream;
     }
     
     /// <summary>
@@ -62,11 +83,17 @@ public class IIIFS3Service(
         logger.LogDebug("Uploading resource {Customer}:{ResourceId} file to S3", dbResource.CustomerId, dbResource.Id);
         EnsureIIIFValid(iiifResource, flatId);
         var iiifJson = iiifResource.AsJson();
+        await SaveToS3(dbResource, saveToStaging ? BucketLocationType.Staging : BucketLocationType.Default, iiifJson, cancellationToken);
+    }
+
+     public async Task SaveToS3(IHierarchyResource dbResource, BucketLocationType locationType,
+        string iiifJson, CancellationToken cancellationToken)
+    {
         var item = new ObjectInBucket(options.CurrentValue.S3.StorageBucket,
-            dbResource.GetResourceBucketKey(saveToStaging));
+            dbResource.GetResourceBucketKey(locationType));
         await bucketWriter.WriteToBucket(item, iiifJson, "application/json", cancellationToken);
     }
-    
+
     /// <summary>
     /// Delete IIIF resource from S3
     /// </summary>
@@ -75,8 +102,17 @@ public class IIIFS3Service(
         logger.LogDebug("Deleting resource {Customer}:{ResourceId} file from S3{StagingIndicator}",
             dbResource.CustomerId, dbResource.Id, fromStaging ? "[staging]" : string.Empty);
         var item = new ObjectInBucket(options.CurrentValue.S3.StorageBucket,
-            dbResource.GetResourceBucketKey(fromStaging));
-        await bucketWriter.DeleteFromBucket(item);
+            dbResource.GetResourceBucketKey(fromStaging ? BucketLocationType.Staging : BucketLocationType.Default));
+        var deleteTask = bucketWriter.DeleteFromBucket(item);
+        
+        if (dbResource.Created >= behaviour.CurrentValue.StoresPayloadsSince)
+        {
+            var originalItem =  new ObjectInBucket(options.CurrentValue.S3.StorageBucket,
+                dbResource.GetResourceBucketKey(BucketLocationType.Original));
+            await bucketWriter.DeleteFromBucket(originalItem);
+        }
+        
+        await deleteTask;
     }
 
     private static void EnsureIIIFValid(ResourceBase iiifResource, string flatId)

--- a/src/IIIFPresentation/AWS/Helpers/IIIFS3Service.cs
+++ b/src/IIIFPresentation/AWS/Helpers/IIIFS3Service.cs
@@ -106,8 +106,10 @@ public class IIIFS3Service(
         
         if (behaviour.CurrentValue.ShouldHaveStoredOriginal(dbResource.Created))
         {
-            var originalItem =  new ObjectInBucket(options.CurrentValue.S3.StorageBucket,
-                dbResource.GetResourceBucketKey(fromStaging ? BucketLocationType.OriginalStaging : BucketLocationType.Original));
+            var originalItem = new ObjectInBucket(options.CurrentValue.S3.StorageBucket,
+                dbResource.GetResourceBucketKey(fromStaging
+                    ? BucketLocationType.OriginalStaging
+                    : BucketLocationType.Original));
             await bucketWriter.DeleteFromBucket(originalItem);
         }
         

--- a/src/IIIFPresentation/AWS/Helpers/IIIFS3Service.cs
+++ b/src/IIIFPresentation/AWS/Helpers/IIIFS3Service.cs
@@ -26,10 +26,10 @@ public interface IIIIFS3Service
 
     public Task DeleteIIIFFromS3(IHierarchyResource dbResource, bool fromStaging = false);
 
-    Task SaveToS3(IHierarchyResource dbResource, BucketLocationType locationType,
+    public Task SaveToS3(IHierarchyResource dbResource, BucketLocationType locationType,
         string iiifJson, CancellationToken cancellationToken);
 
-    Task<Stream?> ReadStreamFromS3(IHierarchyResource dbResource,
+    public Task<Stream?> ReadStreamFromS3(IHierarchyResource dbResource,
         BucketLocationType locationType, CancellationToken cancellationToken);
 }
 
@@ -55,8 +55,7 @@ public class IIIFS3Service(
         CancellationToken cancellationToken) where T : ResourceBase, new()
     {
         var stream = await ReadStreamFromS3(bucketKey, cancellationToken);
-        if (stream == null)
-            return null;
+        if (stream == null) return null;
         
         return await stream.ToPresentation<T>(logger: logger);
     }

--- a/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionMessageHandlerTests.cs
+++ b/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionMessageHandlerTests.cs
@@ -200,7 +200,7 @@ public class BatchCompletionMessageHandlerTests
         const int space = 2;
         var flatId = $"https://localhost:5000/1/manifests/{manifestId}";
 
-        A.CallTo(() => iiifS3.ReadIIIFFromS3<IIIFManifest>(A<IHierarchyResource>._, true, A<CancellationToken>._))
+        A.CallTo(() => iiifS3.ReadIIIFFromS3<IIIFManifest>(A<IHierarchyResource>._, BucketLocationType.Staging, A<CancellationToken>._))
             .ReturnsLazily(() => new IIIFManifest
             {
                 Id = identifier
@@ -314,7 +314,7 @@ public class BatchCompletionMessageHandlerTests
         var (identifier, canvasPaintingId) = TestIdentifiers.IdCanvasPainting();
         const int space = 3;
 
-        A.CallTo(() => iiifS3.ReadIIIFFromS3<IIIFManifest>(A<IHierarchyResource>._, true, A<CancellationToken>._))
+        A.CallTo(() => iiifS3.ReadIIIFFromS3<IIIFManifest>(A<IHierarchyResource>._, BucketLocationType.Staging, A<CancellationToken>._))
             .ReturnsLazily(() => (IIIFManifest?)null);
 
         var manifestEntityEntry = await dbContext.Manifests.AddTestManifest(identifier, batchId: batchId);
@@ -352,7 +352,7 @@ public class BatchCompletionMessageHandlerTests
         var batchId = TestIdentifiers.BatchId();
         var flatId = $"https://localhost:5000/1/manifests/{identifier}";
 
-        A.CallTo(() => iiifS3.ReadIIIFFromS3<IIIFManifest>(A<IHierarchyResource>._, true, A<CancellationToken>._))
+        A.CallTo(() => iiifS3.ReadIIIFFromS3<IIIFManifest>(A<IHierarchyResource>._, BucketLocationType.Staging, A<CancellationToken>._))
             .ReturnsLazily(() => new IIIFManifest
             {
                 Id = identifier

--- a/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionMessageHandlerTests.cs
+++ b/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionMessageHandlerTests.cs
@@ -195,6 +195,7 @@ public class BatchCompletionMessageHandlerTests
     [InlineData(DeliverableType.Asset, true)]
     [InlineData(DeliverableType.Asset, false)]
     [InlineData(DeliverableType.Adjunct, false)]
+    [InlineData(DeliverableType.Adjunct, true)]
     public async Task HandleMessage_SavesResultingManifest_ToS3(DeliverableType deliverableType, bool storeOriginal)
     {
         // Arrange

--- a/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionMessageHandlerTests.cs
+++ b/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionMessageHandlerTests.cs
@@ -1,4 +1,5 @@
-﻿using AWS.Helpers;
+﻿using System.Text;
+using AWS.Helpers;
 using AWS.SQS;
 using BackgroundHandler.BatchCompletion;
 using BackgroundHandler.Infrastructure;
@@ -39,6 +40,7 @@ public class BatchCompletionMessageHandlerTests
     private readonly BatchCompletionMessageHandler sut;
     private readonly IDlcsOrchestratorClient dlcsClient;
     private readonly IIIIFS3Service iiifS3;
+    private readonly BehaviourSettings behaviour = new();
     private readonly PathSettings pathSettings;
     private const int CustomerId = 1;
     private const int AlternativeCustomer = 10;
@@ -69,7 +71,7 @@ public class BatchCompletionMessageHandlerTests
             new PathRewriteParser(Options.Create(PathRewriteOptions.Default), new NullLogger<PathRewriteParser>());
         
         var manifestMerger = new ManifestMerger(pathGenerator, pathRewriteParser, new NullLogger<ManifestMerger>());
-        var manifestS3Manager = new ManifestS3Manager(iiifS3, pathGenerator, dlcsClient, manifestMerger, new TestOptionsMonitor<BehaviourSettings>(new BehaviourSettings()),
+        var manifestS3Manager = new ManifestS3Manager(iiifS3, pathGenerator, dlcsClient, manifestMerger, new TestOptionsMonitor<BehaviourSettings>(behaviour),
             new NullLogger<ManifestS3Manager>());
         var customerIdProvider = new SetCustomerIdProvider();
 
@@ -188,18 +190,38 @@ public class BatchCompletionMessageHandlerTests
         batch.Status.Should().Be(BatchStatus.Completed);
         batch.Processed.Should().Be(processedDate, "Process date hasn't changed");
     }
-
+    
     [Theory]
-    [InlineData(DeliverableType.Asset)]
-    [InlineData(DeliverableType.Adjunct)]
-    public async Task HandleMessage_SavesResultingManifest_ToS3(DeliverableType deliverableType)
+    [InlineData(DeliverableType.Asset, true)]
+    [InlineData(DeliverableType.Asset, true)]
+    [InlineData(DeliverableType.Adjunct, false)]
+    public async Task HandleMessage_SavesResultingManifest_ToS3(DeliverableType deliverableType, bool storeOriginal)
     {
         // Arrange
+        var uniqueName = $"{nameof(HandleMessage_SavesResultingManifest_ToS3)}{storeOriginal.ToString()}";
         var batchId = TestIdentifiers.BatchId();
-        var (identifier, canvasPaintingId) = TestIdentifiers.IdCanvasPainting();
+        var (identifier, canvasPaintingId) = TestIdentifiers.IdCanvasPainting(uniqueName);
         var manifestId = TestIdentifiers.IdWithSuffix(suffix: deliverableType.ToString());
         const int space = 2;
         var flatId = $"https://localhost:5000/1/manifests/{manifestId}";
+
+        if (storeOriginal)
+        {
+            // Testing with stored original, setup mock for reading original-staging
+            A.CallTo(() =>
+                    iiifS3.ReadStreamFromS3(A<IHierarchyResource>._, BucketLocationType.OriginalStaging,
+                        A<CancellationToken>._))
+                .ReturnsLazily(() =>
+                {
+                    var data = Encoding.UTF8.GetBytes(uniqueName);
+                    return new MemoryStream(data);
+                });
+        }
+        else
+        {
+            // Testing as pre-store-originals, set a future date to disable this behaviour
+            behaviour.StoresPayloadsSince = DateTimeOffset.Now.AddMonths(1);
+        }
 
         A.CallTo(() => iiifS3.ReadIIIFFromS3<IIIFManifest>(A<IHierarchyResource>._, BucketLocationType.Staging, A<CancellationToken>._))
             .ReturnsLazily(() => new IIIFManifest
@@ -233,6 +255,18 @@ public class BatchCompletionMessageHandlerTests
         A.CallTo(() => iiifS3.SaveIIIFToS3(A<ResourceBase>._, A<Manifest>.That.Matches(m => m.Id == manifestId),
                 flatId, false, A<CancellationToken>._))
             .MustHaveHappened(1, Times.Exactly);
+        
+        if (storeOriginal)
+        {
+            A.CallTo(() => iiifS3.SaveToS3(A<IHierarchyResource>._, BucketLocationType.Original, A<string>._,  A<CancellationToken>._))
+                .MustHaveHappened(1, Times.Exactly);
+        }
+        else
+        {
+            A.CallTo(() => iiifS3.SaveToS3(A<IHierarchyResource>._, BucketLocationType.Original, A<string>._,  A<CancellationToken>._))
+                .MustNotHaveHappened();
+        }
+        
         var savedManifest = (IIIFManifest)resourceBase!;
         var expectedCanvasId = $"https://localhost:5000/1/canvases/{canvasPaintingId}";
         var firstCanvas = savedManifest.Items![0];
@@ -314,7 +348,7 @@ public class BatchCompletionMessageHandlerTests
         var batchId = TestIdentifiers.BatchId();
         var (identifier, canvasPaintingId) = TestIdentifiers.IdCanvasPainting();
         const int space = 3;
-
+        
         A.CallTo(() => iiifS3.ReadIIIFFromS3<IIIFManifest>(A<IHierarchyResource>._, BucketLocationType.Staging, A<CancellationToken>._))
             .ReturnsLazily(() => (IIIFManifest?)null);
 
@@ -345,6 +379,9 @@ public class BatchCompletionMessageHandlerTests
         var (identifier, canvasPaintingId) = TestIdentifiers.IdCanvasPainting();
         const int space = 2;
         var assetId = new AssetId(CustomerId, space, identifier);
+        
+        // Testing as pre-store-originals, set a future date to disable this behaviour
+        behaviour.StoresPayloadsSince = DateTimeOffset.Now.AddMonths(1);
         
         var otherCustomerManifest = await dbContext.Manifests.AddTestManifest(batchId: initialBatchId, customer: AlternativeCustomer, ingested: false);
         await dbContext.CanvasPaintings.AddTestCanvasPainting(otherCustomerManifest.Entity, id: canvasPaintingId, assetId: assetId,

--- a/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionMessageHandlerTests.cs
+++ b/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionMessageHandlerTests.cs
@@ -4,6 +4,7 @@ using BackgroundHandler.BatchCompletion;
 using BackgroundHandler.Infrastructure;
 using BackgroundHandler.Tests.Helpers;
 using BackgroundHandler.Tests.infrastructure;
+using Core.Settings;
 using DLCS;
 using DLCS.API;
 using FakeItEasy;
@@ -68,7 +69,7 @@ public class BatchCompletionMessageHandlerTests
             new PathRewriteParser(Options.Create(PathRewriteOptions.Default), new NullLogger<PathRewriteParser>());
         
         var manifestMerger = new ManifestMerger(pathGenerator, pathRewriteParser, new NullLogger<ManifestMerger>());
-        var manifestS3Manager = new ManifestS3Manager(iiifS3, pathGenerator, dlcsClient, manifestMerger,
+        var manifestS3Manager = new ManifestS3Manager(iiifS3, pathGenerator, dlcsClient, manifestMerger, new TestOptionsMonitor<BehaviourSettings>(new BehaviourSettings()),
             new NullLogger<ManifestS3Manager>());
         var customerIdProvider = new SetCustomerIdProvider();
 

--- a/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionMessageHandlerTests.cs
+++ b/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionMessageHandlerTests.cs
@@ -193,15 +193,14 @@ public class BatchCompletionMessageHandlerTests
     
     [Theory]
     [InlineData(DeliverableType.Asset, true)]
-    [InlineData(DeliverableType.Asset, true)]
+    [InlineData(DeliverableType.Asset, false)]
     [InlineData(DeliverableType.Adjunct, false)]
     public async Task HandleMessage_SavesResultingManifest_ToS3(DeliverableType deliverableType, bool storeOriginal)
     {
         // Arrange
-        var uniqueName = $"{nameof(HandleMessage_SavesResultingManifest_ToS3)}{storeOriginal.ToString()}";
         var batchId = TestIdentifiers.BatchId();
-        var (identifier, canvasPaintingId) = TestIdentifiers.IdCanvasPainting(uniqueName);
-        var manifestId = TestIdentifiers.IdWithSuffix(suffix: deliverableType.ToString());
+        var (identifier, canvasPaintingId) = TestIdentifiers.IdCanvasPainting(nameof(HandleMessage_SavesResultingManifest_ToS3) + storeOriginal);
+        var manifestId = TestIdentifiers.IdWithSuffix(suffix: $"{deliverableType.ToString()}{storeOriginal.ToString()}");
         const int space = 2;
         var flatId = $"https://localhost:5000/1/manifests/{manifestId}";
 
@@ -213,7 +212,7 @@ public class BatchCompletionMessageHandlerTests
                         A<CancellationToken>._))
                 .ReturnsLazily(() =>
                 {
-                    var data = Encoding.UTF8.GetBytes(uniqueName);
+                    var data = Encoding.UTF8.GetBytes(manifestId);
                     return new MemoryStream(data);
                 });
         }
@@ -297,7 +296,10 @@ public class BatchCompletionMessageHandlerTests
         var assetId = new AssetId(CustomerId, space, identifier);
         var stubAssetId = new AssetId(CustomerId, 0, $"Manifest_{manifestId}");
 
-        A.CallTo(() => iiifS3.ReadIIIFFromS3<IIIFManifest>(A<IHierarchyResource>._, true, A<CancellationToken>._))
+        // Testing as pre-store-originals, set a future date to disable this behaviour
+        behaviour.StoresPayloadsSince = DateTimeOffset.Now.AddMonths(1);
+        
+        A.CallTo(() => iiifS3.ReadIIIFFromS3<IIIFManifest>(A<IHierarchyResource>._, BucketLocationType.Staging, A<CancellationToken>._))
             .ReturnsLazily(() => new IIIFManifest { Id = identifier });
 
         var manifestEntityEntry = await dbContext.Manifests.AddTestManifest(id: manifestId, batchId: batchId);

--- a/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionPathRewriteTests.cs
+++ b/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionPathRewriteTests.cs
@@ -35,6 +35,8 @@ public class BatchCompletionPathRewriteTests
     private readonly IDlcsOrchestratorClient dlcsClient;
     private readonly IIIIFS3Service iiifS3;
     private readonly PathSettings backgroundHandlerSettings;
+    // Testing as pre-store-originals, set a future date to disable this behaviour
+    private readonly BehaviourSettings behaviour = new(){StoresPayloadsSince = DateTimeOffset.Now.AddMonths(1)};
     private const int Space = 2;
     
     public BatchCompletionPathRewriteTests(PresentationContextFixture dbFixture)
@@ -91,7 +93,7 @@ public class BatchCompletionPathRewriteTests
         var manifestMerger = new ManifestMerger(pathGenerator, pathRewriteParser, new NullLogger<ManifestMerger>());
 
         var manifestS3Manager = new ManifestS3Manager(iiifS3, pathGenerator, dlcsClient, manifestMerger,
-            new TestOptionsMonitor<BehaviourSettings>(new BehaviourSettings()),
+            new TestOptionsMonitor<BehaviourSettings>(behaviour),
             new NullLogger<ManifestS3Manager>());
 
         sut = new BatchCompletionMessageHandler(sutContext, dbFixture.CustomerIdProvider, manifestS3Manager,

--- a/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionPathRewriteTests.cs
+++ b/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionPathRewriteTests.cs
@@ -104,7 +104,7 @@ public class BatchCompletionPathRewriteTests
         var batchId = TestIdentifiers.BatchId();
         var identifier = TestIdentifiers.Id();
 
-        A.CallTo(() => iiifS3.ReadIIIFFromS3<IIIFManifest>(A<IHierarchyResource>._, true, A<CancellationToken>._))
+        A.CallTo(() => iiifS3.ReadIIIFFromS3<IIIFManifest>(A<IHierarchyResource>._, BucketLocationType.Staging, A<CancellationToken>._))
             .ReturnsLazily(() => new IIIFManifest
         {
             Id = identifier
@@ -148,7 +148,7 @@ public class BatchCompletionPathRewriteTests
         var batchId = TestIdentifiers.BatchId();
         var identifier = TestIdentifiers.Id();
 
-        A.CallTo(() => iiifS3.ReadIIIFFromS3<IIIFManifest>(A<IHierarchyResource>._, true, A<CancellationToken>._))
+        A.CallTo(() => iiifS3.ReadIIIFFromS3<IIIFManifest>(A<IHierarchyResource>._, BucketLocationType.Staging, A<CancellationToken>._))
             .ReturnsLazily(() => new IIIFManifest
             {
                 Id = identifier
@@ -192,7 +192,7 @@ public class BatchCompletionPathRewriteTests
         var batchId = TestIdentifiers.BatchId();
         var identifier = TestIdentifiers.Id();
 
-        A.CallTo(() => iiifS3.ReadIIIFFromS3<IIIFManifest>(A<IHierarchyResource>._, true, A<CancellationToken>._))
+        A.CallTo(() => iiifS3.ReadIIIFFromS3<IIIFManifest>(A<IHierarchyResource>._, BucketLocationType.Staging, A<CancellationToken>._))
             .ReturnsLazily(() => new IIIFManifest
             {
                 Id = identifier

--- a/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionPathRewriteTests.cs
+++ b/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionPathRewriteTests.cs
@@ -2,6 +2,7 @@
 using BackgroundHandler.BatchCompletion;
 using BackgroundHandler.Tests.Helpers;
 using BackgroundHandler.Tests.infrastructure;
+using Core.Settings;
 using Core.Web;
 using DLCS;
 using DLCS.API;
@@ -90,6 +91,7 @@ public class BatchCompletionPathRewriteTests
         var manifestMerger = new ManifestMerger(pathGenerator, pathRewriteParser, new NullLogger<ManifestMerger>());
 
         var manifestS3Manager = new ManifestS3Manager(iiifS3, pathGenerator, dlcsClient, manifestMerger,
+            new TestOptionsMonitor<BehaviourSettings>(new BehaviourSettings()),
             new NullLogger<ManifestS3Manager>());
 
         sut = new BatchCompletionMessageHandler(sutContext, dbFixture.CustomerIdProvider, manifestS3Manager,

--- a/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionPathRewriteTests.cs
+++ b/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionPathRewriteTests.cs
@@ -108,6 +108,9 @@ public class BatchCompletionPathRewriteTests
         var batchId = TestIdentifiers.BatchId();
         var identifier = TestIdentifiers.Id();
 
+        // Testing as pre-store-originals, set a future date to disable this behaviour
+        behaviour.StoresPayloadsSince = DateTimeOffset.Now.AddMonths(1);
+        
         A.CallTo(() => iiifS3.ReadIIIFFromS3<IIIFManifest>(A<IHierarchyResource>._, BucketLocationType.Staging, A<CancellationToken>._))
             .ReturnsLazily(() => new IIIFManifest
         {

--- a/src/IIIFPresentation/Core/Settings/BehaviourSettings.cs
+++ b/src/IIIFPresentation/Core/Settings/BehaviourSettings.cs
@@ -1,0 +1,12 @@
+﻿namespace Core.Settings;
+
+public class BehaviourSettings
+{
+    /// <summary>
+    /// Marks a point in time since the payload storing functionality was deployed.
+    /// This serves as a way to limit other functionality that depends on storing payloads to items that were
+    /// created afterwards.
+    /// null value means all items are expected to have been created after that functionality was deployed.
+    /// </summary>
+    public DateTimeOffset? StoresPayloadsSince { get; set; }
+}

--- a/src/IIIFPresentation/Core/Settings/BehaviourSettings.cs
+++ b/src/IIIFPresentation/Core/Settings/BehaviourSettings.cs
@@ -10,6 +10,9 @@ public class BehaviourSettings
     /// </summary>
     public DateTimeOffset? StoresPayloadsSince { get; set; }
 
+    /// <summary>
+    /// Returns true if the "Store payload" functionality was available at specified date.
+    /// </summary>
     public bool ShouldHaveStoredOriginal(DateTime created)
         => !StoresPayloadsSince.HasValue || created >= StoresPayloadsSince;
 }

--- a/src/IIIFPresentation/Core/Settings/BehaviourSettings.cs
+++ b/src/IIIFPresentation/Core/Settings/BehaviourSettings.cs
@@ -9,4 +9,7 @@ public class BehaviourSettings
     /// null value means all items are expected to have been created after that functionality was deployed.
     /// </summary>
     public DateTimeOffset? StoresPayloadsSince { get; set; }
+    
+    public bool ShouldHaveStoredOriginal(DateTime created)
+    => !StoresPayloadsSince.HasValue ||  created >= StoresPayloadsSince;
 }

--- a/src/IIIFPresentation/Core/Settings/BehaviourSettings.cs
+++ b/src/IIIFPresentation/Core/Settings/BehaviourSettings.cs
@@ -9,7 +9,7 @@ public class BehaviourSettings
     /// null value means all items are expected to have been created after that functionality was deployed.
     /// </summary>
     public DateTimeOffset? StoresPayloadsSince { get; set; }
-    
+
     public bool ShouldHaveStoredOriginal(DateTime created)
-    => !StoresPayloadsSince.HasValue ||  created >= StoresPayloadsSince;
+        => !StoresPayloadsSince.HasValue || created >= StoresPayloadsSince;
 }

--- a/src/IIIFPresentation/Core/Streams/StreamX.cs
+++ b/src/IIIFPresentation/Core/Streams/StreamX.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using System.Text;
 
 namespace Core.Streams;
 
@@ -11,4 +12,18 @@ public static class StreamX
     /// <returns>True if stream is null</returns>
     public static bool IsNull([NotNullWhen(false)]this Stream? stream)
         => stream == null || stream == Stream.Null;
+    
+    public static async Task<string> ReadStreamAsStringAsync(
+        this Stream stream,
+        CancellationToken cancellationToken = default)
+    {
+        using var reader = new StreamReader(
+            stream,
+            Encoding.UTF8,
+            detectEncodingFromByteOrderMarks: true,
+            bufferSize: 1024,
+            leaveOpen: true);
+
+        return await reader.ReadToEndAsync(cancellationToken);
+    }
 }

--- a/src/IIIFPresentation/Core/Streams/StreamX.cs
+++ b/src/IIIFPresentation/Core/Streams/StreamX.cs
@@ -21,8 +21,7 @@ public static class StreamX
             stream,
             Encoding.UTF8,
             detectEncodingFromByteOrderMarks: true,
-            bufferSize: 1024,
-            leaveOpen: true);
+            bufferSize: 1024);
 
         return await reader.ReadToEndAsync(cancellationToken);
     }

--- a/src/IIIFPresentation/Services/Manifests/AWS/ManifestS3Manager.cs
+++ b/src/IIIFPresentation/Services/Manifests/AWS/ManifestS3Manager.cs
@@ -1,9 +1,11 @@
 ﻿using AWS.Helpers;
 using Core.Helpers;
+using Core.Settings;
 using Core.Streams;
 using DLCS.API;
 using IIIF.Presentation.V3;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Repository.Paths;
 
 namespace Services.Manifests.AWS;
@@ -16,6 +18,7 @@ public class ManifestS3Manager(
     IPathGenerator pathGenerator,
     IDlcsOrchestratorClient dlcsOrchestratorClient,
     IManifestMerger manifestMerger,
+    IOptionsMonitor<BehaviourSettings> behaviour,
     ILogger<ManifestS3Manager> logger) : IManifestStorageManager
 {
     public async Task<Manifest> UpsertManifestInStorage(Manifest manifest,
@@ -38,10 +41,14 @@ public class ManifestS3Manager(
         manifest.ThrowIfNull(nameof(manifest), "Manifest was not found in staging location");
 
         // Future improvement would be to perform a copy without reading
-        var stagedOriginalStream = await iiifS3.ReadStreamFromS3(dbManifest, BucketLocationType.OriginalStaging, cancellationToken);
-        var stagedOriginal = stagedOriginalStream == null
-            ? null
-            : await stagedOriginalStream.ReadStreamAsStringAsync(cancellationToken);
+        string? stagedOriginal = null;
+        if (behaviour.CurrentValue.ShouldHaveStoredOriginal(dbManifest.Created))
+        {
+            var stagedOriginalStream =
+                await iiifS3.ReadStreamFromS3(dbManifest, BucketLocationType.OriginalStaging, cancellationToken);
+            if (!stagedOriginalStream.IsNull())
+                stagedOriginal = await stagedOriginalStream.ReadStreamAsStringAsync(cancellationToken);
+        }
         
         await UpsertManifest(manifest!, dbManifest, stagedOriginal, cancellationToken);
 

--- a/src/IIIFPresentation/Services/Manifests/AWS/ManifestS3Manager.cs
+++ b/src/IIIFPresentation/Services/Manifests/AWS/ManifestS3Manager.cs
@@ -22,8 +22,7 @@ public class ManifestS3Manager(
     ILogger<ManifestS3Manager> logger) : IManifestStorageManager
 {
     public async Task<Manifest> UpsertManifestInStorage(Manifest manifest,
-        Models.Database.Collections.Manifest dbManifest,
-        string? originalPayload, CancellationToken cancellationToken)
+        Models.Database.Collections.Manifest dbManifest, string? originalPayload, CancellationToken cancellationToken)
     {
         logger.LogInformation("Creating manifest {Manifest} in S3", dbManifest.Id);
 
@@ -31,7 +30,7 @@ public class ManifestS3Manager(
 
         return mergedManifest;
     }
-    
+
     public async Task UpsertManifestFromStagingInStorage(Models.Database.Collections.Manifest dbManifest,
         CancellationToken cancellationToken)
     {
@@ -51,12 +50,12 @@ public class ManifestS3Manager(
                 stagedOriginal = await stagedOriginalStream.ReadStreamAsStringAsync(cancellationToken);
             }
         }
-        
+
         await UpsertManifest(manifest!, dbManifest, stagedOriginal, cancellationToken);
 
         await iiifS3.DeleteIIIFFromS3(dbManifest, true);
     }
-    
+
     public async Task SaveManifestInStorage(Manifest manifest, Models.Database.Collections.Manifest dbManifest,
         string? originalPayload, bool saveToStaging, CancellationToken cancellationToken)
     {
@@ -66,19 +65,27 @@ public class ManifestS3Manager(
         if (originalPayload != null)
         {
             var location = saveToStaging ? BucketLocationType.OriginalStaging : BucketLocationType.Original;
-            logger.LogDebug("Saving original payload to {Location}", location);
+            logger.LogDebug("Saving {ManifestId} original payload to {Location}", manifest.Id, location);
             await iiifS3.SaveToS3(dbManifest, location, originalPayload, cancellationToken);
         }
 
         await saveIiif;
-        
+
         if (!saveToStaging)
         {
             dbManifest.LastProcessed = DateTime.UtcNow;
         }
     }
-    
-    private async Task<Manifest> UpsertManifest(Manifest manifest, Models.Database.Collections.Manifest dbManifest, 
+
+    public async Task DeleteOriginalPayload(Models.Database.Collections.Manifest dbManifest)
+    {
+        if (!behaviour.CurrentValue.ShouldHaveStoredOriginal(dbManifest.Created)) return;
+
+        logger.LogDebug("Deleting any stale original payload for manifest {ManifestId}", dbManifest.Id);
+        await iiifS3.DeleteFromS3(dbManifest, BucketLocationType.Original);
+    }
+
+    private async Task<Manifest> UpsertManifest(Manifest manifest, Models.Database.Collections.Manifest dbManifest,
         string? originalPayload, CancellationToken cancellationToken)
     {
         var namedQueryManifest =
@@ -92,8 +99,8 @@ public class ManifestS3Manager(
             dbManifest.CustomerId,
             dbManifest.Id);
 
-        await SaveManifestInStorage(mergedManifest, dbManifest,originalPayload, false, cancellationToken);
-        
+        await SaveManifestInStorage(mergedManifest, dbManifest, originalPayload, false, cancellationToken);
+
         return mergedManifest;
     }
 }
@@ -101,22 +108,25 @@ public class ManifestS3Manager(
 public interface IManifestStorageManager
 {
     /// <summary>
-    /// Upserts a final manifest that requires setting items from the staging environment
+    /// Upserts a final manifest that requires external content, merged with Manifest from the staging storage.
     /// </summary>
     public Task UpsertManifestFromStagingInStorage(Models.Database.Collections.Manifest dbManifest,
         CancellationToken cancellationToken);
-    
-    /// <summary>
-    /// Upserts a manifest that requires setting items to the final location directly
-    /// </summary>
-    public Task<Manifest> UpsertManifestInStorage(Manifest manifest, Models.Database.Collections.Manifest dbManifest,
-        string? originalPayload,
-        CancellationToken cancellationToken);
 
     /// <summary>
-    /// Saves a manifest that does not require further processing
+    /// Upserts a manifest that requires external content, merged with Manifest provided.
+    /// </summary>
+    public Task<Manifest> UpsertManifestInStorage(Manifest manifest, Models.Database.Collections.Manifest dbManifest,
+        string? originalPayload, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Upserts provided manifest directly to storage
     /// </summary>
     public Task SaveManifestInStorage(Manifest manifest, Models.Database.Collections.Manifest dbManifest,
-        string? originalPayload,
-        bool saveToStaging, CancellationToken cancellationToken);
+        string? originalPayload, bool saveToStaging, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Removes any stored original payload for a manifest (e.g. a stale one left by a prior version).
+    /// </summary>
+    public Task DeleteOriginalPayload(Models.Database.Collections.Manifest dbManifest);
 }

--- a/src/IIIFPresentation/Services/Manifests/AWS/ManifestS3Manager.cs
+++ b/src/IIIFPresentation/Services/Manifests/AWS/ManifestS3Manager.cs
@@ -1,5 +1,6 @@
 ﻿using AWS.Helpers;
 using Core.Helpers;
+using Core.Streams;
 using DLCS.API;
 using IIIF.Presentation.V3;
 using Microsoft.Extensions.Logging;
@@ -19,11 +20,11 @@ public class ManifestS3Manager(
 {
     public async Task<Manifest> UpsertManifestInStorage(Manifest manifest,
         Models.Database.Collections.Manifest dbManifest,
-        CancellationToken cancellationToken)
+        string? originalPayload, CancellationToken cancellationToken)
     {
         logger.LogInformation("Creating manifest {Manifest} in S3", dbManifest.Id);
 
-        var mergedManifest = await UpsertManifest(manifest, dbManifest, cancellationToken);
+        var mergedManifest = await UpsertManifest(manifest, dbManifest, originalPayload, cancellationToken);
 
         return mergedManifest;
     }
@@ -33,19 +34,33 @@ public class ManifestS3Manager(
     {
         logger.LogInformation("Updating manifest {Manifest} in S3", dbManifest.Id);
 
-        var manifest = await iiifS3.ReadIIIFFromS3<Manifest>(dbManifest, true, cancellationToken);
+        var manifest = await iiifS3.ReadIIIFFromS3<Manifest>(dbManifest, BucketLocationType.Staging, cancellationToken);
         manifest.ThrowIfNull(nameof(manifest), "Manifest was not found in staging location");
 
-        await UpsertManifest(manifest!, dbManifest, cancellationToken);
+        // Future improvement would be to perform a copy without reading
+        var stagedOriginalStream = await iiifS3.ReadStreamFromS3(dbManifest, BucketLocationType.OriginalStaging, cancellationToken);
+        var stagedOriginal = stagedOriginalStream == null
+            ? null
+            : await stagedOriginalStream.ReadStreamAsStringAsync(cancellationToken);
+        
+        await UpsertManifest(manifest!, dbManifest, stagedOriginal, cancellationToken);
 
         await iiifS3.DeleteIIIFFromS3(dbManifest, true);
     }
     
-    public async Task SaveManifestInStorage(Manifest manifest, Models.Database.Collections.Manifest dbManifest, bool saveToStaging,
-        CancellationToken cancellationToken)
+    public async Task SaveManifestInStorage(Manifest manifest, Models.Database.Collections.Manifest dbManifest,
+        string? originalPayload, bool saveToStaging, CancellationToken cancellationToken)
     {
-        await iiifS3.SaveIIIFToS3(manifest, dbManifest, pathGenerator.GenerateFlatManifestId(dbManifest),
+        var saveIiif = iiifS3.SaveIIIFToS3(manifest, dbManifest, pathGenerator.GenerateFlatManifestId(dbManifest),
             saveToStaging, cancellationToken);
+
+        if (originalPayload != null)
+        {
+            var location = saveToStaging ? BucketLocationType.OriginalStaging : BucketLocationType.Original;
+            await iiifS3.SaveToS3(dbManifest, location, originalPayload, cancellationToken);
+        }
+
+        await saveIiif;
         
         if (!saveToStaging)
         {
@@ -54,7 +69,7 @@ public class ManifestS3Manager(
     }
     
     private async Task<Manifest> UpsertManifest(Manifest manifest, Models.Database.Collections.Manifest dbManifest, 
-        CancellationToken cancellationToken)
+        string? originalPayload, CancellationToken cancellationToken)
     {
         var namedQueryManifest =
             await dlcsOrchestratorClient.RetrieveAssetsForManifest(dbManifest.CustomerId, dbManifest.Id,
@@ -67,7 +82,7 @@ public class ManifestS3Manager(
             dbManifest.CustomerId,
             dbManifest.Id);
 
-        await SaveManifestInStorage(mergedManifest, dbManifest, false, cancellationToken);
+        await SaveManifestInStorage(mergedManifest, dbManifest,originalPayload, false, cancellationToken);
         
         return mergedManifest;
     }
@@ -85,11 +100,13 @@ public interface IManifestStorageManager
     /// Upserts a manifest that requires setting items to the final location directly
     /// </summary>
     public Task<Manifest> UpsertManifestInStorage(Manifest manifest, Models.Database.Collections.Manifest dbManifest,
+        string? originalPayload,
         CancellationToken cancellationToken);
 
     /// <summary>
     /// Saves a manifest that does not require further processing
     /// </summary>
     public Task SaveManifestInStorage(Manifest manifest, Models.Database.Collections.Manifest dbManifest,
+        string? originalPayload,
         bool saveToStaging, CancellationToken cancellationToken);
 }

--- a/src/IIIFPresentation/Services/Manifests/AWS/ManifestS3Manager.cs
+++ b/src/IIIFPresentation/Services/Manifests/AWS/ManifestS3Manager.cs
@@ -47,7 +47,9 @@ public class ManifestS3Manager(
             var stagedOriginalStream =
                 await iiifS3.ReadStreamFromS3(dbManifest, BucketLocationType.OriginalStaging, cancellationToken);
             if (!stagedOriginalStream.IsNull())
+            {
                 stagedOriginal = await stagedOriginalStream.ReadStreamAsStringAsync(cancellationToken);
+            }
         }
         
         await UpsertManifest(manifest!, dbManifest, stagedOriginal, cancellationToken);

--- a/src/IIIFPresentation/Services/Manifests/AWS/ManifestS3Manager.cs
+++ b/src/IIIFPresentation/Services/Manifests/AWS/ManifestS3Manager.cs
@@ -66,6 +66,7 @@ public class ManifestS3Manager(
         if (originalPayload != null)
         {
             var location = saveToStaging ? BucketLocationType.OriginalStaging : BucketLocationType.Original;
+            logger.LogDebug("Saving original payload to {Location}", location);
             await iiifS3.SaveToS3(dbManifest, location, originalPayload, cancellationToken);
         }
 


### PR DESCRIPTION
## What does this change?

Implements #576 

* New `DateTimeOffset?` setting `StoresPayloadsSince` loaded as a part of new `BehaviourSettings` - declares since when we can expect an entity to have their original payload stored - saves reaching to S3 for nothing. If not set, code assumes all entities should have that payload stored (within other rules)
* Refactored `IIIFS3Service` to allow saving/reading raw streams, as we treat the payload as arbitrary `string`, not serialised/deserialised IIIF entity
* Added logic to API behaviour that includes storing the original, if the `PaintedResources` were included in manifest, as this will make normally-saved manifest differ from the payload
* Expanded `BucketHelperX` to take an enum pointing to a "variant" of location - this expands on the original `isStaging`  flag
* Modified `BatchCompletionMessageHandlerTests` to work without new functionality, and included two-scenario `HandleMessage_SavesResultingManifest_ToS3` that also tests the new behaviour.



## Configuration Changes

> [!NOTE]
> This PR introduces configuration changes.
>
> |Service | AppSetting | Required? | Description | Default |
> |---|---|---|---|---|
> | API |  `StoresPayloadsSince` | N | Timestamp of moment since storing payloads | `null` |
