### PR TITLE
Fix manifest level adjuncts not being placed on the output of a manifest when no painted resources

### DIFF
--- a/src/IIIFPresentation/API.Tests/Helpers/BatchHelperTests.cs
+++ b/src/IIIFPresentation/API.Tests/Helpers/BatchHelperTests.cs
@@ -29,7 +29,7 @@ public class BatchHelperTests
         var batchId = TestIdentifiers.BatchId();
         var batch = new Batch
         {
-            ResourceId = batchId.ToString(),
+            ResourceId = $"http://dlcs.example.com/batches/{batchId}",
             Submitted = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Unspecified),
             Finished = new DateTime(2024, 1, 1, 13, 0, 0, DateTimeKind.Unspecified),
             Count = 10,
@@ -57,7 +57,7 @@ public class BatchHelperTests
         var finished = new DateTime(2024, 1, 1, 13, 0, 0, DateTimeKind.Unspecified);
         var batch = new Batch
         {
-            ResourceId = batchId.ToString(),
+            ResourceId = $"http://dlcs.example.com/batches/{batchId}",
             Submitted = submitted,
             Finished = finished
         };
@@ -89,7 +89,7 @@ public class BatchHelperTests
         var batchId = TestIdentifiers.BatchId();
         var batch = new Batch
         {
-            ResourceId = batchId.ToString(),
+            ResourceId = $"http://dlcs.example.com/batches/{batchId}",
             Submitted = DateTime.UtcNow,
             Finished = null
         };
@@ -114,7 +114,7 @@ public class BatchHelperTests
         var batchId = TestIdentifiers.BatchId();
         var batch = new Batch
         {
-            ResourceId = batchId.ToString(),
+            ResourceId = $"http://dlcs.example.com/batches/{batchId}",
             Submitted = DateTime.UtcNow,
             Finished = null
         };
@@ -139,7 +139,7 @@ public class BatchHelperTests
         var batchId = TestIdentifiers.BatchId();
         var batch = new Batch
         {
-            ResourceId = batchId.ToString(),
+            ResourceId = $"http://dlcs.example.com/batches/{batchId}",
             Submitted = DateTime.UtcNow,
             Finished = DateTime.UtcNow
         };
@@ -159,26 +159,26 @@ public class BatchHelperTests
         // Arrange
         var customerId = PresentationContextFixture.CustomerId;
         var manifestId = "test-manifest";
-        var id1 = TestIdentifiers.BatchId();
-        var id2 = TestIdentifiers.BatchId();
-        var id3 = TestIdentifiers.BatchId();
+        var idOne = TestIdentifiers.BatchId();
+        var idTwo = TestIdentifiers.BatchId();
+        var idThree = TestIdentifiers.BatchId();
         var batches = new List<Batch>
         {
             new()
             {
-                ResourceId = id1.ToString(),
+                ResourceId = $"http://dlcs.example.com/batches/{idOne}",
                 Submitted = DateTime.UtcNow,
                 Finished = null
             },
             new()
             {
-                ResourceId = id2.ToString(),
+                ResourceId = $"http://dlcs.example.com/batches/{idTwo}",
                 Submitted = DateTime.UtcNow,
                 Finished = DateTime.UtcNow
             },
             new()
             {
-                ResourceId = id3.ToString(),
+                ResourceId = $"http://dlcs.example.com/batches/{idThree}",
                 Submitted = DateTime.UtcNow,
                 Finished = null
             }
@@ -188,9 +188,9 @@ public class BatchHelperTests
         await batches.AddBatchesToDatabase(customerId, manifestId, dbContext, DeliverableType.Asset);
 
         // Assert
-        var trackedBatches = dbContext.Batches.Local.Where(b => b.Id == id1 || b.Id == id2 || b.Id == id3).ToList();
+        var trackedBatches = dbContext.Batches.Local.Where(b => b.Id == idOne || b.Id == idTwo || b.Id == idThree).ToList();
         trackedBatches.Should().HaveCount(3);
-        trackedBatches.Select(b => b.Id).Should().ContainInOrder(id1, id2, id3);
+        trackedBatches.Select(b => b.Id).Should().ContainInOrder(idOne, idTwo, idThree);
     }
 
     [Fact]
@@ -219,7 +219,7 @@ public class BatchHelperTests
         var unspecifiedTime = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Unspecified);
         var batch = new Batch
         {
-            ResourceId = batchId.ToString(),
+            ResourceId = $"http://dlcs.example.com/batches/{batchId}",
             Submitted = unspecifiedTime,
             Finished = null
         };
@@ -243,7 +243,7 @@ public class BatchHelperTests
         var batchId = TestIdentifiers.BatchId();
         var batch = new Batch
         {
-            ResourceId = batchId.ToString(),
+            ResourceId = $"http://dlcs.example.com/batches/{batchId}",
             Submitted = DateTime.UtcNow,
             Finished = DateTime.UtcNow
         };
@@ -268,7 +268,7 @@ public class BatchHelperTests
         var unspecifiedTime = new DateTime(2024, 1, 1, 13, 0, 0, DateTimeKind.Unspecified);
         var batch = new Batch
         {
-            ResourceId = batchId.ToString(),
+            ResourceId = $"http://dlcs.example.com/batches/{batchId}",
             Submitted = DateTime.UtcNow,
             Finished = unspecifiedTime
         };

--- a/src/IIIFPresentation/API.Tests/Helpers/BatchHelperTests.cs
+++ b/src/IIIFPresentation/API.Tests/Helpers/BatchHelperTests.cs
@@ -2,6 +2,7 @@ using API.Helpers;
 using API.Tests.Integration.Infrastructure;
 using Models.Database.General;
 using Repository;
+using Test.Helpers;
 using Test.Helpers.Integration;
 using Batch = DLCS.Models.Batch;
 
@@ -25,9 +26,10 @@ public class BatchHelperTests
         // Arrange
         var customerId = PresentationContextFixture.CustomerId;
         var manifestId = "test-manifest";
+        var batchId = TestIdentifiers.BatchId();
         var batch = new Batch
         {
-            ResourceId = "http://dlcs.example.com/batches/456",
+            ResourceId = batchId.ToString(),
             Submitted = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Unspecified),
             Finished = new DateTime(2024, 1, 1, 13, 0, 0, DateTimeKind.Unspecified),
             Count = 10,
@@ -40,7 +42,7 @@ public class BatchHelperTests
         await batches.AddBatchesToDatabase(customerId, manifestId, dbContext, DeliverableType.Asset);
 
         // Assert
-        var trackedBatch = dbContext.Batches.Local.SingleOrDefault(b => b.Id == 456);
+        var trackedBatch = dbContext.Batches.Local.SingleOrDefault(b => b.Id == batchId);
         trackedBatch.Should().NotBeNull();
     }
 
@@ -50,11 +52,12 @@ public class BatchHelperTests
         // Arrange
         var customerId = PresentationContextFixture.CustomerId;
         var manifestId = "test-manifest";
+        var batchId = TestIdentifiers.BatchId();
         var submitted = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Unspecified);
         var finished = new DateTime(2024, 1, 1, 13, 0, 0, DateTimeKind.Unspecified);
         var batch = new Batch
         {
-            ResourceId = "http://dlcs.example.com/batches/789",
+            ResourceId = batchId.ToString(),
             Submitted = submitted,
             Finished = finished
         };
@@ -64,7 +67,7 @@ public class BatchHelperTests
         await batches.AddBatchesToDatabase(customerId, manifestId, dbContext, DeliverableType.Asset);
 
         // Assert
-        var trackedBatch = dbContext.Batches.Local.Single(b => b.Id == 789);
+        var trackedBatch = dbContext.Batches.Local.Single(b => b.Id == batchId);
         trackedBatch.CustomerId.Should().Be(customerId);
         trackedBatch.ManifestId.Should().Be(manifestId);
         trackedBatch.Submitted.Should().Be(submitted.ToUniversalTime());
@@ -83,9 +86,10 @@ public class BatchHelperTests
         // Arrange
         var customerId = PresentationContextFixture.CustomerId;
         var manifestId = "test-manifest";
+        var batchId = TestIdentifiers.BatchId();
         var batch = new Batch
         {
-            ResourceId = "http://dlcs.example.com/batches/101",
+            ResourceId = batchId.ToString(),
             Submitted = DateTime.UtcNow,
             Finished = null
         };
@@ -95,7 +99,7 @@ public class BatchHelperTests
         await batches.AddBatchesToDatabase(customerId, manifestId, dbContext, DeliverableType.Asset);
 
         // Assert
-        var trackedBatch = dbContext.Batches.Local.Single(b => b.Id == 101);
+        var trackedBatch = dbContext.Batches.Local.Single(b => b.Id == batchId);
         trackedBatch.Status.Should().Be(BatchStatus.Ingesting);
         trackedBatch.Processed.Should().BeNull();
         trackedBatch.Finished.Should().BeNull();
@@ -107,9 +111,10 @@ public class BatchHelperTests
         // Arrange
         var customerId = PresentationContextFixture.CustomerId;
         var manifestId = "test-manifest";
+        var batchId = TestIdentifiers.BatchId();
         var batch = new Batch
         {
-            ResourceId = "http://dlcs.example.com/batches/202",
+            ResourceId = batchId.ToString(),
             Submitted = DateTime.UtcNow,
             Finished = null
         };
@@ -119,7 +124,7 @@ public class BatchHelperTests
         await batches.AddBatchesToDatabase(customerId, manifestId, dbContext, DeliverableType.Asset);
 
         // Assert
-        var trackedBatch = dbContext.Batches.Local.Single(b => b.Id == 202);
+        var trackedBatch = dbContext.Batches.Local.Single(b => b.Id == batchId);
         trackedBatch.Processed.Should().BeNull();
     }
 
@@ -131,9 +136,10 @@ public class BatchHelperTests
         // Arrange
         var customerId = PresentationContextFixture.CustomerId;
         var manifestId = "test-manifest";
+        var batchId = TestIdentifiers.BatchId();
         var batch = new Batch
         {
-            ResourceId = "http://dlcs.example.com/batches/303",
+            ResourceId = batchId.ToString(),
             Submitted = DateTime.UtcNow,
             Finished = DateTime.UtcNow
         };
@@ -143,7 +149,7 @@ public class BatchHelperTests
         await batches.AddBatchesToDatabase(customerId, manifestId, dbContext, deliverableType);
 
         // Assert
-        var trackedBatch = dbContext.Batches.Local.Single(b => b.Id == 303);
+        var trackedBatch = dbContext.Batches.Local.Single(b => b.Id == batchId);
         trackedBatch.DeliverableType.Should().Be(deliverableType);
     }
 
@@ -153,23 +159,26 @@ public class BatchHelperTests
         // Arrange
         var customerId = PresentationContextFixture.CustomerId;
         var manifestId = "test-manifest";
+        var id1 = TestIdentifiers.BatchId();
+        var id2 = TestIdentifiers.BatchId();
+        var id3 = TestIdentifiers.BatchId();
         var batches = new List<Batch>
         {
             new()
             {
-                ResourceId = "http://dlcs.example.com/batches/111",
+                ResourceId = id1.ToString(),
                 Submitted = DateTime.UtcNow,
                 Finished = null
             },
             new()
             {
-                ResourceId = "http://dlcs.example.com/batches/222",
+                ResourceId = id2.ToString(),
                 Submitted = DateTime.UtcNow,
                 Finished = DateTime.UtcNow
             },
             new()
             {
-                ResourceId = "http://dlcs.example.com/batches/333",
+                ResourceId = id3.ToString(),
                 Submitted = DateTime.UtcNow,
                 Finished = null
             }
@@ -179,9 +188,9 @@ public class BatchHelperTests
         await batches.AddBatchesToDatabase(customerId, manifestId, dbContext, DeliverableType.Asset);
 
         // Assert
-        var trackedBatches = dbContext.Batches.Local.Where(b => b.Id is 111 or 222 or 333).ToList();
+        var trackedBatches = dbContext.Batches.Local.Where(b => b.Id == id1 || b.Id == id2 || b.Id == id3).ToList();
         trackedBatches.Should().HaveCount(3);
-        trackedBatches.Select(b => b.Id).Should().ContainInOrder(111, 222, 333);
+        trackedBatches.Select(b => b.Id).Should().ContainInOrder(id1, id2, id3);
     }
 
     [Fact]
@@ -206,10 +215,11 @@ public class BatchHelperTests
         // Arrange
         var customerId = PresentationContextFixture.CustomerId;
         var manifestId = "test-manifest";
+        var batchId = TestIdentifiers.BatchId();
         var unspecifiedTime = new DateTime(2024, 1, 1, 12, 0, 0, DateTimeKind.Unspecified);
         var batch = new Batch
         {
-            ResourceId = "http://dlcs.example.com/batches/606",
+            ResourceId = batchId.ToString(),
             Submitted = unspecifiedTime,
             Finished = null
         };
@@ -219,7 +229,7 @@ public class BatchHelperTests
         await batches.AddBatchesToDatabase(customerId, manifestId, dbContext, DeliverableType.Asset);
 
         // Assert
-        var trackedBatch = dbContext.Batches.Local.Single(b => b.Id == 606);
+        var trackedBatch = dbContext.Batches.Local.Single(b => b.Id == batchId);
         trackedBatch.Submitted.Kind.Should().Be(DateTimeKind.Utc);
         trackedBatch.Submitted.Should().Be(unspecifiedTime.ToUniversalTime());
     }
@@ -230,9 +240,10 @@ public class BatchHelperTests
         // Arrange
         var customerId = PresentationContextFixture.CustomerId;
         var manifestId = "test-manifest";
+        var batchId = TestIdentifiers.BatchId();
         var batch = new Batch
         {
-            ResourceId = "http://dlcs.example.com/batches/707",
+            ResourceId = batchId.ToString(),
             Submitted = DateTime.UtcNow,
             Finished = DateTime.UtcNow
         };
@@ -242,7 +253,7 @@ public class BatchHelperTests
         await batches.AddBatchesToDatabase(customerId, manifestId, dbContext, DeliverableType.Asset);
 
         // Assert
-        var trackedBatch = dbContext.Batches.Local.Single(b => b.Id == 707);
+        var trackedBatch = dbContext.Batches.Local.Single(b => b.Id == batchId);
         trackedBatch.Processed.Should().NotBeNull();
         trackedBatch.Processed!.Value.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(3));
     }
@@ -253,10 +264,11 @@ public class BatchHelperTests
         // Arrange
         var customerId = PresentationContextFixture.CustomerId;
         var manifestId = "test-manifest";
+        var batchId = TestIdentifiers.BatchId();
         var unspecifiedTime = new DateTime(2024, 1, 1, 13, 0, 0, DateTimeKind.Unspecified);
         var batch = new Batch
         {
-            ResourceId = "http://dlcs.example.com/batches/808",
+            ResourceId = batchId.ToString(),
             Submitted = DateTime.UtcNow,
             Finished = unspecifiedTime
         };
@@ -266,7 +278,7 @@ public class BatchHelperTests
         await batches.AddBatchesToDatabase(customerId, manifestId, dbContext, DeliverableType.Asset);
 
         // Assert
-        var trackedBatch = dbContext.Batches.Local.Single(b => b.Id == 808);
+        var trackedBatch = dbContext.Batches.Local.Single(b => b.Id == batchId);
         trackedBatch.Finished.Should().NotBeNull();
         trackedBatch.Finished!.Value.Kind.Should().Be(DateTimeKind.Utc);
         trackedBatch.Finished.Should().Be(unspecifiedTime.ToUniversalTime());

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestManifestAdjunctTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestManifestAdjunctTests.cs
@@ -594,6 +594,62 @@ public class ModifyManifestManifestAdjunctTests : IClassFixture<PresentationAppF
     }
 
     [Fact]
+    public async Task CreateManifest_WithOnlyManifestAdjuncts_WhenBatchesCompleteUpfront_WritesSeeAlsoToS3()
+    {
+        // Arrange
+        var (slug, _) = TestIdentifiers.SlugResource();
+        const string seeAlsoId = "https://example.com/mets.xml";
+
+        // Override: batches complete immediately (Finished is set) → canBeBuiltUpfront = true
+        A.CallTo(() => DLCSApiClient.IngestDeliverables(Customer, A<List<JObject>>._, A<bool>._, A<CancellationToken>._))
+            .ReturnsLazily(_ => Task.FromResult(new List<Batch>
+            {
+                new() { ResourceId = TestIdentifiers.BatchId().ToString(), Submitted = DateTime.Now, Finished = DateTime.Now }
+            }));
+
+        // NQ manifest carries only the stub canvas with a seeAlso adjunct
+        A.CallTo(() => DLCSOrchestratorClient.RetrieveAssetsForManifest(A<int>._, A<string>._, A<CancellationToken>._))
+            .ReturnsLazily((int _, string manifestId, CancellationToken _) =>
+            {
+                var stubAssetId = new AssetId(Customer, 0, $"Manifest_{manifestId}");
+                return ManifestTestCreator.New()
+                    .WithCanvas(stubAssetId, c => c.WithImage().WithAdjunctSeeAlso(seeAlsoId))
+                    .Build();
+            });
+
+        var payload = $$"""
+            {
+                "type": "Manifest",
+                "slug": "{{slug}}",
+                "parent": "http://localhost/{{Customer}}/collections/root",
+                "adjuncts": [
+                    { "id": "mets.xml", "mediaType": "text/xml", "iiifLink": "seeAlso" }
+                ]
+            }
+            """;
+
+        var request = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Post,
+            $"{Customer}/manifests", payload);
+
+        // Act
+        var response = await httpClient.AsCustomer().SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var responseManifest = await response.ReadAsPresentationResponseAsync<PresentationManifest>();
+        var manifestId = responseManifest!.Id!.Split('/').Last();
+
+        responseManifest.SeeAlso.Should().ContainSingle(s => s.Id == seeAlsoId,
+            "manifest-level seeAlso from stub canvas must appear in the write response");
+
+        var savedS3 = await amazonS3.GetObjectAsync(LocalStackFixture.StorageBucketName,
+            $"{Customer}/manifests/{manifestId}");
+        var s3Manifest = savedS3.ResponseStream.FromJsonStream<IIIF.Presentation.V3.Manifest>();
+        s3Manifest.SeeAlso.Should().ContainSingle(s => s.Id == seeAlsoId,
+            "manifest-level seeAlso from stub canvas must be persisted to real S3 location");
+    }
+
+    [Fact]
     public async Task CreateManifest_WithInvalidAdjunctId_Returns400()
     {
         // Arrange

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
@@ -290,8 +290,7 @@ public class ManifestWriteService(
     private async Task<PresUpdateResult> SaveToS3AndGenerateResult(WriteManifestRequest request, DbManifest dbManifest,
         DlcsInteractionResult dlcsInteractionResult, WriteResult writeResult, CancellationToken cancellationToken)
     {
-        var hasAssets = request.PresentationManifest.PaintedResources.HasAsset();
-        await SaveToS3(dbManifest, request, hasAssets, dlcsInteractionResult.CanBeBuiltUpfront, cancellationToken);
+        await SaveToS3(dbManifest, request, dlcsInteractionResult.CanBeBuiltUpfront, cancellationToken);
         return await GeneratePresentationSuccessResult(request.PresentationManifest, request.CustomerId, dbManifest,
             writeResult, cancellationToken);
     }
@@ -392,23 +391,20 @@ public class ManifestWriteService(
     /// </summary>
     /// <param name="dbManifest">The manifest record</param>
     /// <param name="request">The request made by the caller</param>
-    /// <param name="hasAssets">
-    /// Whether there are any assets identified in the request
-    ///
-    /// This is relevant for both painted resources and assets from items
-    /// </param>
     /// <param name="canBeBuiltUpfront">
     /// Whether there's assets, but they're all tracked by the DLCS
     ///
     /// This is relevant for painted resources + resource level adjuncts
     /// </param>
     /// <param name="cancellationToken">A cancellation token</param>
-    private async Task SaveToS3(DbManifest dbManifest, WriteManifestRequest request, bool hasAssets,
-        bool canBeBuiltUpfront, CancellationToken cancellationToken)
+    private async Task SaveToS3(DbManifest dbManifest, WriteManifestRequest request, bool canBeBuiltUpfront,
+        CancellationToken cancellationToken)
     {
         var iiifManifest = request.RawRequestBody.ToManifest();
-        
-        if (canBeBuiltUpfront && hasAssets)
+        var hasAssets = request.PresentationManifest.PaintedResources.HasAsset();
+        var hasAdjuncts = request.PresentationManifest.Adjuncts != null;
+
+        if (canBeBuiltUpfront && (hasAssets || hasAdjuncts))
         {
             var manifest = await manifestStorageManager.UpsertManifestInStorage(iiifManifest, dbManifest, cancellationToken);
             MergeManifestFields(manifest, request.PresentationManifest);


### PR DESCRIPTION
## What does this change?

This PR fixes an issue where manifests were not having manifest-level adjuncts outputted onto the final manifest after being processed when there is only manifest-level adjuncts.

This is because the logic to push the manifest through the `ManifestMerger` only occurs when it needs to, and in this case the manifest merger did not take into account manifests with no assets

additionally, modifies some tests to avoid hardcoded batch ids