### PR TITLE
Allow null or empty manifest-level adjuncts to go through the serialiser correctly

### DIFF
--- a/src/IIIFPresentation/API.Tests/Features/Manifest/ManifestWriteServiceTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Manifest/ManifestWriteServiceTests.cs
@@ -646,7 +646,7 @@ public class ManifestWriteServiceTests
                 ]
             });
 
-        const string stubManifestAdjunctId = "https://example.com/manifest-adjunct.xml";
+        const string stubManifestAdjunctId = "manifest-adjunct.xml";
         var stubAssetName = $"Manifest_{resourceId}";
         A.CallTo(() => dlcsClient.GetCustomerImages(Customer, A<string>._, A<CancellationToken>._))
             .Returns(Task.FromResult<IList<JObject>>(
@@ -776,7 +776,7 @@ public class ManifestWriteServiceTests
                 A<IIIFManifest>._, A<Models.Database.Collections.Manifest>._, A<CancellationToken>._))
             .ReturnsLazily(() => new IIIFManifest());
 
-        const string existingAdjunctId = "https://example.com/existing-adjunct.xml";
+        const string existingAdjunctId = "existing-adjunct.xml";
         var stubAssetName = $"Manifest_{resourceId}";
         A.CallTo(() => dlcsClient.GetCustomerImages(Customer, A<string>._, A<CancellationToken>._))
             .Returns(Task.FromResult<IList<JObject>>(

--- a/src/IIIFPresentation/API.Tests/Features/Manifest/ManifestWriteServiceTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Manifest/ManifestWriteServiceTests.cs
@@ -872,7 +872,7 @@ public class ManifestWriteServiceTests
 
         // Assert
         result.Error.Should().BeNull();
-        result.Entity.Adjuncts.Should().BeEmpty("Adjuncts=[] (explicit clear) on the request is preserved as-is, not replaced by stub asset lookup");
+        result.Entity.Adjuncts.Should().BeEmpty("Adjuncts=[] (explicit clear) is preserved — stub lookup finds no adjuncts so the value is unchanged");
         A.CallTo(() => manifestStorageManager.UpsertManifestInStorage(
                 A<IIIFManifest>._, A<Models.Database.Collections.Manifest>._, A<CancellationToken>._))
             .MustHaveHappenedOnceExactly();

--- a/src/IIIFPresentation/API.Tests/Features/Manifest/ManifestWriteServiceTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Manifest/ManifestWriteServiceTests.cs
@@ -20,6 +20,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Models.API.Manifest;
 using Models.DLCS;
+using DbDeliverableType = Models.Database.General.DeliverableType;
 using Newtonsoft.Json.Linq;
 using Repository;
 using Repository.Paths;
@@ -645,8 +646,20 @@ public class ManifestWriteServiceTests
                 ]
             });
 
+        const string stubManifestAdjunctId = "https://example.com/manifest-adjunct.xml";
+        var stubAssetName = $"Manifest_{resourceId}";
         A.CallTo(() => dlcsClient.GetCustomerImages(Customer, A<string>._, A<CancellationToken>._))
-            .Returns(Task.FromResult<IList<JObject>>([]));
+            .Returns(Task.FromResult<IList<JObject>>(
+            [
+                JObject.Parse($$"""
+                {
+                    "@id": "https://localhost/customers/{{Customer}}/spaces/0/images/{{stubAssetName}}",
+                    "id": "{{stubAssetName}}",
+                    "space": 0,
+                    "adjuncts": [{ "id": "{{stubManifestAdjunctId}}", "mediaType": "text/xml" }]
+                }
+                """)
+            ]));
 
         var manifest = new PresentationManifest
         {
@@ -681,6 +694,9 @@ public class ManifestWriteServiceTests
         result.Entity.Annotations.Should()
             .Contain(a => a.Id == userAnnotationId, "user-set annotations must not be lost when stub canvas adjuncts are merged").And
             .Contain(a => a.Id == stubAnnotationId, "stub canvas annotations must be added alongside user-set values");
+        result.Entity.Adjuncts.Should().ContainSingle()
+            .Which.Value<string>("id").Should().Be(stubManifestAdjunctId,
+                "manifest-level adjuncts from the DLCS stub asset must be returned when Adjuncts was null on the request");
     }
 
     [Fact]
@@ -741,6 +757,125 @@ public class ManifestWriteServiceTests
         result.Entity.SeeAlso.Should().BeEmpty();
         result.Entity.Rendering.Should().BeEmpty();
         result.Entity.Annotations.Should().BeEmpty();
+        result.Entity.Adjuncts.Should().BeNull("no stub asset carries adjuncts so Adjuncts should not be populated");
+    }
+
+    [Fact]
+    public async Task Upsert_CallsUpsertManifestInStorage_WhenAdjunctsNull_AndExistingAdjunctBatch()
+    {
+        // Arrange - no painted resources, adjuncts = null ("no change"), but the manifest has a previously
+        // ingested adjunct batch. ManifestMerger must run to bake the existing DLCS adjunct properties
+        // (SeeAlso/Rendering/Annotations) back into the S3 manifest.
+        var (slug, resourceId) = TestIdentifiers.SlugResource();
+
+        var dbManifest = await presentationContext.Manifests.AddTestManifest(resourceId, slug: slug);
+        await presentationContext.Batches.AddTestBatch(9991, dbManifest.Entity, DbDeliverableType.Adjunct);
+        await presentationContext.SaveChangesAsync();
+
+        A.CallTo(() => manifestStorageManager.UpsertManifestInStorage(
+                A<IIIFManifest>._, A<Models.Database.Collections.Manifest>._, A<CancellationToken>._))
+            .ReturnsLazily(() => new IIIFManifest());
+
+        const string existingAdjunctId = "https://example.com/existing-adjunct.xml";
+        var stubAssetName = $"Manifest_{resourceId}";
+        A.CallTo(() => dlcsClient.GetCustomerImages(Customer, A<string>._, A<CancellationToken>._))
+            .Returns(Task.FromResult<IList<JObject>>(
+            [
+                JObject.Parse($$"""
+                {
+                    "@id": "https://localhost/customers/{{Customer}}/spaces/0/images/{{stubAssetName}}",
+                    "id": "{{stubAssetName}}",
+                    "space": 0,
+                    "adjuncts": [{ "id": "{{existingAdjunctId}}", "mediaType": "text/xml" }]
+                }
+                """)
+            ]));
+
+        var manifest = new PresentationManifest { Slug = slug, Adjuncts = null };
+
+        var request = new UpsertManifestRequest(resourceId, dbManifest.Entity.Etag.ToString(), Customer, manifest,
+            manifest.AsJson(), false);
+
+        // Act
+        var result = await sut.Upsert(request, CancellationToken.None);
+
+        // Assert
+        result.Error.Should().BeNull();
+        result.Entity.Adjuncts.Should().ContainSingle()
+            .Which.Value<string>("id").Should().Be(existingAdjunctId,
+                "existing adjuncts from the DLCS stub asset must be returned when Adjuncts was null on the request");
+        A.CallTo(() => manifestStorageManager.UpsertManifestInStorage(
+                A<IIIFManifest>._, A<Models.Database.Collections.Manifest>._, A<CancellationToken>._))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
+    public async Task Upsert_CallsSaveManifestInStorage_WhenAdjunctsNull_AndNoPriorDlcsContent()
+    {
+        // Arrange - items-only manifest: no painted resources, no adjuncts, no prior DLCS batches.
+        // ManifestMerger must NOT be called — doing so would make an unnecessary DLCS NQ call.
+        var (slug, resourceId) = TestIdentifiers.SlugResource();
+
+        var dbManifest = await presentationContext.Manifests.AddTestManifest(resourceId, slug: slug);
+        await presentationContext.SaveChangesAsync();
+
+        A.CallTo(() => dlcsClient.GetCustomerImages(Customer, A<string>._, A<CancellationToken>._))
+            .Returns(Task.FromResult<IList<JObject>>([]));
+
+        var manifest = new PresentationManifest { Slug = slug, Adjuncts = null };
+
+        var request = new UpsertManifestRequest(resourceId, dbManifest.Entity.Etag.ToString(), Customer, manifest,
+            manifest.AsJson(), false);
+
+        // Act
+        var result = await sut.Upsert(request, CancellationToken.None);
+
+        // Assert
+        result.Error.Should().BeNull();
+        result.Entity.Adjuncts.Should().BeNull("no DLCS content exists so the stub asset has no adjuncts to return");
+        A.CallTo(() => manifestStorageManager.UpsertManifestInStorage(
+                A<IIIFManifest>._, A<Models.Database.Collections.Manifest>._, A<CancellationToken>._))
+            .MustNotHaveHappened();
+    }
+
+    [Fact]
+    public async Task Upsert_CallsUpsertManifestInStorage_WhenAdjunctsEmpty_AndNoAssets()
+    {
+        // Arrange - no painted resources, adjuncts = [] (explicit clear) and stub asset already in DLCS.
+        // canBeBuiltUpfront = true (stub exists, no new batch needed) so ManifestMerger must be called.
+        var (slug, resourceId) = TestIdentifiers.SlugResource();
+
+        var dbManifest = await presentationContext.Manifests.AddTestManifest(resourceId, slug: slug);
+        await presentationContext.SaveChangesAsync();
+
+        // Return the existing stub when DLCS is queried for it, simulating the stub already existing
+        var stubAssetName = $"Manifest_{resourceId}";
+        var stubAssetId = $"{Customer}/0/{stubAssetName}";
+        A.CallTo(() => dlcsClient.GetCustomerImages(Customer,
+                A<IList<string>>.That.Matches(l => l.Contains(stubAssetId)), A<CancellationToken>._))
+            .Returns(Task.FromResult<IList<JObject>>(
+            [
+                JObject.Parse($$"""{ "id": "{{stubAssetName}}", "space": 0 }""")
+            ]));
+
+        A.CallTo(() => manifestStorageManager.UpsertManifestInStorage(
+                A<IIIFManifest>._, A<Models.Database.Collections.Manifest>._, A<CancellationToken>._))
+            .ReturnsLazily(() => new IIIFManifest());
+
+        var manifest = new PresentationManifest { Slug = slug, Adjuncts = [] };
+
+        var request = new UpsertManifestRequest(resourceId, dbManifest.Entity.Etag.ToString(), Customer, manifest,
+            manifest.AsJson(), false);
+
+        // Act
+        var result = await sut.Upsert(request, CancellationToken.None);
+
+        // Assert
+        result.Error.Should().BeNull();
+        result.Entity.Adjuncts.Should().BeEmpty("Adjuncts=[] (explicit clear) on the request is preserved as-is, not replaced by stub asset lookup");
+        A.CallTo(() => manifestStorageManager.UpsertManifestInStorage(
+                A<IIIFManifest>._, A<Models.Database.Collections.Manifest>._, A<CancellationToken>._))
+            .MustHaveHappenedOnceExactly();
     }
 
     [Fact]

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestManifestAdjunctTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestManifestAdjunctTests.cs
@@ -471,6 +471,8 @@ public class ModifyManifestManifestAdjunctTests : IClassFixture<PresentationAppF
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var responseManifest = await response.ReadAsPresentationResponseAsync<PresentationManifest>();
+        responseManifest!.Adjuncts.Should().BeNull("clearing adjuncts returns no adjuncts property, not an empty array");
 
         // Existing adjunct deleted
         A.CallTo(() => DLCSApiClient.DeleteAdjuncts(Customer,

--- a/src/IIIFPresentation/API/Converters/ManifestConverter.cs
+++ b/src/IIIFPresentation/API/Converters/ManifestConverter.cs
@@ -74,6 +74,21 @@ public static class ManifestConverter
     }
 
     /// <summary>
+    /// Populates <see cref="PresentationManifest.Adjuncts"/> from the manifest-level stub asset in <paramref name="assets"/>.
+    /// No-op if the stub asset is not present or carries no adjuncts.
+    /// </summary>
+    public static void SetManifestLevelAdjuncts(this PresentationManifest manifest,
+        Dictionary<string, JObject> assets, int customerId, string manifestId)
+    {
+        var stubAssetId = ResourceAdjunctInteractions.GetResourceStubAssetId(manifest, customerId, manifestId);
+        var stubAsset = assets.Values.FirstOrDefault(a => a[AssetProperties.Id]?.Value<string>() == stubAssetId.Asset);
+        if (stubAsset?[AssetProperties.Adjuncts] is JArray adjunctsArray)
+        {
+            manifest.Adjuncts = adjunctsArray.OfType<JObject>().ToList();
+        }
+    }
+
+    /// <summary>
     /// Generate <see cref="Canvas"/> items from provided <see cref="CanvasPainting"/> collection. These can be either
     /// provisional canvases that have the structure of the final canvases without the full content-resource details, or completed canvases
     /// </summary>

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestReadService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestReadService.cs
@@ -78,7 +78,7 @@ public class ManifestReadService(
 
         // If the DLCS lookup failed, assets will be null (error already logged in DlcsManifestCoordinator).
         // Return the manifest without manifest-level adjuncts rather than failing the GET.
-        if (assets != null) SetManifestLevelAdjuncts(manifest, assets, customerId, dbManifest.Id);
+        if (assets != null) manifest.SetManifestLevelAdjuncts(assets, customerId, dbManifest.Id);
 
         manifest = manifest.SetGeneratedFields(dbManifest, pathGenerator, settingsBasedPathGenerator, assets,
             m => Enumerable.Single(m.Hierarchy!, h => h.Canonical));
@@ -93,14 +93,4 @@ public class ManifestReadService(
         return FetchEntityResult<PresentationManifest>.Success(manifest, etag);
     }
 
-    private static void SetManifestLevelAdjuncts(PresentationManifest manifest,
-        Dictionary<string, JObject> assets, int customerId, string manifestId)
-    {
-        var stubAssetId = ResourceAdjunctInteractions.GetResourceStubAssetId(manifest, customerId, manifestId);
-        var stubAsset = assets.Values.FirstOrDefault(a => a[AssetProperties.Id]?.Value<string>() == stubAssetId.Asset);
-        if (stubAsset?[AssetProperties.Adjuncts] is JArray adjunctsArray)
-        {
-            manifest.Adjuncts = adjunctsArray.OfType<JObject>().ToList();
-        }
-    }
 }

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
@@ -300,7 +300,7 @@ public class ManifestWriteService(
     {
         var assets = await dlcsManifestCoordinator.GetAssets(customerId, dbManifest, cancellationToken);
 
-        if (presentationManifest.Adjuncts == null && assets != null)
+        if (assets != null)
         {
             presentationManifest.SetManifestLevelAdjuncts(assets, customerId, dbManifest.Id);
         }

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
@@ -298,9 +298,15 @@ public class ManifestWriteService(
     private async Task<PresUpdateResult> GeneratePresentationSuccessResult(PresentationManifest presentationManifest,
         int customerId, DbManifest dbManifest, WriteResult writeResult, CancellationToken cancellationToken)
     {
+        var assets = await dlcsManifestCoordinator.GetAssets(customerId, dbManifest, cancellationToken);
+
+        if (presentationManifest.Adjuncts == null && assets != null)
+        {
+            presentationManifest.SetManifestLevelAdjuncts(assets, customerId, dbManifest.Id);
+        }
+
         return PresUpdateResult.Success(
-            presentationManifest.SetGeneratedFields(dbManifest, pathGenerator, savedManifestPathGenerator,
-                await dlcsManifestCoordinator.GetAssets(customerId, dbManifest, cancellationToken)),
+            presentationManifest.SetGeneratedFields(dbManifest, pathGenerator, savedManifestPathGenerator, assets),
             writeResult,
             dbManifest?.Etag);
     }
@@ -402,7 +408,8 @@ public class ManifestWriteService(
     {
         var iiifManifest = request.RawRequestBody.ToManifest();
         var hasAssets = request.PresentationManifest.PaintedResources.HasAsset();
-        var hasAdjuncts = request.PresentationManifest.Adjuncts != null;
+        var hasAdjuncts = request.PresentationManifest.Adjuncts != null
+            || dbManifest.Batches?.Any(b => b.DeliverableType == DeliverableType.Adjunct) == true;
 
         if (canBeBuiltUpfront && (hasAssets || hasAdjuncts))
         {


### PR DESCRIPTION
## What does this change?

Resolves #610 

This PR causes null or empty adjuncts to correctly go through the serialiser (in the case of null with adjuncts) and have the manifest-level `adjuncts` property be correctly filled out.  I.e.: with adjunct for `null` 

> [!Note]
> there's a slight variation from how `[]` works in painted resources if  `"adjuncts": []` is sent in a `canvasPainting` asset the API will respond with `"adjuncts": []`, whereas in a manifest-level adjunct, the response will be to not have an `adjuncts` property.  There is a bug tracking this on #612


