### PR TITLE
Delete text-services job when manifest is deleted

### DIFF
--- a/src/IIIFPresentation/API.Tests/Integration/DeleteManifestTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/DeleteManifestTests.cs
@@ -3,12 +3,15 @@ using Amazon.S3;
 using API.Tests.Integration.Infrastructure;
 using Core.Helpers;
 using Core.Response;
+using FakeItEasy;
 using IIIF.Serialisation;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Models.API.General;
 using Models.API.Manifest;
 using Models.Database.General;
 using Repository;
+using Services.TextServices;
 using Test.Helpers.Helpers;
 using Test.Helpers.Integration;
 
@@ -21,15 +24,18 @@ public class DeleteManifestTests : IClassFixture<PresentationAppFactory<Program>
     private readonly HttpClient httpClient;
     private readonly PresentationContext dbContext;
     private readonly IAmazonS3 amazonS3;
+    private static readonly ITextBuilderClient TextServicesClient = A.Fake<ITextBuilderClient>();
     private const int Customer = 1;
 
     public DeleteManifestTests(StorageFixture storageFixture, PresentationAppFactory<Program> factory)
     {
         dbContext = storageFixture.DbFixture.DbContext;
         amazonS3 = storageFixture.LocalStackFixture.AWSS3ClientFactory();
+        A.CallTo(() => TextServicesClient.DeleteJob(A<TextJobId>._, A<CancellationToken>._)).Returns(true);
 
         httpClient = factory.ConfigureBasicIntegrationTestHttpClient(storageFixture.DbFixture,
-            appFactory => appFactory.WithLocalStack(storageFixture.LocalStackFixture));
+            appFactory => appFactory.WithLocalStack(storageFixture.LocalStackFixture),
+            services => services.AddSingleton(TextServicesClient));
 
         storageFixture.DbFixture.CleanUp();
     }
@@ -51,6 +57,46 @@ public class DeleteManifestTests : IClassFixture<PresentationAppFactory<Program>
         response.StatusCode.Should().Be(HttpStatusCode.NoContent);
 
         (await dbContext.Manifests.CountAsync(m => m.Id == dbManifest.Id)).Should().Be(0, "the manifest was deleted");
+    }
+
+    [Fact]
+    public async Task DeleteManifest_DeletesTextBuilderJob_WhenManifestHasPipelineJob()
+    {
+        // Arrange
+        var dbManifest = (await dbContext.Manifests.AddTestManifest().WithTestPipelineJob()).Entity;
+        await dbContext.SaveChangesAsync();
+
+        var requestMessage = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Delete,
+            $"{Customer}/manifests/{dbManifest.Id}", dbContext.GetETag(dbManifest));
+
+        // Act
+        var response = await httpClient.AsCustomer().SendAsync(requestMessage);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        A.CallTo(() => TextServicesClient.DeleteJob(
+            A<TextJobId>.That.Matches(j => j.CustomerId == Customer && j.ResourceId == dbManifest.Id),
+            A<CancellationToken>._)).MustHaveHappened();
+    }
+
+    [Fact]
+    public async Task DeleteManifest_DoesNotCallTextBuilder_WhenManifestHasNoPipelineJob()
+    {
+        // Arrange
+        var dbManifest = (await dbContext.Manifests.AddTestManifest()).Entity;
+        await dbContext.SaveChangesAsync();
+
+        var requestMessage = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Delete,
+            $"{Customer}/manifests/{dbManifest.Id}", dbContext.GetETag(dbManifest));
+
+        // Act
+        var response = await httpClient.AsCustomer().SendAsync(requestMessage);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        A.CallTo(() => TextServicesClient.DeleteJob(
+            A<TextJobId>.That.Matches(j => j.ResourceId == dbManifest.Id),
+            A<CancellationToken>._)).MustNotHaveHappened();
     }
 
     [Fact]

--- a/src/IIIFPresentation/API.Tests/Integration/DeleteManifestTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/DeleteManifestTests.cs
@@ -100,6 +100,27 @@ public class DeleteManifestTests : IClassFixture<PresentationAppFactory<Program>
     }
 
     [Fact]
+    public async Task DeleteManifest_DeletesManifest_WhenTextBuilderClientThrows()
+    {
+        // Arrange
+        var dbManifest = (await dbContext.Manifests.AddTestManifest().WithTestPipelineJob()).Entity;
+        await dbContext.SaveChangesAsync();
+        A.CallTo(() => TextServicesClient.DeleteJob(A<TextJobId>._, A<CancellationToken>._))
+            .Throws(new HttpRequestException("text-services unreachable"));
+
+        var requestMessage = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Delete,
+            $"{Customer}/manifests/{dbManifest.Id}", dbContext.GetETag(dbManifest));
+
+        // Act
+        var response = await httpClient.AsCustomer().SendAsync(requestMessage);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        (await dbContext.Manifests.CountAsync(m => m.Id == dbManifest.Id)).Should().Be(0,
+            "the manifest should still be deleted even though text-services was unreachable");
+    }
+
+    [Fact]
     public async Task DeleteManifest_NotFound_WhenDoesNotExists()
     {
         // Arrange

--- a/src/IIIFPresentation/API/Features/Common/Helpers/HierarchyResourceDeleter.cs
+++ b/src/IIIFPresentation/API/Features/Common/Helpers/HierarchyResourceDeleter.cs
@@ -81,8 +81,23 @@ public class HierarchyResourceDeleter(
         CancellationToken cancellationToken)
     {
         dbContext.Remove(manifest);
-        await iiifS3.DeleteIIIFFromS3(resource);
-        await pipelineJobService.DeletePipelineJob(manifest, cancellationToken);
+        await Task.WhenAll(
+            iiifS3.DeleteIIIFFromS3(resource),
+            DeletePipelineJobSafely(manifest, cancellationToken));
+    }
+
+    private async Task DeletePipelineJobSafely(Models.Database.Collections.Manifest manifest,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await pipelineJobService.DeletePipelineJob(manifest, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            // Text-services being unreachable shouldn't stop the manifest itself from being deleted
+            logger.LogWarning(ex, "Error deleting text-services job for manifest {ManifestId}", manifest.Id);
+        }
     }
 
 }

--- a/src/IIIFPresentation/API/Features/Common/Helpers/HierarchyResourceDeleter.cs
+++ b/src/IIIFPresentation/API/Features/Common/Helpers/HierarchyResourceDeleter.cs
@@ -6,12 +6,14 @@ using Microsoft.EntityFrameworkCore;
 using Models.API.General;
 using Models.Database.Collections;
 using Repository;
+using Services.TextServices;
 
 namespace API.Features.Common.Helpers;
 
 public class HierarchyResourceDeleter(
     PresentationContext dbContext,
     IIIIFS3Service iiifS3,
+    IPipelineJobService pipelineJobService,
     ILogger<HierarchyResourceDeleter> logger)
 {
     public async Task<ResultMessage<DeleteResult, DeleteResourceErrorType>> DeleteResource<T>(string? etagFromRequest, int customerId, 
@@ -32,7 +34,7 @@ public class HierarchyResourceDeleter(
                 break;
             }
             case Models.Database.Collections.Manifest manifest:
-                await DeleteManifest(resource, manifest);
+                await DeleteManifest(resource, manifest, cancellationToken);
                 break;
         }
 
@@ -75,10 +77,12 @@ public class HierarchyResourceDeleter(
         return null;
     }
     
-    private async Task DeleteManifest(IHierarchyResource resource, Models.Database.Collections.Manifest manifest)
+    private async Task DeleteManifest(IHierarchyResource resource, Models.Database.Collections.Manifest manifest,
+        CancellationToken cancellationToken)
     {
         dbContext.Remove(manifest);
         await iiifS3.DeleteIIIFFromS3(resource);
+        await pipelineJobService.DeletePipelineJob(manifest, cancellationToken);
     }
 
 }

--- a/src/IIIFPresentation/Services.Tests/TextServices/PipelineJobServiceTests.cs
+++ b/src/IIIFPresentation/Services.Tests/TextServices/PipelineJobServiceTests.cs
@@ -1,5 +1,6 @@
 using FakeItEasy;
 using Microsoft.Extensions.Logging.Abstractions;
+using MockQueryable.FakeItEasy;
 using Models.API.Manifest;
 using Models.Database.General;
 using Repository;
@@ -96,5 +97,50 @@ public class PipelineJobServiceTests
         var result = await sut.SubmitPipelineJob(dbManifest, job, CancellationToken.None);
 
         result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task DeletePipelineJob_CallsTextBuilderClient_WhenManifestHasPipelineJob()
+    {
+        var dbManifest = MakeManifest();
+        var jobs = new List<PipelineJob>
+        {
+            new() { ManifestId = dbManifest.Id, CustomerId = dbManifest.CustomerId, JobType = PipelineJobType.TextService }
+        };
+        A.CallTo(() => dbContext.PipelineJobs).Returns(jobs.BuildMockDbSet());
+        A.CallTo(() => textBuilderClient.DeleteJob(A<TextJobId>._, A<CancellationToken>._)).Returns(true);
+
+        await sut.DeletePipelineJob(dbManifest, CancellationToken.None);
+
+        A.CallTo(() => textBuilderClient.DeleteJob(
+            A<TextJobId>.That.Matches(j => j.CustomerId == dbManifest.CustomerId && j.ResourceId == dbManifest.Id),
+            A<CancellationToken>._)).MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
+    public async Task DeletePipelineJob_DoesNotCallTextBuilderClient_WhenManifestHasNoPipelineJob()
+    {
+        var dbManifest = MakeManifest();
+        A.CallTo(() => dbContext.PipelineJobs).Returns(new List<PipelineJob>().BuildMockDbSet());
+
+        await sut.DeletePipelineJob(dbManifest, CancellationToken.None);
+
+        A.CallTo(() => textBuilderClient.DeleteJob(A<TextJobId>._, A<CancellationToken>._)).MustNotHaveHappened();
+    }
+
+    [Fact]
+    public async Task DeletePipelineJob_DoesNotThrow_WhenTextBuilderClientFails()
+    {
+        var dbManifest = MakeManifest();
+        var jobs = new List<PipelineJob>
+        {
+            new() { ManifestId = dbManifest.Id, CustomerId = dbManifest.CustomerId, JobType = PipelineJobType.TextService }
+        };
+        A.CallTo(() => dbContext.PipelineJobs).Returns(jobs.BuildMockDbSet());
+        A.CallTo(() => textBuilderClient.DeleteJob(A<TextJobId>._, A<CancellationToken>._)).Returns(false);
+
+        var act = async () => await sut.DeletePipelineJob(dbManifest, CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
     }
 }

--- a/src/IIIFPresentation/Services.Tests/TextServices/PipelineJobServiceTests.cs
+++ b/src/IIIFPresentation/Services.Tests/TextServices/PipelineJobServiceTests.cs
@@ -147,6 +147,35 @@ public class PipelineJobServiceTests
     }
 
     [Fact]
+    public async Task DeletePipelineJob_CallsTextBuilderClient_WhenAnyPastInvocationWasSubmitted()
+    {
+        // A manifest can accumulate several PipelineJob rows across reprocessing; even if the most
+        // recent one never reached text-services, an earlier submitted one still needs cleaning up
+        var dbManifest = MakeManifest();
+        var jobs = new List<PipelineJob>
+        {
+            new()
+            {
+                ManifestId = dbManifest.Id, CustomerId = dbManifest.CustomerId, JobType = PipelineJobType.TextService,
+                Status = PipelineJobStatus.Completed, InvocationId = "1"
+            },
+            new()
+            {
+                ManifestId = dbManifest.Id, CustomerId = dbManifest.CustomerId, JobType = PipelineJobType.TextService,
+                Status = PipelineJobStatus.FailedToSubmit, InvocationId = null
+            }
+        };
+        A.CallTo(() => dbContext.PipelineJobs).Returns(jobs.BuildMockDbSet());
+        A.CallTo(() => textBuilderClient.DeleteJob(A<TextJobId>._, A<CancellationToken>._)).Returns(true);
+
+        await sut.DeletePipelineJob(dbManifest, CancellationToken.None);
+
+        A.CallTo(() => textBuilderClient.DeleteJob(
+            A<TextJobId>.That.Matches(j => j.CustomerId == dbManifest.CustomerId && j.ResourceId == dbManifest.Id),
+            A<CancellationToken>._)).MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
     public async Task DeletePipelineJob_DoesNotThrow_WhenTextBuilderClientFails()
     {
         var dbManifest = MakeManifest();

--- a/src/IIIFPresentation/Services.Tests/TextServices/PipelineJobServiceTests.cs
+++ b/src/IIIFPresentation/Services.Tests/TextServices/PipelineJobServiceTests.cs
@@ -128,6 +128,24 @@ public class PipelineJobServiceTests
         A.CallTo(() => textBuilderClient.DeleteJob(A<TextJobId>._, A<CancellationToken>._)).MustNotHaveHappened();
     }
 
+    [Theory]
+    [InlineData(PipelineJobStatus.NotSubmitted)]
+    [InlineData(PipelineJobStatus.FailedToSubmit)]
+    public async Task DeletePipelineJob_DoesNotCallTextBuilderClient_WhenJobNeverReachedTextServices(
+        PipelineJobStatus status)
+    {
+        var dbManifest = MakeManifest();
+        var jobs = new List<PipelineJob>
+        {
+            new() { ManifestId = dbManifest.Id, CustomerId = dbManifest.CustomerId, JobType = PipelineJobType.TextService, Status = status }
+        };
+        A.CallTo(() => dbContext.PipelineJobs).Returns(jobs.BuildMockDbSet());
+
+        await sut.DeletePipelineJob(dbManifest, CancellationToken.None);
+
+        A.CallTo(() => textBuilderClient.DeleteJob(A<TextJobId>._, A<CancellationToken>._)).MustNotHaveHappened();
+    }
+
     [Fact]
     public async Task DeletePipelineJob_DoesNotThrow_WhenTextBuilderClientFails()
     {

--- a/src/IIIFPresentation/Services.Tests/TextServices/TextBuilderClientTests.cs
+++ b/src/IIIFPresentation/Services.Tests/TextServices/TextBuilderClientTests.cs
@@ -227,4 +227,62 @@ public class TextBuilderClientTests
         var expected = (int)(JobServices.All);
         body.Should().Contain($"\"services\":{expected}");
     }
+
+    [Fact]
+    public async Task DeleteJob_ReturnsTrue_WhenDeleteSucceeds()
+    {
+        var sut = CreateSut(new TextServicesSettings { BuilderApiUri = new Uri("http://text-services/") });
+        messageHandler.Enqueue(HttpStatusCode.OK);
+
+        var result = await sut.DeleteJob(new TextJobId(1, "my-manifest"), CancellationToken.None);
+
+        result.Should().BeTrue();
+        var request = messageHandler.Requests.Single();
+        request.Method.Should().Be(HttpMethod.Delete);
+        request.RequestUri!.ToString().Should().Be("http://text-services/textbuilder/1/iiif/my-manifest");
+    }
+
+    [Fact]
+    public async Task DeleteJob_ReturnsTrue_WhenJobAlreadyGone()
+    {
+        var sut = CreateSut(new TextServicesSettings { BuilderApiUri = new Uri("http://text-services/") });
+        messageHandler.Enqueue(HttpStatusCode.NotFound);
+
+        var result = await sut.DeleteJob(new TextJobId(1, "my-manifest"), CancellationToken.None);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task DeleteJob_ReturnsFalse_WhenBuilderApiUriNotConfigured()
+    {
+        var sut = CreateSut(new TextServicesSettings { BuilderApiUri = null });
+
+        var result = await sut.DeleteJob(new TextJobId(1, "my-manifest"), CancellationToken.None);
+
+        result.Should().BeFalse();
+        messageHandler.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task DeleteJob_ReturnsFalse_WhenDeleteReturnsNonSuccess()
+    {
+        var sut = CreateSut(new TextServicesSettings { BuilderApiUri = new Uri("http://text-services/") });
+        messageHandler.Enqueue(HttpStatusCode.InternalServerError);
+
+        var result = await sut.DeleteJob(new TextJobId(1, "my-manifest"), CancellationToken.None);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task DeleteJob_ReturnsFalse_WhenDeleteTimesOut()
+    {
+        var sut = CreateSut(new TextServicesSettings { BuilderApiUri = new Uri("http://text-services/") });
+        messageHandler.EnqueueException(new TaskCanceledException());
+
+        var result = await sut.DeleteJob(new TextJobId(1, "my-manifest"), CancellationToken.None);
+
+        result.Should().BeFalse();
+    }
 }

--- a/src/IIIFPresentation/Services/TextServices/IPipelineJobService.cs
+++ b/src/IIIFPresentation/Services/TextServices/IPipelineJobService.cs
@@ -18,4 +18,10 @@ public interface IPipelineJobService
     /// underlying <see cref="ITextBuilderClient"/> call; callers are responsible for saving that change.
     /// </summary>
     Task<bool> SubmitPipelineJob(DbManifest dbManifest, PipelineJob job, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Deletes any text-services job associated with the given manifest. A no-op if the manifest has no
+    /// associated <see cref="PipelineJob"/>.
+    /// </summary>
+    Task DeletePipelineJob(DbManifest dbManifest, CancellationToken cancellationToken);
 }

--- a/src/IIIFPresentation/Services/TextServices/ITextBuilderClient.cs
+++ b/src/IIIFPresentation/Services/TextServices/ITextBuilderClient.cs
@@ -16,4 +16,10 @@ public interface ITextBuilderClient
     /// <param name="manifest">The manifest whose staged source the job will read</param>
     /// <param name="job">The pipeline job to submit</param>
     Task<bool> UpsertJob(DbManifest manifest, PipelineJob job, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Delete a text-builder job. A job that no longer exists in text-builder is treated as a success.
+    /// </summary>
+    /// <param name="jobId">Id of the job to delete</param>
+    Task<bool> DeleteJob(TextJobId jobId, CancellationToken cancellationToken);
 }

--- a/src/IIIFPresentation/Services/TextServices/PipelineJobService.cs
+++ b/src/IIIFPresentation/Services/TextServices/PipelineJobService.cs
@@ -1,3 +1,4 @@
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Models.API.Manifest;
 using Models.Database.General;
@@ -38,6 +39,20 @@ public class PipelineJobService(
 
         logger.LogError("Failed to submit {JobType} pipeline job for manifest {ManifestId}", job.JobType, dbManifest.Id);
         return false;
+    }
+
+    public async Task DeletePipelineJob(DbManifest dbManifest, CancellationToken cancellationToken)
+    {
+        var hasJob = await dbContext.PipelineJobs
+            .AnyAsync(p => p.ManifestId == dbManifest.Id && p.CustomerId == dbManifest.CustomerId, cancellationToken);
+        if (!hasJob) return;
+
+        var jobId = new TextJobId(dbManifest.CustomerId, dbManifest.Id);
+        if (!await textBuilderClient.DeleteJob(jobId, cancellationToken))
+        {
+            logger.LogWarning("Failed to delete text-services job {JobId} for manifest {ManifestId}", jobId,
+                dbManifest.Id);
+        }
     }
 
     private static PipelineJob? BuildPipelineJob(DbManifest dbManifest, List<PipelineItem> pipeline)

--- a/src/IIIFPresentation/Services/TextServices/PipelineJobService.cs
+++ b/src/IIIFPresentation/Services/TextServices/PipelineJobService.cs
@@ -43,14 +43,17 @@ public class PipelineJobService(
 
     public async Task DeletePipelineJob(DbManifest dbManifest, CancellationToken cancellationToken)
     {
-        var job = await dbContext.PipelineJobs
-            .FirstOrDefaultAsync(p => p.ManifestId == dbManifest.Id && p.CustomerId == dbManifest.CustomerId,
-                cancellationToken);
+        // A manifest can have several PipelineJob rows over its lifetime (one per invocation); the
+        // text-services job id is deterministic per manifest, so if any of them ever reached
+        // text-services (i.e. isn't NotSubmitted/FailedToSubmit) there's something to delete there
+        var everSubmitted = await dbContext.PipelineJobs.AnyAsync(p =>
+                p.ManifestId == dbManifest.Id && p.JobType == PipelineJobType.TextService &&
+                p.Status != PipelineJobStatus.NotSubmitted && p.Status != PipelineJobStatus.FailedToSubmit,
+            cancellationToken);
 
-        // NotSubmitted/FailedToSubmit jobs never reached text-services, so there's nothing to delete there
-        if (job == null || job.Status is PipelineJobStatus.NotSubmitted or PipelineJobStatus.FailedToSubmit) return;
+        if (!everSubmitted) return;
 
-        var jobId = job.GetJobId();
+        var jobId = new TextJobId(dbManifest.CustomerId, dbManifest.Id);
         if (!await textBuilderClient.DeleteJob(jobId, cancellationToken))
         {
             logger.LogWarning("Failed to delete text-services job {JobId} for manifest {ManifestId}", jobId,

--- a/src/IIIFPresentation/Services/TextServices/PipelineJobService.cs
+++ b/src/IIIFPresentation/Services/TextServices/PipelineJobService.cs
@@ -43,11 +43,14 @@ public class PipelineJobService(
 
     public async Task DeletePipelineJob(DbManifest dbManifest, CancellationToken cancellationToken)
     {
-        var hasJob = await dbContext.PipelineJobs
-            .AnyAsync(p => p.ManifestId == dbManifest.Id && p.CustomerId == dbManifest.CustomerId, cancellationToken);
-        if (!hasJob) return;
+        var job = await dbContext.PipelineJobs
+            .FirstOrDefaultAsync(p => p.ManifestId == dbManifest.Id && p.CustomerId == dbManifest.CustomerId,
+                cancellationToken);
 
-        var jobId = new TextJobId(dbManifest.CustomerId, dbManifest.Id);
+        // NotSubmitted/FailedToSubmit jobs never reached text-services, so there's nothing to delete there
+        if (job == null || job.Status is PipelineJobStatus.NotSubmitted or PipelineJobStatus.FailedToSubmit) return;
+
+        var jobId = job.GetJobId();
         if (!await textBuilderClient.DeleteJob(jobId, cancellationToken))
         {
             logger.LogWarning("Failed to delete text-services job {JobId} for manifest {ManifestId}", jobId,

--- a/src/IIIFPresentation/Services/TextServices/TextBuilderClient.cs
+++ b/src/IIIFPresentation/Services/TextServices/TextBuilderClient.cs
@@ -97,6 +97,36 @@ public class TextBuilderClient(
         }
     }
 
+    public async Task<bool> DeleteJob(TextJobId jobId, CancellationToken cancellationToken)
+    {
+        var settings = options.Value;
+        if (settings.BuilderApiUri == null)
+        {
+            logger.LogWarning("TextServices BuilderApiUri is not configured; skipping job deletion for {JobId}", jobId);
+            return false;
+        }
+
+        var deleteUri = new Uri(settings.BuilderApiUri, $"textbuilder/{jobId}");
+        try
+        {
+            var response = await httpClient.DeleteAsync(deleteUri, cancellationToken);
+
+            if (response.IsSuccessStatusCode || response.StatusCode == HttpStatusCode.NotFound)
+            {
+                logger.LogDebug("Text-services job {JobId} deleted", jobId);
+                return true;
+            }
+
+            logger.LogError("Failed to delete text-services job {JobId}: {StatusCode}", jobId, response.StatusCode);
+        }
+        catch (TaskCanceledException e)
+        {
+            logger.LogError(e, "Text-services job {JobId} deletion timed out", jobId);
+        }
+
+        return false;
+    }
+
     private string CreateJobRequestJsonBody(DbManifest manifest, TextJobId jobId)
     {
         var sourceS3Uri = GetManifestS3Key(manifest);


### PR DESCRIPTION
## What does this change?

Resolves #626

Allows the text-services job to be deleted when a manifest is also deleted
