### PR TITLE
Allow submitting pipelines following asset ingestion

### DIFF
--- a/src/IIIFPresentation/API.Tests/Features/Manifest/ManifestWriteServiceTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Manifest/ManifestWriteServiceTests.cs
@@ -130,9 +130,10 @@ public class ManifestWriteServiceTests
         A.CallTo(() => textBuilderClient.UpsertJob(A<DbManifest>._, A<PipelineJob>._, A<CancellationToken>._))
             .Invokes((DbManifest _, PipelineJob job, CancellationToken _) => job.Status = PipelineJobStatus.Waiting)
             .Returns(true);
+        var pipelineJobService = new PipelineJobService(sutContext, textBuilderClient, new NullLogger<PipelineJobService>());
         sut = new ManifestWriteService(sutContext, identityManager, canvasPaintingResolver,
             new TestPathGenerator(presentationGenerator), settingsBasedPathGenerator, dlcsManifestCoordinator, parentSlugParser,
-            manifestStorageManager, dlcsManifestMerger, pathRewriteParser, manifestLockManager, textBuilderClient,
+            manifestStorageManager, dlcsManifestMerger, pathRewriteParser, manifestLockManager, pipelineJobService,
             new NullLogger<ManifestWriteService>());
 
         var parentCollection =

--- a/src/IIIFPresentation/API.Tests/Features/Manifest/ManifestWriteServiceTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Manifest/ManifestWriteServiceTests.cs
@@ -1241,7 +1241,7 @@ public class ManifestWriteServiceTests
         var flatId = result.Entity.FlatId;
         var pipelineJob = presentationContext.PipelineJobs.FirstOrDefault(p => p.ManifestId == flatId);
         pipelineJob.Should().NotBeNull("pipeline job must be registered even when submission is deferred");
-        pipelineJob!.Status.Should().Be(PipelineJobStatus.Waiting);
+        pipelineJob!.Status.Should().Be(PipelineJobStatus.NotSubmitted);
     }
 
     [Fact]
@@ -1308,7 +1308,7 @@ public class ManifestWriteServiceTests
         // Pipeline job must be persisted so the batch-completion handler can submit it later
         var pipelineJob = presentationContext.PipelineJobs.FirstOrDefault(p => p.ManifestId == flatId);
         pipelineJob.Should().NotBeNull("pipeline job must be registered even when submission is deferred");
-        pipelineJob!.Status.Should().Be(PipelineJobStatus.Waiting);
+        pipelineJob!.Status.Should().Be(PipelineJobStatus.NotSubmitted);
     }
 
     [Fact]

--- a/src/IIIFPresentation/API.Tests/Features/Manifest/ManifestWriteServiceTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Manifest/ManifestWriteServiceTests.cs
@@ -1183,6 +1183,135 @@ public class ManifestWriteServiceTests
     }
 
     [Fact]
+    public async Task Create_RegistersPipelineJob_ButDoesNotCallTextServices_WhenManifestHasPipelineAndAssetsBeingIngested()
+    {
+        // Arrange - new assets require DLCS ingestion (canBeBuiltUpfront=false), so text-services submission
+        // must be deferred until the batch-completion background handler fires.
+        dynamic asset = new JObject();
+        var (slug, resourceId, assetId, canvasId) = TestIdentifiers.SlugResourceAssetCanvas();
+        asset.id = assetId;
+
+        // Return an ingesting batch so canBeBuiltUpfront=false — the asset is being processed by DLCS
+        A.CallTo(() => dlcsClient.IngestDeliverables(A<int>._, A<List<JObject>>._, A<bool>._, A<CancellationToken>._))
+            .Returns([
+                new()
+                {
+                    ResourceId = $"https://dlcs.api/customers/{Customer}/queue/batches/1001",
+                    Submitted = DateTime.UtcNow
+                }
+            ]);
+
+        var manifest = new PresentationManifest
+        {
+            Slug = slug,
+            Items =
+            [
+                ManifestTestCreator.Canvas($"https://base/0/canvases/{canvasId}")
+                    .WithImage()
+                    .Build()
+            ],
+            PaintedResources =
+            [
+                new PaintedResource
+                {
+                    Asset = asset,
+                    CanvasPainting = new CanvasPainting
+                    {
+                        CanvasId = TestIdentifiers.IdCanvasPainting().canvasPaintingId,
+                        CanvasOrder = 1
+                    }
+                }
+            ],
+            Pipeline = [new PipelineItem { Name = "text", Config = new PipelineConfig { Action = "Index" } }]
+        };
+        var request = new UpsertManifestRequest(resourceId, null, Customer, manifest, manifest.AsJson(), true);
+
+        // Act
+        var result = await sut.Create(request, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.WriteResult.Should().Be(WriteResult.Accepted);
+
+        // Text-services must NOT be called — ingestion is still in progress
+        A.CallTo(() => textServicesClient.UpsertJob(A<DbManifest>._, A<PipelineJob>._, A<CancellationToken>._))
+            .MustNotHaveHappened();
+
+        // Pipeline job must be persisted so the batch-completion handler can submit it later
+        var flatId = result.Entity.FlatId;
+        var pipelineJob = presentationContext.PipelineJobs.FirstOrDefault(p => p.ManifestId == flatId);
+        pipelineJob.Should().NotBeNull("pipeline job must be registered even when submission is deferred");
+        pipelineJob!.Status.Should().Be(PipelineJobStatus.Waiting);
+    }
+
+    [Fact]
+    public async Task Upsert_RegistersPipelineJob_ButDoesNotCallTextServices_WhenManifestHasPipelineAndAssetsBeingIngested()
+    {
+        // Arrange — create a bare manifest first, then update it to add pipeline + new assets still being ingested
+        var (slug, resourceId, assetId, canvasId) = TestIdentifiers.SlugResourceAssetCanvas();
+
+        var createManifest = new PresentationManifest { Slug = slug };
+        var createRequest = new UpsertManifestRequest(resourceId, null, Customer, createManifest, createManifest.AsJson(), true);
+        var createResult = await sut.Create(createRequest, CancellationToken.None);
+        var flatId = createResult.Entity.FlatId;
+        var etag = presentationContext.Manifests.First(m => m.Id == flatId).Etag.ToString();
+
+        // Return an ingesting batch so canBeBuiltUpfront=false — the asset is being processed by DLCS
+        A.CallTo(() => dlcsClient.IngestDeliverables(A<int>._, A<List<JObject>>._, A<bool>._, A<CancellationToken>._))
+            .Returns([
+                new()
+                {
+                    ResourceId = $"https://dlcs.api/customers/{Customer}/queue/batches/1002",
+                    Submitted = DateTime.UtcNow
+                }
+            ]);
+
+        dynamic asset = new JObject();
+        asset.id = assetId;
+
+        var updateManifest = new PresentationManifest
+        {
+            Slug = slug,
+            Items =
+            [
+                ManifestTestCreator.Canvas($"https://base/0/canvases/{canvasId}")
+                    .WithImage()
+                    .Build()
+            ],
+            PaintedResources =
+            [
+                new PaintedResource
+                {
+                    Asset = asset,
+                    CanvasPainting = new CanvasPainting
+                    {
+                        CanvasId = TestIdentifiers.IdCanvasPainting().canvasPaintingId,
+                        CanvasOrder = 1
+                    }
+                }
+            ],
+            Pipeline = [new PipelineItem { Name = "text", Config = new PipelineConfig { Action = "Index" } }]
+        };
+        var updateRequest = new UpsertManifestRequest(flatId, etag, Customer, updateManifest, updateManifest.AsJson(), false);
+
+        // Act
+        var result = await sut.Upsert(updateRequest, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.WriteResult.Should().Be(WriteResult.Accepted);
+
+        // Text-services must NOT be called — DLCS batch is still ingesting
+        A.CallTo(() => textServicesClient.UpsertJob(A<DbManifest>._, A<PipelineJob>._, A<CancellationToken>._))
+            .MustNotHaveHappened();
+
+        // Pipeline job must be persisted so the batch-completion handler can submit it later
+        var pipelineJob = presentationContext.PipelineJobs.FirstOrDefault(p => p.ManifestId == flatId);
+        pipelineJob.Should().NotBeNull("pipeline job must be registered even when submission is deferred");
+        pipelineJob!.Status.Should().Be(PipelineJobStatus.Waiting);
+    }
+
+    [Fact]
     public async Task Create_ReturnsError_AndDoesNotPersistManifest_WhenTextServiceSubmissionFails()
     {
         // Arrange

--- a/src/IIIFPresentation/API.Tests/Features/Manifest/ManifestWriteServiceTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Manifest/ManifestWriteServiceTests.cs
@@ -56,7 +56,7 @@ public class ManifestWriteServiceTests
     private readonly IManifestStorageManager manifestStorageManager;
     private readonly IDlcsManifestMerger dlcsManifestMerger;
     private readonly LockManager manifestLockManager;
-    private readonly ITextBuilderClient textServicesClient;
+    private readonly ITextBuilderClient textBuilderClient;
     
     public ManifestWriteServiceTests(PresentationContextFixture dbFixture)
     {
@@ -126,12 +126,12 @@ public class ManifestWriteServiceTests
 
         manifestLockManager = new LockManager();
 
-        textServicesClient = A.Fake<ITextBuilderClient>();
-        A.CallTo(() => textServicesClient.UpsertJob(A<DbManifest>._, A<PipelineJob>._, A<CancellationToken>._))
+        textBuilderClient = A.Fake<ITextBuilderClient>();
+        A.CallTo(() => textBuilderClient.UpsertJob(A<DbManifest>._, A<PipelineJob>._, A<CancellationToken>._))
             .Returns(true);
         sut = new ManifestWriteService(sutContext, identityManager, canvasPaintingResolver,
             new TestPathGenerator(presentationGenerator), settingsBasedPathGenerator, dlcsManifestCoordinator, parentSlugParser,
-            manifestStorageManager, dlcsManifestMerger, pathRewriteParser, manifestLockManager, textServicesClient,
+            manifestStorageManager, dlcsManifestMerger, pathRewriteParser, manifestLockManager, textBuilderClient,
             new NullLogger<ManifestWriteService>());
 
         var parentCollection =
@@ -1170,7 +1170,7 @@ public class ManifestWriteServiceTests
         var result = await sut.Create(request, CancellationToken.None);
 
         // Assert
-        A.CallTo(() => textServicesClient.UpsertJob(A<DbManifest>._, A<PipelineJob>._, A<CancellationToken>._))
+        A.CallTo(() => textBuilderClient.UpsertJob(A<DbManifest>._, A<PipelineJob>._, A<CancellationToken>._))
             .MustHaveHappenedOnceExactly();
 
         var flatId = result.Entity.FlatId;
@@ -1234,7 +1234,7 @@ public class ManifestWriteServiceTests
         result.WriteResult.Should().Be(WriteResult.Accepted);
 
         // Text-services must NOT be called — ingestion is still in progress
-        A.CallTo(() => textServicesClient.UpsertJob(A<DbManifest>._, A<PipelineJob>._, A<CancellationToken>._))
+        A.CallTo(() => textBuilderClient.UpsertJob(A<DbManifest>._, A<PipelineJob>._, A<CancellationToken>._))
             .MustNotHaveHappened();
 
         // Pipeline job must be persisted so the batch-completion handler can submit it later
@@ -1302,7 +1302,7 @@ public class ManifestWriteServiceTests
         result.WriteResult.Should().Be(WriteResult.Accepted);
 
         // Text-services must NOT be called — DLCS batch is still ingesting
-        A.CallTo(() => textServicesClient.UpsertJob(A<DbManifest>._, A<PipelineJob>._, A<CancellationToken>._))
+        A.CallTo(() => textBuilderClient.UpsertJob(A<DbManifest>._, A<PipelineJob>._, A<CancellationToken>._))
             .MustNotHaveHappened();
 
         // Pipeline job must be persisted so the batch-completion handler can submit it later
@@ -1322,7 +1322,7 @@ public class ManifestWriteServiceTests
             Pipeline = [new PipelineItem { Name = "text", Config = new PipelineConfig { Action = "Index" } }]
         };
         var request = new UpsertManifestRequest(resourceId, null, Customer, manifest, manifest.AsJson(), true);
-        A.CallTo(() => textServicesClient.UpsertJob(A<DbManifest>._, A<PipelineJob>._, A<CancellationToken>._))
+        A.CallTo(() => textBuilderClient.UpsertJob(A<DbManifest>._, A<PipelineJob>._, A<CancellationToken>._))
             .Returns(false);
 
         // Act
@@ -1358,7 +1358,7 @@ public class ManifestWriteServiceTests
         await sut.Create(request, CancellationToken.None);
 
         // Assert
-        A.CallTo(() => textServicesClient.UpsertJob(A<DbManifest>._, A<PipelineJob>._, A<CancellationToken>._))
+        A.CallTo(() => textBuilderClient.UpsertJob(A<DbManifest>._, A<PipelineJob>._, A<CancellationToken>._))
             .MustNotHaveHappened();
     }
 
@@ -1417,7 +1417,7 @@ public class ManifestWriteServiceTests
 
         // Assert
         result.WriteResult.Should().Be(WriteResult.Accepted);
-        A.CallTo(() => textServicesClient.UpsertJob(A<DbManifest>._, A<PipelineJob>._, A<CancellationToken>._))
+        A.CallTo(() => textBuilderClient.UpsertJob(A<DbManifest>._, A<PipelineJob>._, A<CancellationToken>._))
             .MustHaveHappenedTwiceExactly();
 
         var jobs = presentationContext.PipelineJobs.Where(p => p.ManifestId == flatId).ToList();

--- a/src/IIIFPresentation/API.Tests/Features/Manifest/ManifestWriteServiceTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Manifest/ManifestWriteServiceTests.cs
@@ -1331,7 +1331,7 @@ public class ManifestWriteServiceTests
         // Assert
         result.IsSuccess.Should().BeFalse();
         result.WriteResult.Should().Be(WriteResult.Error);
-        result.Error.Should().Contain("text service");
+        result.Error.Should().Contain("text pipeline job");
 
         // Manifest and pipeline job should be rolled back — resubmitting the same slug must not conflict
         presentationContext.Hierarchy.Any(h => h.Slug == slug).Should().BeFalse();

--- a/src/IIIFPresentation/API.Tests/Features/Manifest/ManifestWriteServiceTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Manifest/ManifestWriteServiceTests.cs
@@ -128,6 +128,7 @@ public class ManifestWriteServiceTests
 
         textBuilderClient = A.Fake<ITextBuilderClient>();
         A.CallTo(() => textBuilderClient.UpsertJob(A<DbManifest>._, A<PipelineJob>._, A<CancellationToken>._))
+            .Invokes((DbManifest _, PipelineJob job, CancellationToken _) => job.Status = PipelineJobStatus.Waiting)
             .Returns(true);
         sut = new ManifestWriteService(sutContext, identityManager, canvasPaintingResolver,
             new TestPathGenerator(presentationGenerator), settingsBasedPathGenerator, dlcsManifestCoordinator, parentSlugParser,

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
@@ -539,7 +539,6 @@ public class ManifestWriteService(
                 ModifyCollectionType.CannotConnectToTextService, WriteResult.Error);
         }
 
-        job.Status = PipelineJobStatus.Waiting;
         await dbContext.SaveChangesAsync(cancellationToken);
         return null;
     }

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
@@ -540,6 +540,8 @@ public class ManifestWriteService(
                 ModifyCollectionType.CannotConnectToTextService, WriteResult.Error);
         }
 
+        job.Status = PipelineJobStatus.Waiting;
+        await dbContext.SaveChangesAsync(cancellationToken);
         return null;
     }
 
@@ -555,7 +557,7 @@ public class ManifestWriteService(
                     ManifestId = dbManifest.Id,
                     JobType = PipelineJobType.TextService,
                     CustomerId = dbManifest.CustomerId,
-                    Status = PipelineJobStatus.Waiting,
+                    Status = PipelineJobStatus.NotSubmitted,
                     Config = pipelineItem.Config,
                     Created = DateTime.UtcNow
                 };

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
@@ -99,7 +99,7 @@ public class ManifestWriteService(
     IDlcsManifestMerger dlcsManifestMerger,
     IPathRewriteParser pathRewriteParser,
     ILockManager manifestLockManager,
-    ITextBuilderClient textServicesClient,
+    ITextBuilderClient textBuilderClient,
     ILogger<ManifestWriteService> logger) : IManifestWrite
 {
     /// <summary>
@@ -487,15 +487,15 @@ public class ManifestWriteService(
 
         if (request.PresentationManifest.HasPipelineJob())
         {
-            var registerError = await RegisterPipelineJob(dbManifest, request.PresentationManifest.Pipeline!, cancellationToken);
-            if (registerError != null) return registerError;
+            var job = await RegisterPipelineJob(dbManifest, request.PresentationManifest.Pipeline!, cancellationToken);
+            if (job == null) return null;
 
             // Submission is deferred until DLCS batch completion when assets are still being ingested
             if (canBeBuiltUpfront)
             {
                 logger.LogDebug("Submitting pipeline job for manifest {ManifestId}",
                     dbManifest.Id);
-                return await SubmitPipelineJob(dbManifest, cancellationToken);
+                return await SubmitPipelineJob(dbManifest, job, cancellationToken);
             }
 
             logger.LogDebug("Deferring text-services submission for manifest {ManifestId} until DLCS batch completion",
@@ -509,8 +509,8 @@ public class ManifestWriteService(
     }
 
     // Persists the pipeline job record within the open transaction.
-    // Returns a failure result if no recognised pipeline type is found, otherwise null.
-    private async Task<PresUpdateResult?> RegisterPipelineJob(DbManifest dbManifest,
+    // Returns the created job, or null if no recognised pipeline type was found (nothing registered).
+    private async Task<PipelineJob?> RegisterPipelineJob(DbManifest dbManifest,
         List<PipelineItem> pipeline, CancellationToken cancellationToken)
     {
         var job = BuildPipelineJob(dbManifest, pipeline);
@@ -523,16 +523,16 @@ public class ManifestWriteService(
 
         (dbManifest.PipelineJobs ??= []).Add(job);
         await dbContext.SaveChangesAsync(cancellationToken);
-        return null;
+        return job;
     }
 
-    // Submits the most recently registered pipeline job to text-services.
+    // Submits the given pipeline job to text-services.
     // The HTTP call runs while the DB transaction is still open — the HttpClient should be configured with a short
     // timeout to bound this window. On failure the staged manifest is cleaned up so the caller can retry cleanly.
-    private async Task<PresUpdateResult?> SubmitPipelineJob(DbManifest dbManifest, CancellationToken cancellationToken)
+    private async Task<PresUpdateResult?> SubmitPipelineJob(DbManifest dbManifest, PipelineJob job,
+        CancellationToken cancellationToken)
     {
-        var job = dbManifest.PipelineJobs!.Last();
-        if (!await textServicesClient.UpsertJob(dbManifest, job, cancellationToken))
+        if (!await textBuilderClient.UpsertJob(dbManifest, job, cancellationToken))
         {
             logger.LogError("Failed to submit {JobType} pipeline job for manifest {ManifestId}", job.JobType, dbManifest.Id);
             await manifestStorageManager.DeleteStagedManifest(dbManifest);

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
@@ -487,8 +487,20 @@ public class ManifestWriteService(
 
         if (request.PresentationManifest.HasPipelineJob())
         {
-            return await RegisterAndSubmitPipelineJobs(dbManifest, request.PresentationManifest.Pipeline!,
-                cancellationToken);
+            var registerError = await RegisterPipelineJob(dbManifest, request.PresentationManifest.Pipeline!, cancellationToken);
+            if (registerError != null) return registerError;
+
+            // Submission is deferred until DLCS batch completion when assets are still being ingested
+            if (canBeBuiltUpfront)
+            {
+                logger.LogDebug("Submitting pipeline job for manifest {ManifestId}",
+                    dbManifest.Id);
+                return await SubmitPipelineJob(dbManifest, cancellationToken);
+            }
+
+            logger.LogDebug("Deferring text-services submission for manifest {ManifestId} until DLCS batch completion",
+                dbManifest.Id);
+            return null;
         }
 
         // save changes called if there are no pipeline jobs
@@ -496,14 +508,9 @@ public class ManifestWriteService(
         return null;
     }
 
-    // Persists pipeline job entities within the open transaction, then submits to external services.
-    // Submitting after SaveChangesAsync ensures DB state is consistent if the HTTP call fails and
-    // the transaction is rolled back by the caller.
-    // Trade-off: the HTTP call to text-services runs while the DB transaction is still open.
-    // This keeps rollback simple (no compensating transaction needed) at the cost of holding
-    // the transaction for the duration of the HTTP round-trip. The HttpClient should be
-    // configured with a short timeout to bound this window.
-    private async Task<PresUpdateResult?> RegisterAndSubmitPipelineJobs(DbManifest dbManifest,
+    // Persists the pipeline job record within the open transaction.
+    // Returns a failure result if no recognised pipeline type is found, otherwise null.
+    private async Task<PresUpdateResult?> RegisterPipelineJob(DbManifest dbManifest,
         List<PipelineItem> pipeline, CancellationToken cancellationToken)
     {
         var job = BuildPipelineJob(dbManifest, pipeline);
@@ -516,7 +523,15 @@ public class ManifestWriteService(
 
         (dbManifest.PipelineJobs ??= []).Add(job);
         await dbContext.SaveChangesAsync(cancellationToken);
+        return null;
+    }
 
+    // Submits the most recently registered pipeline job to text-services.
+    // The HTTP call runs while the DB transaction is still open — the HttpClient should be configured with a short
+    // timeout to bound this window. On failure the staged manifest is cleaned up so the caller can retry cleanly.
+    private async Task<PresUpdateResult?> SubmitPipelineJob(DbManifest dbManifest, CancellationToken cancellationToken)
+    {
+        var job = dbManifest.PipelineJobs!.Last();
         if (!await textServicesClient.UpsertJob(dbManifest, job, cancellationToken))
         {
             logger.LogError("Failed to submit {JobType} pipeline job for manifest {ManifestId}", job.JobType, dbManifest.Id);

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
@@ -99,7 +99,7 @@ public class ManifestWriteService(
     IDlcsManifestMerger dlcsManifestMerger,
     IPathRewriteParser pathRewriteParser,
     ILockManager manifestLockManager,
-    ITextBuilderClient textBuilderClient,
+    IPipelineJobService pipelineJobService,
     ILogger<ManifestWriteService> logger) : IManifestWrite
 {
     /// <summary>
@@ -487,7 +487,8 @@ public class ManifestWriteService(
 
         if (request.PresentationManifest.HasPipelineJob())
         {
-            var job = await PersistPipelineJob(dbManifest, request.PresentationManifest.Pipeline!, cancellationToken);
+            var job = await pipelineJobService.PersistPipelineJob(dbManifest, request.PresentationManifest.Pipeline!,
+                cancellationToken);
             if (job == null) return null;
 
             if (canBeBuiltUpfront)
@@ -507,60 +508,20 @@ public class ManifestWriteService(
         return null;
     }
 
-    // Persists the pipeline job record within the open transaction.
-    // Returns the created job, or null if no recognised pipeline type was found (nothing registered).
-    private async Task<PipelineJob?> PersistPipelineJob(DbManifest dbManifest,
-        List<PipelineItem> pipeline, CancellationToken cancellationToken)
-    {
-        var job = BuildPipelineJob(dbManifest, pipeline);
-        if (job == null)
-        {
-            logger.LogWarning("No recognised pipeline type for manifest {ManifestId}; ignoring pipeline", dbManifest.Id);
-            await dbContext.SaveChangesAsync(cancellationToken);
-            return null;
-        }
-
-        (dbManifest.PipelineJobs ??= []).Add(job);
-        await dbContext.SaveChangesAsync(cancellationToken);
-        return job;
-    }
-
     // Submits the given pipeline job to text-services.
     // The HTTP call runs while the DB transaction is still open — the HttpClient should be configured with a short
     // timeout to bound this window. On failure the staged manifest is cleaned up so the caller can retry cleanly.
     private async Task<PresUpdateResult?> SubmitPipelineJob(DbManifest dbManifest, PipelineJob job,
         CancellationToken cancellationToken)
     {
-        if (!await textBuilderClient.UpsertJob(dbManifest, job, cancellationToken))
+        if (!await pipelineJobService.SubmitPipelineJob(dbManifest, job, cancellationToken))
         {
-            logger.LogError("Failed to submit {JobType} pipeline job for manifest {ManifestId}", job.JobType, dbManifest.Id);
             await manifestStorageManager.DeleteStagedManifest(dbManifest);
             return PresUpdateResult.Failure("Error submitting text pipeline job",
                 ModifyCollectionType.CannotConnectToTextService, WriteResult.Error);
         }
 
         await dbContext.SaveChangesAsync(cancellationToken);
-        return null;
-    }
-
-    private static PipelineJob? BuildPipelineJob(DbManifest dbManifest, List<PipelineItem> pipeline)
-    {
-        // Returns a job for the first recognised pipeline step; additional steps of the same type are ignored.
-        foreach (var pipelineItem in pipeline)
-        {
-            if (string.Equals(pipelineItem.Name, PipelineHelper.TextPipeline.Name, StringComparison.OrdinalIgnoreCase))
-            {
-                return new PipelineJob
-                {
-                    ManifestId = dbManifest.Id,
-                    JobType = PipelineJobType.TextService,
-                    CustomerId = dbManifest.CustomerId,
-                    Status = PipelineJobStatus.NotSubmitted,
-                    Config = pipelineItem.Config,
-                    Created = DateTime.UtcNow
-                };
-            }
-        }
         return null;
     }
 

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
@@ -493,8 +493,7 @@ public class ManifestWriteService(
             // Submission is deferred until DLCS batch completion when assets are still being ingested
             if (canBeBuiltUpfront)
             {
-                logger.LogDebug("Submitting pipeline job for manifest {ManifestId}",
-                    dbManifest.Id);
+                logger.LogDebug("Submitting pipeline job for manifest {ManifestId}", dbManifest.Id);
                 return await SubmitPipelineJob(dbManifest, job, cancellationToken);
             }
 

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
@@ -487,16 +487,16 @@ public class ManifestWriteService(
 
         if (request.PresentationManifest.HasPipelineJob())
         {
-            var job = await RegisterPipelineJob(dbManifest, request.PresentationManifest.Pipeline!, cancellationToken);
+            var job = await PersistPipelineJob(dbManifest, request.PresentationManifest.Pipeline!, cancellationToken);
             if (job == null) return null;
 
-            // Submission is deferred until DLCS batch completion when assets are still being ingested
             if (canBeBuiltUpfront)
             {
                 logger.LogDebug("Submitting pipeline job for manifest {ManifestId}", dbManifest.Id);
                 return await SubmitPipelineJob(dbManifest, job, cancellationToken);
             }
 
+            // Submission is deferred until DLCS batch completion when assets are still being ingested
             logger.LogDebug("Deferring text-services submission for manifest {ManifestId} until DLCS batch completion",
                 dbManifest.Id);
             return null;
@@ -509,7 +509,7 @@ public class ManifestWriteService(
 
     // Persists the pipeline job record within the open transaction.
     // Returns the created job, or null if no recognised pipeline type was found (nothing registered).
-    private async Task<PipelineJob?> RegisterPipelineJob(DbManifest dbManifest,
+    private async Task<PipelineJob?> PersistPipelineJob(DbManifest dbManifest,
         List<PipelineItem> pipeline, CancellationToken cancellationToken)
     {
         var job = BuildPipelineJob(dbManifest, pipeline);
@@ -535,7 +535,7 @@ public class ManifestWriteService(
         {
             logger.LogError("Failed to submit {JobType} pipeline job for manifest {ManifestId}", job.JobType, dbManifest.Id);
             await manifestStorageManager.DeleteStagedManifest(dbManifest);
-            return PresUpdateResult.Failure("Error connecting to the text service",
+            return PresUpdateResult.Failure("Error submitting text pipeline job",
                 ModifyCollectionType.CannotConnectToTextService, WriteResult.Error);
         }
 

--- a/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionMessageHandlerTests.cs
+++ b/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionMessageHandlerTests.cs
@@ -81,9 +81,10 @@ public class BatchCompletionMessageHandlerTests
         var manifestS3Manager = new ManifestS3Manager(iiifS3, pathGenerator,
             new TestOptionsMonitor<BehaviourSettings>(behaviour), new NullLogger<ManifestS3Manager>());
         var customerIdProvider = new SetCustomerIdProvider();
+        var pipelineJobService = new PipelineJobService(sutContext, textBuilderClient, new NullLogger<PipelineJobService>());
 
         sut = new BatchCompletionMessageHandler(sutContext, customerIdProvider, manifestS3Manager, dlcsManifestMerger,
-            textBuilderClient, new NullLogger<BatchCompletionMessageHandler>());
+            pipelineJobService, new NullLogger<BatchCompletionMessageHandler>());
     }
 
     [Fact]

--- a/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionMessageHandlerTests.cs
+++ b/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionMessageHandlerTests.cs
@@ -471,7 +471,7 @@ public class BatchCompletionMessageHandlerTests
             ManifestId = manifestId,
             CustomerId = CustomerId,
             JobType = PipelineJobType.TextService,
-            Status = PipelineJobStatus.Waiting,
+            Status = PipelineJobStatus.NotSubmitted,
             Created = DateTime.UtcNow
         });
         await dbContext.SaveChangesAsync();
@@ -497,18 +497,21 @@ public class BatchCompletionMessageHandlerTests
             .MustHaveHappened(1, Times.Exactly);
         A.CallTo(() => iiifS3.DeleteIIIFFromS3(A<IHierarchyResource>._, A<bool>._))
             .MustNotHaveHappened();
+        var pipelineJob = await dbContext.PipelineJobs.SingleAsync(p => p.ManifestId == manifestId);
+        pipelineJob.Status.Should().Be(PipelineJobStatus.Waiting,
+            "successful submission moves the job from NotSubmitted to Waiting for its completion notification");
     }
 
     [Fact]
-    public async Task HandleMessage_SubmitsMostRecentWaitingJob_WhenManifestHasMultiplePipelineJobs()
+    public async Task HandleMessage_SubmitsMostRecentNotSubmittedJob_WhenManifestHasMultiplePipelineJobs()
     {
         // Arrange - a manifest can accumulate multiple PipelineJob rows (each resubmission creates a new one for
         // history, see ManifestWriteServiceTests.Create_AddsNewPipelineJob_WhenJobAlreadyExistsForManifest), so more
-        // than one can be Waiting at once. The newest should be the one submitted, matching the "latest wins"
+        // than one can be NotSubmitted at once. The newest should be the one submitted, matching the "latest wins"
         // convention TextServiceJobCompletionMessageHandler already uses when resolving a completion notification.
         var batchId = TestIdentifiers.BatchId();
         var (identifier, canvasPaintingId) = TestIdentifiers.IdCanvasPainting(
-            nameof(HandleMessage_SubmitsMostRecentWaitingJob_WhenManifestHasMultiplePipelineJobs));
+            nameof(HandleMessage_SubmitsMostRecentNotSubmittedJob_WhenManifestHasMultiplePipelineJobs));
         var manifestId = TestIdentifiers.IdWithSuffix(suffix: "pipeline_multiple");
         const int space = 2;
         var assetId = new AssetId(CustomerId, space, identifier);
@@ -528,7 +531,7 @@ public class BatchCompletionMessageHandlerTests
             ManifestId = manifestId,
             CustomerId = CustomerId,
             JobType = PipelineJobType.TextService,
-            Status = PipelineJobStatus.Waiting,
+            Status = PipelineJobStatus.NotSubmitted,
             Created = DateTime.UtcNow.AddMinutes(-10)
         });
         var newestJobEntry = await dbContext.PipelineJobs.AddAsync(new PipelineJob
@@ -536,7 +539,7 @@ public class BatchCompletionMessageHandlerTests
             ManifestId = manifestId,
             CustomerId = CustomerId,
             JobType = PipelineJobType.TextService,
-            Status = PipelineJobStatus.Waiting,
+            Status = PipelineJobStatus.NotSubmitted,
             Created = DateTime.UtcNow
         });
         await dbContext.SaveChangesAsync();
@@ -585,7 +588,7 @@ public class BatchCompletionMessageHandlerTests
             ManifestId = manifestId,
             CustomerId = CustomerId,
             JobType = PipelineJobType.TextService,
-            Status = PipelineJobStatus.Waiting,
+            Status = PipelineJobStatus.NotSubmitted,
             Created = DateTime.UtcNow
         });
         await dbContext.SaveChangesAsync();
@@ -603,6 +606,9 @@ public class BatchCompletionMessageHandlerTests
         A.CallTo(() => iiifS3.SaveIIIFToS3(A<ResourceBase>._, A<Manifest>.That.Matches(m => m.Id == manifestId),
                 A<string>._, false, A<CancellationToken>._))
             .MustNotHaveHappened();
+        var pipelineJob = await dbContext.PipelineJobs.SingleAsync(p => p.ManifestId == manifestId);
+        pipelineJob.Status.Should().Be(PipelineJobStatus.NotSubmitted,
+            "failed submission must not move the job out of NotSubmitted, so a retry picks it up again");
     }
 
     [Fact]

--- a/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionMessageHandlerTests.cs
+++ b/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionMessageHandlerTests.cs
@@ -24,6 +24,7 @@ using Services.Manifests;
 using Services.Manifests.AWS;
 using Services.Manifests.Helpers;
 using Services.Manifests.Settings;
+using Services.TextServices;
 using Test.Helpers;
 using Test.Helpers.Helpers;
 using Test.Helpers.Integration;
@@ -40,6 +41,7 @@ public class BatchCompletionMessageHandlerTests
     private readonly BatchCompletionMessageHandler sut;
     private readonly IDlcsOrchestratorClient dlcsClient;
     private readonly IIIIFS3Service iiifS3;
+    private readonly ITextBuilderClient textBuilderClient;
     private readonly BehaviourSettings behaviour = new();
     private readonly PathSettings pathSettings;
     private const int CustomerId = 1;
@@ -50,12 +52,15 @@ public class BatchCompletionMessageHandlerTests
         // The context from dbFixture doesn't track changes so setup/assert
         dbContext = dbFixture.DbContext;
         dbFixture.CustomerIdProvider.SetCustomerId(CustomerId);
-        
+
         // The context used by SUT should track to mimic context config in actual use
         var sutContext = dbFixture.GetNewPresentationContext(dbFixture.CustomerIdProvider);
-        
+
         dlcsClient = A.Fake<IDlcsOrchestratorClient>();
         iiifS3 = A.Fake<IIIIFS3Service>();
+        textBuilderClient = A.Fake<ITextBuilderClient>();
+        A.CallTo(() => textBuilderClient.UpsertJob(A<Manifest>._, A<PipelineJob>._, A<CancellationToken>._))
+            .Returns(true);
 
         pathSettings = new PathSettings
         {
@@ -66,10 +71,10 @@ public class BatchCompletionMessageHandlerTests
         {
             ApiUri = new Uri("https://dlcs.api")
         }), new SettingsDrivenPresentationConfigGenerator(Options.Create(pathSettings)));
-        
+
         var pathRewriteParser =
             new PathRewriteParser(Options.Create(PathRewriteOptions.Default), new NullLogger<PathRewriteParser>());
-        
+
         var manifestMerger = new ManifestMerger(pathGenerator, pathRewriteParser, new NullLogger<ManifestMerger>());
         var dlcsManifestMerger = new DlcsManifestMerger(dlcsClient, manifestMerger, new NullLogger<DlcsManifestMerger>());
         var manifestS3Manager = new ManifestS3Manager(iiifS3, pathGenerator,
@@ -77,7 +82,7 @@ public class BatchCompletionMessageHandlerTests
         var customerIdProvider = new SetCustomerIdProvider();
 
         sut = new BatchCompletionMessageHandler(sutContext, customerIdProvider, manifestS3Manager, dlcsManifestMerger,
-            new NullLogger<BatchCompletionMessageHandler>());
+            textBuilderClient, new NullLogger<BatchCompletionMessageHandler>());
     }
 
     [Fact]
@@ -434,6 +439,112 @@ public class BatchCompletionMessageHandlerTests
         paintingAnnotation.Id.Should().Be($"https://localhost:5000/1/canvases/{canvasPaintingId}/annotations/1",
             "PaintingAnnotation Id overwritten");
         paintingAnnotation.Target.As<Canvas>().Id.Should().Be(expectedCanvasId, "Target Id matches canvasId");
+    }
+
+    [Theory]
+    [InlineData(DeliverableType.Asset)]
+    [InlineData(DeliverableType.Adjunct)]
+    public async Task HandleMessage_SavesMergedManifestToStaging_AndSubmitsTextJob_WhenPipelineJobPending(
+        DeliverableType deliverableType)
+    {
+        // Arrange
+        var batchId = TestIdentifiers.BatchId();
+        var (identifier, canvasPaintingId) = TestIdentifiers.IdCanvasPainting(
+            nameof(HandleMessage_SavesMergedManifestToStaging_AndSubmitsTextJob_WhenPipelineJobPending) + deliverableType);
+        var manifestId = TestIdentifiers.IdWithSuffix(suffix: $"{deliverableType}_pipeline");
+        const int space = 2;
+        var assetId = new AssetId(CustomerId, space, identifier);
+
+        behaviour.StoresPayloadsSince = DateTimeOffset.Now.AddMonths(1);
+
+        A.CallTo(() => iiifS3.ReadIIIFFromS3<IIIFManifest>(A<IHierarchyResource>._, BucketLocationType.Staging,
+                A<CancellationToken>._))
+            .ReturnsLazily(() => new IIIFManifest { Id = identifier });
+
+        var manifestEntityEntry = await dbContext.Manifests.AddTestManifest(id: manifestId, batchId: batchId);
+        var manifest = manifestEntityEntry.Entity;
+        manifest.Batches!.Single().DeliverableType = deliverableType;
+        await dbContext.CanvasPaintings.AddTestCanvasPainting(manifest, id: canvasPaintingId, assetId: assetId,
+            canvasOrder: 1, ingesting: true);
+        await dbContext.PipelineJobs.AddAsync(new PipelineJob
+        {
+            ManifestId = manifestId,
+            CustomerId = CustomerId,
+            JobType = PipelineJobType.TextService,
+            Status = PipelineJobStatus.Waiting,
+            Created = DateTime.UtcNow
+        });
+        await dbContext.SaveChangesAsync();
+
+        A.CallTo(() => dlcsClient.RetrieveAssetsForManifest(A<int>._, A<string>._, A<CancellationToken>._))
+            .Returns(ManifestTestCreator.GenerateMinimalNamedQueryManifest(assetId, pathSettings.PresentationApiUrl));
+
+        var message = QueueHelper.CreateQueueMessage(batchId, CustomerId, deliverableType: deliverableType);
+
+        // Act
+        var result = await sut.HandleMessage(message, CancellationToken.None);
+
+        // Assert
+        result.Should().BeTrue();
+        A.CallTo(() => iiifS3.SaveIIIFToS3(A<ResourceBase>._, A<Manifest>.That.Matches(m => m.Id == manifestId),
+                A<string>._, true, A<CancellationToken>._))
+            .MustHaveHappened(1, Times.Exactly);
+        A.CallTo(() => iiifS3.SaveIIIFToS3(A<ResourceBase>._, A<Manifest>.That.Matches(m => m.Id == manifestId),
+                A<string>._, false, A<CancellationToken>._))
+            .MustNotHaveHappened();
+        A.CallTo(() => textBuilderClient.UpsertJob(A<Manifest>.That.Matches(m => m.Id == manifestId),
+                A<PipelineJob>._, A<CancellationToken>._))
+            .MustHaveHappened(1, Times.Exactly);
+        A.CallTo(() => iiifS3.DeleteIIIFFromS3(A<IHierarchyResource>._, A<bool>._))
+            .MustNotHaveHappened();
+    }
+
+    [Fact]
+    public async Task HandleMessage_ReturnsFalse_WhenPipelineJobPending_AndTextServicesFails()
+    {
+        // Arrange
+        var batchId = TestIdentifiers.BatchId();
+        var (identifier, canvasPaintingId) = TestIdentifiers.IdCanvasPainting();
+        var manifestId = TestIdentifiers.IdWithSuffix(suffix: "pipeline_fail");
+        const int space = 2;
+        var assetId = new AssetId(CustomerId, space, identifier);
+
+        behaviour.StoresPayloadsSince = DateTimeOffset.Now.AddMonths(1);
+
+        A.CallTo(() => iiifS3.ReadIIIFFromS3<IIIFManifest>(A<IHierarchyResource>._, BucketLocationType.Staging,
+                A<CancellationToken>._))
+            .ReturnsLazily(() => new IIIFManifest { Id = identifier });
+
+        A.CallTo(() => textBuilderClient.UpsertJob(A<Manifest>._, A<PipelineJob>._, A<CancellationToken>._))
+            .Returns(false);
+
+        var manifestEntityEntry = await dbContext.Manifests.AddTestManifest(id: manifestId, batchId: batchId);
+        var manifest = manifestEntityEntry.Entity;
+        await dbContext.CanvasPaintings.AddTestCanvasPainting(manifest, id: canvasPaintingId, assetId: assetId,
+            canvasOrder: 1, ingesting: true);
+        await dbContext.PipelineJobs.AddAsync(new PipelineJob
+        {
+            ManifestId = manifestId,
+            CustomerId = CustomerId,
+            JobType = PipelineJobType.TextService,
+            Status = PipelineJobStatus.Waiting,
+            Created = DateTime.UtcNow
+        });
+        await dbContext.SaveChangesAsync();
+
+        A.CallTo(() => dlcsClient.RetrieveAssetsForManifest(A<int>._, A<string>._, A<CancellationToken>._))
+            .Returns(ManifestTestCreator.GenerateMinimalNamedQueryManifest(assetId, pathSettings.PresentationApiUrl));
+
+        var message = QueueHelper.CreateQueueMessage(batchId, CustomerId);
+
+        // Act
+        var result = await sut.HandleMessage(message, CancellationToken.None);
+
+        // Assert
+        result.Should().BeFalse("text-services submission failed, message should be retried");
+        A.CallTo(() => iiifS3.SaveIIIFToS3(A<ResourceBase>._, A<Manifest>.That.Matches(m => m.Id == manifestId),
+                A<string>._, false, A<CancellationToken>._))
+            .MustNotHaveHappened();
     }
 
     [Fact]

--- a/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionMessageHandlerTests.cs
+++ b/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionMessageHandlerTests.cs
@@ -500,6 +500,64 @@ public class BatchCompletionMessageHandlerTests
     }
 
     [Fact]
+    public async Task HandleMessage_SubmitsMostRecentWaitingJob_WhenManifestHasMultiplePipelineJobs()
+    {
+        // Arrange - a manifest can accumulate multiple PipelineJob rows (each resubmission creates a new one for
+        // history, see ManifestWriteServiceTests.Create_AddsNewPipelineJob_WhenJobAlreadyExistsForManifest), so more
+        // than one can be Waiting at once. The newest should be the one submitted, matching the "latest wins"
+        // convention TextServiceJobCompletionMessageHandler already uses when resolving a completion notification.
+        var batchId = TestIdentifiers.BatchId();
+        var (identifier, canvasPaintingId) = TestIdentifiers.IdCanvasPainting(
+            nameof(HandleMessage_SubmitsMostRecentWaitingJob_WhenManifestHasMultiplePipelineJobs));
+        var manifestId = TestIdentifiers.IdWithSuffix(suffix: "pipeline_multiple");
+        const int space = 2;
+        var assetId = new AssetId(CustomerId, space, identifier);
+
+        behaviour.StoresPayloadsSince = DateTimeOffset.Now.AddMonths(1);
+
+        A.CallTo(() => iiifS3.ReadIIIFFromS3<IIIFManifest>(A<IHierarchyResource>._, BucketLocationType.Staging,
+                A<CancellationToken>._))
+            .ReturnsLazily(() => new IIIFManifest { Id = identifier });
+
+        var manifestEntityEntry = await dbContext.Manifests.AddTestManifest(id: manifestId, batchId: batchId);
+        var manifest = manifestEntityEntry.Entity;
+        await dbContext.CanvasPaintings.AddTestCanvasPainting(manifest, id: canvasPaintingId, assetId: assetId,
+            canvasOrder: 1, ingesting: true);
+        await dbContext.PipelineJobs.AddAsync(new PipelineJob
+        {
+            ManifestId = manifestId,
+            CustomerId = CustomerId,
+            JobType = PipelineJobType.TextService,
+            Status = PipelineJobStatus.Waiting,
+            Created = DateTime.UtcNow.AddMinutes(-10)
+        });
+        var newestJobEntry = await dbContext.PipelineJobs.AddAsync(new PipelineJob
+        {
+            ManifestId = manifestId,
+            CustomerId = CustomerId,
+            JobType = PipelineJobType.TextService,
+            Status = PipelineJobStatus.Waiting,
+            Created = DateTime.UtcNow
+        });
+        await dbContext.SaveChangesAsync();
+        var newestJobId = newestJobEntry.Entity.Id;
+
+        A.CallTo(() => dlcsClient.RetrieveAssetsForManifest(A<int>._, A<string>._, A<CancellationToken>._))
+            .Returns(ManifestTestCreator.GenerateMinimalNamedQueryManifest(assetId, pathSettings.PresentationApiUrl));
+
+        var message = QueueHelper.CreateQueueMessage(batchId, CustomerId);
+
+        // Act
+        var result = await sut.HandleMessage(message, CancellationToken.None);
+
+        // Assert
+        result.Should().BeTrue();
+        A.CallTo(() => textBuilderClient.UpsertJob(A<Manifest>.That.Matches(m => m.Id == manifestId),
+                A<PipelineJob>.That.Matches(j => j.Id == newestJobId), A<CancellationToken>._))
+            .MustHaveHappened(1, Times.Exactly);
+    }
+
+    [Fact]
     public async Task HandleMessage_ReturnsFalse_WhenPipelineJobPending_AndTextServicesFails()
     {
         // Arrange

--- a/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionMessageHandlerTests.cs
+++ b/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionMessageHandlerTests.cs
@@ -60,6 +60,7 @@ public class BatchCompletionMessageHandlerTests
         iiifS3 = A.Fake<IIIIFS3Service>();
         textBuilderClient = A.Fake<ITextBuilderClient>();
         A.CallTo(() => textBuilderClient.UpsertJob(A<Manifest>._, A<PipelineJob>._, A<CancellationToken>._))
+            .Invokes((Manifest _, PipelineJob job, CancellationToken _) => job.Status = PipelineJobStatus.Waiting)
             .Returns(true);
 
         pathSettings = new PathSettings

--- a/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionPathRewriteTests.cs
+++ b/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionPathRewriteTests.cs
@@ -11,6 +11,7 @@ using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Models.Database.Collections;
+using Models.Database.General;
 using Models.DLCS;
 using Repository;
 using Repository.Paths;
@@ -18,6 +19,7 @@ using Services.Manifests;
 using Services.Manifests.AWS;
 using Services.Manifests.Helpers;
 using Services.Manifests.Settings;
+using Services.TextServices;
 using Test.Helpers;
 using Test.Helpers.Helpers;
 using Test.Helpers.Integration;
@@ -97,8 +99,12 @@ public class BatchCompletionPathRewriteTests
             new TestOptionsMonitor<BehaviourSettings>(behaviour),
             new NullLogger<ManifestS3Manager>());
 
+        var textBuilderClient = A.Fake<ITextBuilderClient>();
+        A.CallTo(() => textBuilderClient.UpsertJob(A<Manifest>._, A<PipelineJob>._, A<CancellationToken>._))
+            .Returns(true);
+
         sut = new BatchCompletionMessageHandler(sutContext, dbFixture.CustomerIdProvider, manifestS3Manager,
-            dlcsManifestMerger, new NullLogger<BatchCompletionMessageHandler>());
+            dlcsManifestMerger, textBuilderClient, new NullLogger<BatchCompletionMessageHandler>());
     }
     
     [Fact]

--- a/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionPathRewriteTests.cs
+++ b/src/IIIFPresentation/BackgroundHandler.Tests/BatchCompletion/BatchCompletionPathRewriteTests.cs
@@ -102,9 +102,10 @@ public class BatchCompletionPathRewriteTests
         var textBuilderClient = A.Fake<ITextBuilderClient>();
         A.CallTo(() => textBuilderClient.UpsertJob(A<Manifest>._, A<PipelineJob>._, A<CancellationToken>._))
             .Returns(true);
+        var pipelineJobService = new PipelineJobService(sutContext, textBuilderClient, new NullLogger<PipelineJobService>());
 
         sut = new BatchCompletionMessageHandler(sutContext, dbFixture.CustomerIdProvider, manifestS3Manager,
-            dlcsManifestMerger, textBuilderClient, new NullLogger<BatchCompletionMessageHandler>());
+            dlcsManifestMerger, pipelineJobService, new NullLogger<BatchCompletionMessageHandler>());
     }
     
     [Fact]

--- a/src/IIIFPresentation/BackgroundHandler/BatchCompletion/BatchCompletionMessageHandler.cs
+++ b/src/IIIFPresentation/BackgroundHandler/BatchCompletion/BatchCompletionMessageHandler.cs
@@ -37,7 +37,7 @@ public class BatchCompletionMessageHandler(
         // Load batch the incoming message is referring to
         var batch = await dbContext.Batches
             .Include(b => b.Manifest).ThenInclude(m => m.CanvasPaintings)
-            .Include(b => b.Manifest).ThenInclude(m => m.PipelineJobs)
+            .Include(b => b.Manifest).ThenInclude(m => m.PipelineJobs.Where(p => p.Status == PipelineJobStatus.NotSubmitted))
             .AsSplitQuery()
             .SingleOrDefaultAsync(
                 b => b.Id == batchCompletionMessage.Id && b.DeliverableType == batchCompletionMessage.DeliverableType,
@@ -68,7 +68,7 @@ public class BatchCompletionMessageHandler(
             {
                 if (TryCompleteBatch(batch, batchCompletionMessage.Finished))
                 {
-                    if (!await CompleteManifestFromStaging(batch.Manifest!, cancellationToken)) return false;
+                    if (!await TryCompleteManifestFromStaging(batch.Manifest!, cancellationToken)) return false;
                 }
                 else
                 {
@@ -95,7 +95,7 @@ public class BatchCompletionMessageHandler(
 
     // Read the staged manifest, merge in the DLCS content, then either hand off to the text pipeline or
     // save the final manifest directly. Returns false if text-services submission fails (caller should retry).
-    private async Task<bool> CompleteManifestFromStaging(Manifest dbManifest, CancellationToken cancellationToken)
+    private async Task<bool> TryCompleteManifestFromStaging(Manifest dbManifest, CancellationToken cancellationToken)
     {
         var staged = await manifestS3Manager.ReadStagedManifest(dbManifest, cancellationToken);
         staged.Manifest.ThrowIfNull(nameof(staged.Manifest), "Manifest was not found in staging location");
@@ -104,10 +104,10 @@ public class BatchCompletionMessageHandler(
 
         // A manifest can accumulate multiple PipelineJob rows (each resubmission creates a new one for history - see
         // ManifestWriteServiceTests.Create_AddsNewPipelineJob_WhenJobAlreadyExistsForManifest), so more than one can
-        // be NotSubmitted at once. Pick the most recent, matching the "latest wins" convention
-        // TextServiceJobCompletionMessageHandler already uses to resolve which job a completion applies to.
+        // be NotSubmitted at once (the query above only loads NotSubmitted jobs). Pick the most recent, matching the
+        // "latest wins" convention TextServiceJobCompletionMessageHandler already uses to resolve which job a
+        // completion applies to.
         var pendingPipelineJob = dbManifest.PipelineJobs?
-            .Where(p => p.Status == PipelineJobStatus.NotSubmitted)
             .OrderByDescending(p => p.Created)
             .FirstOrDefault();
         if (pendingPipelineJob != null)
@@ -115,7 +115,10 @@ public class BatchCompletionMessageHandler(
             Logger.LogInformation(
                 "Manifest {ManifestId} has pending text pipeline; saving merged content to staging and submitting job",
                 dbManifest.Id);
-            await manifestS3Manager.SaveManifestInStorage(merged, dbManifest, staged.Original, saveToStaging: true,
+            // originalPayload omitted: staged.Original was just read unchanged from OriginalStaging, so re-saving it
+            // here would be a no-op write. TextServiceJobCompletionMessageHandler re-reads it fresh when promoting
+            // the final manifest, so nothing downstream depends on it being re-written at this staging step.
+            await manifestS3Manager.SaveManifestInStorage(merged, dbManifest, originalPayload: null, saveToStaging: true,
                 cancellationToken);
             if (!await textBuilderClient.UpsertJob(dbManifest, pendingPipelineJob, cancellationToken))
             {

--- a/src/IIIFPresentation/BackgroundHandler/BatchCompletion/BatchCompletionMessageHandler.cs
+++ b/src/IIIFPresentation/BackgroundHandler/BatchCompletion/BatchCompletionMessageHandler.cs
@@ -8,6 +8,7 @@ using Repository;
 using Repository.Helpers;
 using Services.Manifests;
 using Services.Manifests.AWS;
+using Services.TextServices;
 using Manifest = Models.Database.Collections.Manifest;
 
 namespace BackgroundHandler.BatchCompletion;
@@ -17,6 +18,7 @@ public class BatchCompletionMessageHandler(
     ICustomerIdProvider customerIdProvider,
     IManifestStorageManager manifestS3Manager,
     IDlcsManifestMerger dlcsManifestMerger,
+    ITextBuilderClient textBuilderClient,
     ILogger<BatchCompletionMessageHandler> logger)
     : MessageHandlerBase<BatchCompletionMessage>(logger)
 {
@@ -33,8 +35,9 @@ public class BatchCompletionMessageHandler(
     private async Task<bool> TryUpdateManifest(BatchCompletionMessage batchCompletionMessage, int approximateReceiveCount, CancellationToken cancellationToken)
     {
         // Load batch the incoming message is referring to
-        var batch = await dbContext.Batches.Include(b => b.Manifest)
-            .ThenInclude(m => m.CanvasPaintings)
+        var batch = await dbContext.Batches
+            .Include(b => b.Manifest).ThenInclude(m => m.CanvasPaintings)
+            .Include(b => b.Manifest).ThenInclude(m => m.PipelineJobs)
             .SingleOrDefaultAsync(
                 b => b.Id == batchCompletionMessage.Id && b.DeliverableType == batchCompletionMessage.DeliverableType,
                 cancellationToken);
@@ -64,7 +67,7 @@ public class BatchCompletionMessageHandler(
             {
                 if (TryCompleteBatch(batch, batchCompletionMessage.Finished))
                 {
-                    await CompleteManifestFromStaging(batch.Manifest!, cancellationToken);
+                    if (!await CompleteManifestFromStaging(batch.Manifest!, cancellationToken)) return false;
                 }
                 else
                 {
@@ -89,17 +92,36 @@ public class BatchCompletionMessageHandler(
         return true;
     }
 
-    // Read the staged manifest, merge in the DLCS content, save the final manifest (promoting any stored original
-    // payload) then remove the staging artifacts.
-    private async Task CompleteManifestFromStaging(Manifest dbManifest, CancellationToken cancellationToken)
+    // Read the staged manifest, merge in the DLCS content, then either hand off to the text pipeline or
+    // save the final manifest directly. Returns false if text-services submission fails (caller should retry).
+    private async Task<bool> CompleteManifestFromStaging(Manifest dbManifest, CancellationToken cancellationToken)
     {
         var staged = await manifestS3Manager.ReadStagedManifest(dbManifest, cancellationToken);
         staged.Manifest.ThrowIfNull(nameof(staged.Manifest), "Manifest was not found in staging location");
 
         var merged = await dlcsManifestMerger.Augment(staged.Manifest!, dbManifest, cancellationToken);
+
+        var pendingPipelineJob = dbManifest.PipelineJobs?.FirstOrDefault(p => p.Status == PipelineJobStatus.Waiting);
+        if (pendingPipelineJob != null)
+        {
+            Logger.LogInformation(
+                "Manifest {ManifestId} has pending text pipeline; saving merged content to staging and submitting job",
+                dbManifest.Id);
+            await manifestS3Manager.SaveManifestInStorage(merged, dbManifest, staged.Original, saveToStaging: true,
+                cancellationToken);
+            if (!await textBuilderClient.UpsertJob(dbManifest, pendingPipelineJob, cancellationToken))
+            {
+                Logger.LogError("Failed to submit text-builder job for manifest {ManifestId} after batch completion",
+                    dbManifest.Id);
+                return false;
+            }
+            return true;
+        }
+
         await manifestS3Manager.SaveManifestInStorage(merged, dbManifest, staged.Original, saveToStaging: false,
             cancellationToken);
         await manifestS3Manager.DeleteStagedManifest(dbManifest);
+        return true;
     }
 
     /// <summary>

--- a/src/IIIFPresentation/BackgroundHandler/BatchCompletion/BatchCompletionMessageHandler.cs
+++ b/src/IIIFPresentation/BackgroundHandler/BatchCompletion/BatchCompletionMessageHandler.cs
@@ -120,11 +120,7 @@ public class BatchCompletionMessageHandler(
             // the final manifest, so nothing downstream depends on it being re-written at this staging step.
             await manifestS3Manager.SaveManifestInStorage(merged, dbManifest, originalPayload: null, saveToStaging: true,
                 cancellationToken);
-            if (!await pipelineJobService.SubmitPipelineJob(dbManifest, pendingPipelineJob, cancellationToken))
-            {
-                return false;
-            }
-            return true;
+            return await pipelineJobService.SubmitPipelineJob(dbManifest, pendingPipelineJob, cancellationToken);
         }
 
         await manifestS3Manager.SaveManifestInStorage(merged, dbManifest, staged.Original, saveToStaging: false,

--- a/src/IIIFPresentation/BackgroundHandler/BatchCompletion/BatchCompletionMessageHandler.cs
+++ b/src/IIIFPresentation/BackgroundHandler/BatchCompletion/BatchCompletionMessageHandler.cs
@@ -18,7 +18,7 @@ public class BatchCompletionMessageHandler(
     ICustomerIdProvider customerIdProvider,
     IManifestStorageManager manifestS3Manager,
     IDlcsManifestMerger dlcsManifestMerger,
-    ITextBuilderClient textBuilderClient,
+    IPipelineJobService pipelineJobService,
     ILogger<BatchCompletionMessageHandler> logger)
     : MessageHandlerBase<BatchCompletionMessage>(logger)
 {
@@ -120,10 +120,8 @@ public class BatchCompletionMessageHandler(
             // the final manifest, so nothing downstream depends on it being re-written at this staging step.
             await manifestS3Manager.SaveManifestInStorage(merged, dbManifest, originalPayload: null, saveToStaging: true,
                 cancellationToken);
-            if (!await textBuilderClient.UpsertJob(dbManifest, pendingPipelineJob, cancellationToken))
+            if (!await pipelineJobService.SubmitPipelineJob(dbManifest, pendingPipelineJob, cancellationToken))
             {
-                Logger.LogError("Failed to submit text-builder job for manifest {ManifestId} after batch completion",
-                    dbManifest.Id);
                 return false;
             }
             return true;

--- a/src/IIIFPresentation/BackgroundHandler/BatchCompletion/BatchCompletionMessageHandler.cs
+++ b/src/IIIFPresentation/BackgroundHandler/BatchCompletion/BatchCompletionMessageHandler.cs
@@ -101,7 +101,14 @@ public class BatchCompletionMessageHandler(
 
         var merged = await dlcsManifestMerger.Augment(staged.Manifest!, dbManifest, cancellationToken);
 
-        var pendingPipelineJob = dbManifest.PipelineJobs?.FirstOrDefault(p => p.Status == PipelineJobStatus.Waiting);
+        // A manifest can accumulate multiple PipelineJob rows (each resubmission creates a new one for history - see
+        // ManifestWriteServiceTests.Create_AddsNewPipelineJob_WhenJobAlreadyExistsForManifest), so more than one can
+        // be Waiting at once. Pick the most recent, matching the "latest wins" convention
+        // TextServiceJobCompletionMessageHandler already uses to resolve which job a completion applies to.
+        var pendingPipelineJob = dbManifest.PipelineJobs?
+            .Where(p => p.Status == PipelineJobStatus.Waiting)
+            .OrderByDescending(p => p.Created)
+            .FirstOrDefault();
         if (pendingPipelineJob != null)
         {
             Logger.LogInformation(

--- a/src/IIIFPresentation/BackgroundHandler/BatchCompletion/BatchCompletionMessageHandler.cs
+++ b/src/IIIFPresentation/BackgroundHandler/BatchCompletion/BatchCompletionMessageHandler.cs
@@ -126,7 +126,6 @@ public class BatchCompletionMessageHandler(
                     dbManifest.Id);
                 return false;
             }
-            pendingPipelineJob.Status = PipelineJobStatus.Waiting;
             return true;
         }
 

--- a/src/IIIFPresentation/BackgroundHandler/BatchCompletion/BatchCompletionMessageHandler.cs
+++ b/src/IIIFPresentation/BackgroundHandler/BatchCompletion/BatchCompletionMessageHandler.cs
@@ -38,6 +38,7 @@ public class BatchCompletionMessageHandler(
         var batch = await dbContext.Batches
             .Include(b => b.Manifest).ThenInclude(m => m.CanvasPaintings)
             .Include(b => b.Manifest).ThenInclude(m => m.PipelineJobs)
+            .AsSplitQuery()
             .SingleOrDefaultAsync(
                 b => b.Id == batchCompletionMessage.Id && b.DeliverableType == batchCompletionMessage.DeliverableType,
                 cancellationToken);
@@ -103,10 +104,10 @@ public class BatchCompletionMessageHandler(
 
         // A manifest can accumulate multiple PipelineJob rows (each resubmission creates a new one for history - see
         // ManifestWriteServiceTests.Create_AddsNewPipelineJob_WhenJobAlreadyExistsForManifest), so more than one can
-        // be Waiting at once. Pick the most recent, matching the "latest wins" convention
+        // be NotSubmitted at once. Pick the most recent, matching the "latest wins" convention
         // TextServiceJobCompletionMessageHandler already uses to resolve which job a completion applies to.
         var pendingPipelineJob = dbManifest.PipelineJobs?
-            .Where(p => p.Status == PipelineJobStatus.Waiting)
+            .Where(p => p.Status == PipelineJobStatus.NotSubmitted)
             .OrderByDescending(p => p.Created)
             .FirstOrDefault();
         if (pendingPipelineJob != null)
@@ -122,6 +123,7 @@ public class BatchCompletionMessageHandler(
                     dbManifest.Id);
                 return false;
             }
+            pendingPipelineJob.Status = PipelineJobStatus.Waiting;
             return true;
         }
 

--- a/src/IIIFPresentation/Models/Database/Collections/Manifest.cs
+++ b/src/IIIFPresentation/Models/Database/Collections/Manifest.cs
@@ -76,7 +76,7 @@ public static class ManifestX
     /// Whether a text-services pipeline job is pending for this manifest.
     /// </summary>
     public static bool HasPendingPipelineJob(this Manifest? manifest)
-        => manifest?.PipelineJobs?.Any(p => p.Status == PipelineJobStatus.Waiting) ?? false;
+        => manifest?.PipelineJobs?.Any(p => p.Status is PipelineJobStatus.NotSubmitted or PipelineJobStatus.Waiting) ?? false;
 
     /// <summary>
     /// Whether the manifest has any outstanding background work that must complete before it reaches its final state.

--- a/src/IIIFPresentation/Models/Database/General/PipelineJob.cs
+++ b/src/IIIFPresentation/Models/Database/General/PipelineJob.cs
@@ -41,7 +41,8 @@ public enum PipelineJobStatus
     Running = 1,
     Completed = 2,
     Failed = 3,
-    NotSubmitted = 4
+    NotSubmitted = 1000,
+    FailedToSubmit = 1001
 }
 
 public enum PipelineJobType

--- a/src/IIIFPresentation/Models/Database/General/PipelineJob.cs
+++ b/src/IIIFPresentation/Models/Database/General/PipelineJob.cs
@@ -40,7 +40,8 @@ public enum PipelineJobStatus
     Waiting = 0,
     Running = 1,
     Completed = 2,
-    Failed = 3
+    Failed = 3,
+    NotSubmitted = 4
 }
 
 public enum PipelineJobType

--- a/src/IIIFPresentation/Services.Tests/Manifests/ManifestXTests.cs
+++ b/src/IIIFPresentation/Services.Tests/Manifests/ManifestXTests.cs
@@ -44,6 +44,7 @@ public class ManifestXTests
     [Theory]
     [InlineData(PipelineJobStatus.Completed)]
     [InlineData(PipelineJobStatus.Failed)]
+    [InlineData(PipelineJobStatus.FailedToSubmit)]
     public void HasPendingPipelineJob_ReturnsFalse_WhenJobIsNotQueued(PipelineJobStatus status)
         => ManifestWithJobs(status).HasPendingPipelineJob().Should().BeFalse();
 

--- a/src/IIIFPresentation/Services.Tests/Manifests/ManifestXTests.cs
+++ b/src/IIIFPresentation/Services.Tests/Manifests/ManifestXTests.cs
@@ -52,6 +52,10 @@ public class ManifestXTests
         => ManifestWithJobs(PipelineJobStatus.Waiting).HasPendingPipelineJob().Should().BeTrue();
 
     [Fact]
+    public void HasPendingPipelineJob_ReturnsTrue_WhenJobIsNotSubmitted()
+        => ManifestWithJobs(PipelineJobStatus.NotSubmitted).HasPendingPipelineJob().Should().BeTrue();
+
+    [Fact]
     public void HasFurtherWork_ReturnsFalse_WhenNoIngestingBatchAndNoPendingJob()
         => new Manifest { Id = "x", CustomerId = 1 }.HasFurtherWork().Should().BeFalse();
 
@@ -70,6 +74,10 @@ public class ManifestXTests
     [Fact]
     public void HasFurtherWork_ReturnsTrue_WhenPipelineJobIsQueued()
         => ManifestWithJobs(PipelineJobStatus.Waiting).HasFurtherWork().Should().BeTrue();
+
+    [Fact]
+    public void HasFurtherWork_ReturnsTrue_WhenPipelineJobIsNotSubmitted()
+        => ManifestWithJobs(PipelineJobStatus.NotSubmitted).HasFurtherWork().Should().BeTrue();
 
     [Fact]
     public void HasFurtherWork_ReturnsFalse_WhenBatchCompletedAndJobCompleted()

--- a/src/IIIFPresentation/Services.Tests/Manifests/PipelineHelperTests.cs
+++ b/src/IIIFPresentation/Services.Tests/Manifests/PipelineHelperTests.cs
@@ -170,6 +170,7 @@ public class PipelineHelperTests
     [InlineData(PipelineJobStatus.Running, "Running")]
     [InlineData(PipelineJobStatus.Completed, "Completed")]
     [InlineData(PipelineJobStatus.Failed, "Failed")]
+    [InlineData(PipelineJobStatus.NotSubmitted, "NotSubmitted")]
     public void ToPipelineItem_SetsStatusFromJob(PipelineJobStatus status, string expectedStatus)
     {
         var job = new PipelineJob

--- a/src/IIIFPresentation/Services.Tests/TextServices/PipelineJobServiceTests.cs
+++ b/src/IIIFPresentation/Services.Tests/TextServices/PipelineJobServiceTests.cs
@@ -1,0 +1,99 @@
+using FakeItEasy;
+using Microsoft.Extensions.Logging.Abstractions;
+using Models.API.Manifest;
+using Models.Database.General;
+using Repository;
+using Services.TextServices;
+using DbManifest = Models.Database.Collections.Manifest;
+
+namespace Services.Tests.TextServices;
+
+public class PipelineJobServiceTests
+{
+    private readonly PresentationContext dbContext = A.Fake<PresentationContext>();
+    private readonly ITextBuilderClient textBuilderClient = A.Fake<ITextBuilderClient>();
+    private readonly PipelineJobService sut;
+
+    public PipelineJobServiceTests()
+    {
+        sut = new PipelineJobService(dbContext, textBuilderClient, NullLogger<PipelineJobService>.Instance);
+    }
+
+    private static DbManifest MakeManifest(string id = "manifest1", int customerId = 1) =>
+        new() { Id = id, CustomerId = customerId };
+
+    [Fact]
+    public async Task PersistPipelineJob_ReturnsJob_AndAddsToManifest_WhenPipelineHasRecognisedTextItem()
+    {
+        var dbManifest = MakeManifest();
+        var pipeline = new List<PipelineItem>
+        {
+            new() { Name = "text", Config = new PipelineConfig { Action = "Index" } }
+        };
+
+        var job = await sut.PersistPipelineJob(dbManifest, pipeline, CancellationToken.None);
+
+        job.Should().NotBeNull();
+        job!.ManifestId.Should().Be(dbManifest.Id);
+        job.CustomerId.Should().Be(dbManifest.CustomerId);
+        job.JobType.Should().Be(PipelineJobType.TextService);
+        job.Status.Should().Be(PipelineJobStatus.NotSubmitted);
+        job.Config!.Action.Should().Be("Index");
+        dbManifest.PipelineJobs.Should().ContainSingle().Which.Should().BeSameAs(job);
+    }
+
+    [Fact]
+    public async Task PersistPipelineJob_ReturnsNull_AndDoesNotAddJob_WhenNoPipelineItemIsRecognised()
+    {
+        var dbManifest = MakeManifest();
+        var pipeline = new List<PipelineItem> { new() { Name = "unknown", Config = new PipelineConfig { Action = "Index" } } };
+
+        var job = await sut.PersistPipelineJob(dbManifest, pipeline, CancellationToken.None);
+
+        job.Should().BeNull();
+        dbManifest.PipelineJobs.Should().BeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task PersistPipelineJob_SkipsUnrecognisedItems_AndUsesFirstRecognisedOne()
+    {
+        var dbManifest = MakeManifest();
+        var pipeline = new List<PipelineItem>
+        {
+            new() { Name = "unknown", Config = new PipelineConfig { Action = "Index" } },
+            new() { Name = "text", Config = new PipelineConfig { Action = "Index" } }
+        };
+
+        var job = await sut.PersistPipelineJob(dbManifest, pipeline, CancellationToken.None);
+
+        job.Should().NotBeNull();
+        job!.JobType.Should().Be(PipelineJobType.TextService);
+        dbManifest.PipelineJobs.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task SubmitPipelineJob_ReturnsTrue_WhenTextBuilderClientSucceeds()
+    {
+        A.CallTo(() => textBuilderClient.UpsertJob(A<DbManifest>._, A<PipelineJob>._, A<CancellationToken>._))
+            .Returns(true);
+        var dbManifest = MakeManifest();
+        var job = new PipelineJob { ManifestId = dbManifest.Id, CustomerId = dbManifest.CustomerId, JobType = PipelineJobType.TextService };
+
+        var result = await sut.SubmitPipelineJob(dbManifest, job, CancellationToken.None);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task SubmitPipelineJob_ReturnsFalse_WhenTextBuilderClientFails()
+    {
+        A.CallTo(() => textBuilderClient.UpsertJob(A<DbManifest>._, A<PipelineJob>._, A<CancellationToken>._))
+            .Returns(false);
+        var dbManifest = MakeManifest();
+        var job = new PipelineJob { ManifestId = dbManifest.Id, CustomerId = dbManifest.CustomerId, JobType = PipelineJobType.TextService };
+
+        var result = await sut.SubmitPipelineJob(dbManifest, job, CancellationToken.None);
+
+        result.Should().BeFalse();
+    }
+}

--- a/src/IIIFPresentation/Services.Tests/TextServices/TextBuilderClientTests.cs
+++ b/src/IIIFPresentation/Services.Tests/TextServices/TextBuilderClientTests.cs
@@ -25,14 +25,16 @@ public class TextBuilderClientTests
         new() { CustomerId = customerId, Id = id };
 
     [Fact]
-    public async Task UpsertJob_ReturnsTrue_WhenPostSucceeds()
+    public async Task UpsertJob_ReturnsTrue_AndSetsJobWaiting_WhenPostSucceeds()
     {
         var sut = CreateSut(new TextServicesSettings { BuilderApiUri = new Uri("http://text-services/") });
         messageHandler.Enqueue(HttpStatusCode.OK);
+        var job = MakeJob();
 
-        var result = await sut.UpsertJob(MakeManifest(), MakeJob(), CancellationToken.None);
+        var result = await sut.UpsertJob(MakeManifest(), job, CancellationToken.None);
 
         result.Should().BeTrue();
+        job.Status.Should().Be(PipelineJobStatus.Waiting);
         messageHandler.Requests.Single().Method.Should().Be(HttpMethod.Post);
     }
 
@@ -42,35 +44,41 @@ public class TextBuilderClientTests
         var sut = CreateSut(new TextServicesSettings { BuilderApiUri = new Uri("http://text-services/") });
         messageHandler.Enqueue(HttpStatusCode.Conflict);
         messageHandler.Enqueue(HttpStatusCode.OK);
+        var job = MakeJob();
 
-        var result = await sut.UpsertJob(MakeManifest(), MakeJob(), CancellationToken.None);
+        var result = await sut.UpsertJob(MakeManifest(), job, CancellationToken.None);
 
         result.Should().BeTrue();
+        job.Status.Should().Be(PipelineJobStatus.Waiting);
         messageHandler.Requests.Should().HaveCount(2);
         messageHandler.Requests[0].Method.Should().Be(HttpMethod.Post);
         messageHandler.Requests[1].Method.Should().Be(HttpMethod.Put);
     }
 
     [Fact]
-    public async Task UpsertJob_ReturnsFalse_WhenBuilderApiUriNotConfigured()
+    public async Task UpsertJob_ReturnsFalse_AndSetsJobFailedToSubmit_WhenBuilderApiUriNotConfigured()
     {
         var sut = CreateSut(new TextServicesSettings { BuilderApiUri = null });
+        var job = MakeJob();
 
-        var result = await sut.UpsertJob(MakeManifest(), MakeJob(), CancellationToken.None);
+        var result = await sut.UpsertJob(MakeManifest(), job, CancellationToken.None);
 
         result.Should().BeFalse();
+        job.Status.Should().Be(PipelineJobStatus.FailedToSubmit);
         messageHandler.Requests.Should().BeEmpty();
     }
 
     [Fact]
-    public async Task UpsertJob_ReturnsFalse_WhenPostReturnsNonSuccess()
+    public async Task UpsertJob_ReturnsFalse_AndSetsJobFailedToSubmit_WhenPostReturnsNonSuccess()
     {
         var sut = CreateSut(new TextServicesSettings { BuilderApiUri = new Uri("http://text-services/") });
         messageHandler.Enqueue(HttpStatusCode.InternalServerError);
+        var job = MakeJob();
 
-        var result = await sut.UpsertJob(MakeManifest(), MakeJob(), CancellationToken.None);
+        var result = await sut.UpsertJob(MakeManifest(), job, CancellationToken.None);
 
         result.Should().BeFalse();
+        job.Status.Should().Be(PipelineJobStatus.FailedToSubmit);
     }
 
     [Fact]

--- a/src/IIIFPresentation/Services/ServiceCollectionX.cs
+++ b/src/IIIFPresentation/Services/ServiceCollectionX.cs
@@ -29,6 +29,7 @@ public static class ServiceCollectionX
             client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("IIIF-Presentation", "1.0.0"));
             client.Timeout = TimeSpan.FromSeconds(settings.BuilderApiTimeoutSeconds);
         }).AddHttpMessageHandler<TimingHandler>();
+        services.AddScoped<IPipelineJobService, PipelineJobService>();
         return services;
     }
 

--- a/src/IIIFPresentation/Services/TextServices/IPipelineJobService.cs
+++ b/src/IIIFPresentation/Services/TextServices/IPipelineJobService.cs
@@ -1,0 +1,21 @@
+using Models.API.Manifest;
+using Models.Database.General;
+using DbManifest = Models.Database.Collections.Manifest;
+
+namespace Services.TextServices;
+
+public interface IPipelineJobService
+{
+    /// <summary>
+    /// Builds a job for the first recognised pipeline step, persists it against the manifest, and saves changes.
+    /// Returns null if no recognised pipeline type was found (nothing registered).
+    /// </summary>
+    Task<PipelineJob?> PersistPipelineJob(DbManifest dbManifest, List<PipelineItem> pipeline,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Submits a pipeline job to text-services. The job's <see cref="PipelineJob.Status"/> is updated by the
+    /// underlying <see cref="ITextBuilderClient"/> call; callers are responsible for saving that change.
+    /// </summary>
+    Task<bool> SubmitPipelineJob(DbManifest dbManifest, PipelineJob job, CancellationToken cancellationToken);
+}

--- a/src/IIIFPresentation/Services/TextServices/ITextBuilderClient.cs
+++ b/src/IIIFPresentation/Services/TextServices/ITextBuilderClient.cs
@@ -7,6 +7,8 @@ public interface ITextBuilderClient
 {
     /// <summary>
     /// Create a new text-builder job, or reprocess an existing one.
+    /// Sets <paramref name="job"/>'s <see cref="PipelineJob.Status"/> to <see cref="PipelineJobStatus.Waiting"/> on
+    /// success, or <see cref="PipelineJobStatus.FailedToSubmit"/> on failure.
     /// </summary>
     /// <param name="manifest">The manifest whose staged source the job will read</param>
     /// <param name="job">The pipeline job to submit</param>

--- a/src/IIIFPresentation/Services/TextServices/PipelineJobService.cs
+++ b/src/IIIFPresentation/Services/TextServices/PipelineJobService.cs
@@ -1,0 +1,63 @@
+using Microsoft.Extensions.Logging;
+using Models.API.Manifest;
+using Models.Database.General;
+using Repository;
+using DbManifest = Models.Database.Collections.Manifest;
+
+namespace Services.TextServices;
+
+/// <summary>
+/// Owns the lifecycle of a text-services <see cref="PipelineJob"/>: building and persisting the DB record, and
+/// submitting it to text-services.
+/// </summary>
+public class PipelineJobService(
+    PresentationContext dbContext,
+    ITextBuilderClient textBuilderClient,
+    ILogger<PipelineJobService> logger) : IPipelineJobService
+{
+    public async Task<PipelineJob?> PersistPipelineJob(DbManifest dbManifest, List<PipelineItem> pipeline,
+        CancellationToken cancellationToken)
+    {
+        var job = BuildPipelineJob(dbManifest, pipeline);
+        if (job == null)
+        {
+            logger.LogWarning("No recognised pipeline type for manifest {ManifestId}; ignoring pipeline", dbManifest.Id);
+            await dbContext.SaveChangesAsync(cancellationToken);
+            return null;
+        }
+
+        (dbManifest.PipelineJobs ??= []).Add(job);
+        await dbContext.SaveChangesAsync(cancellationToken);
+        return job;
+    }
+
+    public async Task<bool> SubmitPipelineJob(DbManifest dbManifest, PipelineJob job,
+        CancellationToken cancellationToken)
+    {
+        if (await textBuilderClient.UpsertJob(dbManifest, job, cancellationToken)) return true;
+
+        logger.LogError("Failed to submit {JobType} pipeline job for manifest {ManifestId}", job.JobType, dbManifest.Id);
+        return false;
+    }
+
+    private static PipelineJob? BuildPipelineJob(DbManifest dbManifest, List<PipelineItem> pipeline)
+    {
+        // Returns a job for the first recognised pipeline step; additional steps of the same type are ignored.
+        foreach (var pipelineItem in pipeline)
+        {
+            if (string.Equals(pipelineItem.Name, PipelineHelper.TextPipeline.Name, StringComparison.OrdinalIgnoreCase))
+            {
+                return new PipelineJob
+                {
+                    ManifestId = dbManifest.Id,
+                    JobType = PipelineJobType.TextService,
+                    CustomerId = dbManifest.CustomerId,
+                    Status = PipelineJobStatus.NotSubmitted,
+                    Config = pipelineItem.Config,
+                    Created = DateTime.UtcNow
+                };
+            }
+        }
+        return null;
+    }
+}

--- a/src/IIIFPresentation/Services/TextServices/TextBuilderClient.cs
+++ b/src/IIIFPresentation/Services/TextServices/TextBuilderClient.cs
@@ -30,6 +30,7 @@ public class TextBuilderClient(
         if (settings.BuilderApiUri == null)
         {
             logger.LogWarning("TextServices BuilderApiUri is not configured; skipping job creation for {JobId}", jobId);
+            job.Status = PipelineJobStatus.FailedToSubmit;
             return false;
         }
 
@@ -48,10 +49,12 @@ public class TextBuilderClient(
         if (response.IsSuccessStatusCode)
         {
             logger.LogDebug("Text-services job {JobId} enqueued successfully", jobId);
+            job.Status = PipelineJobStatus.Waiting;
             return true;
         }
 
         logger.LogError("Failed to create/update text-services job {JobId}: {StatusCode}", jobId, response.StatusCode);
+        job.Status = PipelineJobStatus.FailedToSubmit;
         return false;
 
         StringContent GetStringContent()


### PR DESCRIPTION
## What does this change?

Resolves #618

This PR extends text-services to work with assets that are being ingested through the background handler.  It works by submitting a pipeline job after the assets have been ingested.

## Configuration Changes

> [!NOTE]
> This PR introduces configuration changes.
>
> |Service | AppSetting | Required? | Description | Default |
> |---|---|---|---|---|
> | BackgroundHandler | `TextServices:BuilderApiUri` | N | The location of the text services builder | `null` |
> | BackgroundHandler | `TextServices:BuilderApiTimeoutSeconds` | N | Timeout for http requests to builder | 5 |