### PR TITLE
Remove check for ingesting manifest

### DIFF
--- a/docs/ADR/0003-locking.md
+++ b/docs/ADR/0003-locking.md
@@ -8,12 +8,7 @@
 
 When a manifest is ingested through the API there's the possibility of same manifest being "double-submitted" by a caller.  This causes major issues with processing as it can mean batches are double-submitted that means manifests are unable to be processed by the background handler.  [This has occasionally been seen in the live environment](https://github.com/dlcs/iiif-presentation/issues/507).  As such, some way of locking manifests from being processed twice needs to be implemented.
 
-There are a couple of scenarios where this issue can occur:
-
-1. Concurrent requests through the API (essentially execute a second call with the same values while waiting for the first to complete)
-2. Resending the same request while the manifest is waiting for processing in the background handler, but a response has been received from the API for the first request
-
-The second is fairly easy to solve by essentially checking if the manifest is still ingesting, and if it is respond with a `409 Conflict` response instead of accepting the manifest.  However, the first is more complex as it requires a solution to lock a manifest from being processed after the first attempt has been made.
+This occurs due to concurrent duplicate requests through the API (essentially executing a second call with the same values while waiting for the first to complete)
 
 ## Decision drivers
 

--- a/src/IIIFPresentation/API.Tests/Features/Manifest/ManifestWriteServiceTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Manifest/ManifestWriteServiceTests.cs
@@ -969,49 +969,6 @@ public class ManifestWriteServiceTests
         ingestedManifest.Error.Should().Be("Suspected asset from image body (1/1/someItem) and services (1/1/different) point to different managed assets");
         ingestedManifest.WriteResult.Should().Be(WriteResult.BadRequest);
     }
-    
-    [Fact]
-    public async Task Upsert_ReturnsConflict_WhenManifestHasIngestingAssetBatch()
-    {
-        // Arrange
-        var (slug, resourceId) = TestIdentifiers.SlugResource();
-
-        var dbManifest = await presentationContext.Manifests.AddTestManifest(resourceId, slug: slug, batchId: TestIdentifiers.BatchId());
-        await presentationContext.SaveChangesAsync();
-
-        var manifest = new PresentationManifest { Slug = slug };
-        var request = new UpsertManifestRequest(resourceId, dbManifest.Entity.Etag.ToString(), Customer, manifest,
-            manifest.AsJson(), false);
-
-        // Act
-        var result = await sut.Upsert(request, CancellationToken.None);
-
-        // Assert
-        result.WriteResult.Should().Be(WriteResult.Conflict);
-        result.Error.Should().Contain("currently being ingested");
-    }
-
-    [Fact]
-    public async Task Upsert_ReturnsConflict_WhenManifestHasIngestingAdjunctBatch()
-    {
-        // Arrange
-        var (slug, resourceId) = TestIdentifiers.SlugResource();
-
-        var dbManifest = await presentationContext.Manifests.AddTestManifest(resourceId, slug: slug);
-        await presentationContext.Batches.AddTestBatch(TestIdentifiers.BatchId(), dbManifest.Entity, DbDeliverableType.Adjunct);
-        await presentationContext.SaveChangesAsync();
-
-        var manifest = new PresentationManifest { Slug = slug };
-        var request = new UpsertManifestRequest(resourceId, dbManifest.Entity.Etag.ToString(), Customer, manifest,
-            manifest.AsJson(), false);
-
-        // Act
-        var result = await sut.Upsert(request, CancellationToken.None);
-
-        // Assert
-        result.WriteResult.Should().Be(WriteResult.Conflict);
-        result.Error.Should().Contain("currently being ingested");
-    }
 
     [Fact]
     public async Task Upsert_ReturnsConflict_WhenManifestIsAlreadyBeingProcessed()

--- a/src/IIIFPresentation/API.Tests/Integration/ModifyManifestUpdateTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/ModifyManifestUpdateTests.cs
@@ -40,29 +40,6 @@ public class ModifyManifestUpdateTests : IClassFixture<PresentationAppFactory<Pr
     
         storageFixture.DbFixture.CleanUp();
     }
-    
-    [Fact]
-    public async Task PutFlatId_Update_Conflict_IfManifestIsCurrentlyIngesting()
-    {
-        // Arrange
-        var dbManifest = (await dbContext.Manifests.AddTestManifest(batchId: TestIdentifiers.BatchId())).Entity;
-        await dbContext.SaveChangesAsync();
-        var manifest = dbManifest.ToPresentationManifest();
-
-        var requestMessage =
-            HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Put, $"{Customer}/manifests/{dbManifest.Id}",
-                manifest.AsJson(), dbContext.GetETag(dbManifest));
-
-        // Act
-        var response = await httpClient.AsCustomer().SendAsync(requestMessage);
-
-        // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
-
-        var error = await response.ReadAsPresentationResponseAsync<Error>();
-        error!.ErrorTypeUri.Should()
-            .Be("http://localhost/errors/ModifyCollectionType/ManifestCurrentlyIngesting");
-    }
 
     [Fact]
     public async Task PutFlatId_Update_PreConditionFailed_IfEtagNotProvided()

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
@@ -127,13 +127,6 @@ public class ManifestWriteService(
                 return await CreateInternal(request, request.ManifestId, cancellationToken);
             }
 
-            if (existingManifest.IsIngesting())
-            {
-                logger.LogDebug("Manifest {ManifestId} for Customer {CustomerId} is currently ingesting, rejecting write",
-                    request.ManifestId, request.CustomerId);
-                return UpsertErrorHelper.ManifestCurrentlyIngesting<PresentationManifest>();
-            }
-
             return await UpdateInternal(request, existingManifest, cancellationToken);
         }
         catch (DlcsException ex)


### PR DESCRIPTION
## What does this change?

Addition to #614 to remove the additional check for currently ingesting - this should instead be caught by the incorrect Etag instead