### PR TITLE
Remove hardcoded batchIds in tests

### DIFF
--- a/src/IIIFPresentation/API.Tests/Integration/GetManifestTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/GetManifestTests.cs
@@ -389,7 +389,7 @@ public class GetManifestTests : IClassFixture<PresentationAppFactory<Program>>
         var id = TestIdentifiers.IdWithSuffix(suffix: "_ingestingAssets");
 
         // Arrange and Act
-        var dbManifest = await dbContext.Manifests.AddTestManifest(id, batchId: 1);
+        var dbManifest = await dbContext.Manifests.AddTestManifest(id, batchId: TestIdentifiers.BatchId());
         await dbContext.CanvasPaintings.AddTestCanvasPainting(dbManifest.Entity,
             createdDate: DateTime.UtcNow.AddDays(-1),
             assetId: new AssetId(1, 2, PaintedResource),
@@ -447,7 +447,7 @@ public class GetManifestTests : IClassFixture<PresentationAppFactory<Program>>
     {
         // Arrange
         var id = nameof(Get_IiifManifest_Hierarchical_ReturnsNotFoundWhenIngesting);
-        await dbContext.Manifests.AddTestManifest(id, batchId: 2);
+        await dbContext.Manifests.AddTestManifest(id, batchId: TestIdentifiers.BatchId());
 
         await amazonS3.PutObjectAsync(new()
         {
@@ -472,7 +472,7 @@ public class GetManifestTests : IClassFixture<PresentationAppFactory<Program>>
         // Arrange
         var id = nameof(Get_IiifManifest_Hierarchical_ReturnsOkWhenIngestingButHasIngestedBefore);
 
-        await dbContext.Manifests.AddTestManifest(id, batchId: 3, ingested: true);
+        await dbContext.Manifests.AddTestManifest(id, batchId: TestIdentifiers.BatchId(), ingested: true);
 
         await amazonS3.PutObjectAsync(new()
         {

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestUpdateTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestUpdateTests.cs
@@ -15,6 +15,7 @@ using Models.API.General;
 using Models.API.Manifest;
 using Models.Database.General;
 using Repository;
+using Test.Helpers;
 using Test.Helpers.Helpers;
 using Test.Helpers.Integration;
 
@@ -529,7 +530,7 @@ public class ModifyManifestUpdateTests : IClassFixture<PresentationAppFactory<Pr
     {
         // Arrange
         var dbManifest =
-            (await dbContext.Manifests.AddTestManifest(batchId: 800, ingested: true, canvasPaintings:
+            (await dbContext.Manifests.AddTestManifest(batchId: TestIdentifiers.BatchId(), ingested: true, canvasPaintings:
             [
                 new Models.Database.CanvasPainting
                 {

--- a/src/IIIFPresentation/DLCS.Tests/API/DlcsApiClientTests.cs
+++ b/src/IIIFPresentation/DLCS.Tests/API/DlcsApiClientTests.cs
@@ -6,7 +6,6 @@ using DLCS.Exceptions;
 using DLCS.Models;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
-using Models.API.Manifest;
 using Models.DLCS;
 using Newtonsoft.Json.Linq;
 using Stubbery;


### PR DESCRIPTION
## What does this change?

Use TestIdentifiers helper instead to ensure uniqueness. Attempting to resolve intermittent test failures via CI