### PR TITLE
Add PublishReadyToRun to API

### DIFF
--- a/src/IIIFPresentation/API/API.csproj
+++ b/src/IIIFPresentation/API/API.csproj
@@ -1,11 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
-
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <RootNamespace>API</RootNamespace>
+        <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
+        <SelfContained>false</SelfContained>
+        <PublishReadyToRun>true</PublishReadyToRun>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## What does this change?

Resolves #328 

This PR adds `PublishReadyToRun` to the API csproj to improve first request times.

> [!Note]
> There's additional follow-ups that could be considered for implementation in the comment below, along with discussion of options presented in the ticket, but discarded