### PR TITLE
Search across

### DIFF
--- a/src/IIIFPresentation/API.Tests/Converters/CollectionConverterTests.cs
+++ b/src/IIIFPresentation/API.Tests/Converters/CollectionConverterTests.cs
@@ -594,8 +594,8 @@ public class CollectionConverterTests
         searchCollection.Behavior.Should().BeNull();
         searchCollection.Totals.Should().BeNull("descendant counts can't be derived from a page of results");
         searchCollection.ItemsOrder.Should().BeNull();
-        searchCollection.Created.Should().Be(default);
-        searchCollection.Modified.Should().Be(default);
+        searchCollection.Created.Should().BeNull();
+        searchCollection.Modified.Should().BeNull();
         searchCollection.CreatedBy.Should().BeNull();
         searchCollection.ModifiedBy.Should().BeNull();
     }

--- a/src/IIIFPresentation/API.Tests/Converters/CollectionConverterTests.cs
+++ b/src/IIIFPresentation/API.Tests/Converters/CollectionConverterTests.cs
@@ -4,6 +4,7 @@ using DLCS;
 using IIIF.Presentation.V3;
 using IIIF.Presentation.V3.Strings;
 using Microsoft.Extensions.Options;
+using Models;
 using Models.API.Collection;
 using Models.Database.General;
 using Repository.Paths;
@@ -122,6 +123,39 @@ public class CollectionConverterTests
         presentationCollection.SeeAlso[1].Profile.Should().Be("api-hierarchical");
     }
     
+    [Fact]
+    public void ToPresentationCollection_NoSearchService_IfNotRootCollection()
+    {
+        // Arrange
+        var collection = CreateTestHierarchicalCollection();
+
+        // Act
+        var presentationCollection =
+            collection.ToPresentationCollection(PageSize, 1, 1, CreateTestItems(), null, pathGenerator, settingsBasedPathGenerator);
+
+        // Assert
+        presentationCollection.Service.Should().BeNull("search-across is only supported from the root collection");
+    }
+
+    [Fact]
+    public void ToPresentationCollection_SearchService_IfRootCollection()
+    {
+        // Arrange
+        var collection = CreateTestHierarchicalCollection();
+        collection.Id = KnownCollections.RootCollection;
+
+        // Act
+        var presentationCollection =
+            collection.ToPresentationCollection(PageSize, 1, 1, CreateTestItems(), null, pathGenerator, settingsBasedPathGenerator);
+
+        // Assert
+        var service = presentationCollection.Service.Should().ContainSingle().Subject
+            .Should().BeOfType<ExternalService>().Subject;
+        service.Id.Should().Be("http://base/1/collections/root/search");
+        service.Type.Should().Be("IIIFCS-Search");
+        service.Profile.Should().Be("level0");
+    }
+
     [Fact]
     public void ToPresentationCollection_ConvertsStorageCollection()
     {

--- a/src/IIIFPresentation/API.Tests/Converters/CollectionConverterTests.cs
+++ b/src/IIIFPresentation/API.Tests/Converters/CollectionConverterTests.cs
@@ -511,6 +511,154 @@ public class CollectionConverterTests
         },
     };
 
+    [Fact]
+    public void ToSearchCollection_IdIsSearchEndpoint_AndItemsUseFlatIds()
+    {
+        // Arrange
+        var collection = CreateTestHierarchicalCollection(true, true);
+
+        // Act
+        var searchCollection = collection.ToSearchCollection("medicine", PageSize, 1, 1, CreateTestItems(),
+            pathGenerator);
+
+        // Assert
+        searchCollection.Id.Should().Be("http://base/1/collections/some-id/search",
+            "the resource is the search, not the collection being searched");
+        searchCollection.TotalItems.Should().Be(1);
+        searchCollection.Items.Should().ContainSingle().Which.Should().BeOfType<IIIF.Presentation.V3.Collection>()
+            .Which.Id.Should().Be("http://base/1/collections/some-child", "results are identified by flat id");
+    }
+
+    [Fact]
+    public void ToSearchCollection_LabelDescribesTheSearch_NotTheCollection()
+    {
+        // Arrange
+        var collection = CreateTestHierarchicalCollection(true, true);
+
+        // Act
+        var searchCollection = collection.ToSearchCollection("hunter thompson", PageSize, 1, 1, CreateTestItems(),
+            pathGenerator);
+
+        // Assert
+        searchCollection.Label!["en"].Should().ContainSingle()
+            .Which.Should().Be("Search results for 'hunter thompson' in 'some-id'");
+    }
+
+    [Fact]
+    public void ToSearchCollection_SeeAlsoPointsAtSearchedCollection()
+    {
+        // Arrange
+        var collection = CreateTestHierarchicalCollection(true, true);
+
+        // Act
+        var searchCollection = collection.ToSearchCollection("medicine", PageSize, 1, 1, CreateTestItems(),
+            pathGenerator);
+
+        // Assert
+        var seeAlso = searchCollection.SeeAlso.Should().ContainSingle().Subject;
+        seeAlso.Id.Should().Be("http://base/1/collections/some-id", "the flat id of the collection being searched");
+        seeAlso.Label!["en"].Should().Contain("repository root");
+    }
+
+    [Fact]
+    public void ToSearchCollection_CarriesTagsOfSearchedCollection()
+    {
+        // Arrange
+        var collection = CreateTestHierarchicalCollection(true, true);
+        collection.Tags = "some, tags";
+
+        // Act
+        var searchCollection = collection.ToSearchCollection("medicine", PageSize, 1, 1, CreateTestItems(),
+            pathGenerator);
+
+        // Assert
+        searchCollection.Tags.Should().Be("some, tags");
+    }
+
+    [Fact]
+    public void ToSearchCollection_OmitsPropertiesOfTheSearchedCollection()
+    {
+        // Arrange - a public storage collection, which would otherwise populate all of the below
+        var collection = CreateTestHierarchicalCollection(true, true);
+
+        // Act
+        var searchCollection = collection.ToSearchCollection("medicine", PageSize, 1, 1, CreateTestItems(),
+            pathGenerator);
+
+        // Assert - search results are synthetic, so properties describing the searched collection don't apply
+        searchCollection.FlatId.Should().BeNull();
+        searchCollection.PublicId.Should().BeNull();
+        searchCollection.Slug.Should().BeNull();
+        searchCollection.Parent.Should().BeNull();
+        searchCollection.PartOf.Should().BeNull();
+        searchCollection.Behavior.Should().BeNull();
+        searchCollection.Totals.Should().BeNull("descendant counts can't be derived from a page of results");
+        searchCollection.ItemsOrder.Should().BeNull();
+        searchCollection.Created.Should().Be(default);
+        searchCollection.Modified.Should().Be(default);
+        searchCollection.CreatedBy.Should().BeNull();
+        searchCollection.ModifiedBy.Should().BeNull();
+    }
+
+    [Fact]
+    public void ToSearchCollection_ViewPointsAtSearchEndpoint_PreservingSearchTerm()
+    {
+        // Arrange
+        var collection = CreateTestHierarchicalCollection(true, true);
+        const string searchPath = "http://base/1/collections/some-id/search";
+
+        // Act - page 2 of 3, so every paging link is generated
+        var searchCollection = collection.ToSearchCollection("hunter thompson", 1, 2, 3, CreateTestItems(),
+            pathGenerator);
+
+        // Assert
+        var view = searchCollection.View!;
+        view.Type.Should().Be(PresentationType.PartialCollectionView);
+        view.Page.Should().Be(2);
+        view.PageSize.Should().Be(1);
+        view.TotalPages.Should().Be(3);
+
+        view.Id.Should().Be($"{searchPath}?label=hunter%20thompson&page=2&pageSize=1");
+        view.First.Should().Be(new Uri($"{searchPath}?label=hunter%20thompson&page=1&pageSize=1"));
+        view.Previous.Should().Be(new Uri($"{searchPath}?label=hunter%20thompson&page=1&pageSize=1"));
+        view.Next.Should().Be(new Uri($"{searchPath}?label=hunter%20thompson&page=3&pageSize=1"));
+        view.Last.Should().Be(new Uri($"{searchPath}?label=hunter%20thompson&page=3&pageSize=1"));
+    }
+
+    [Fact]
+    public void ToSearchCollection_ViewHasNoPagingLinks_WhenSinglePageOfResults()
+    {
+        // Arrange
+        var collection = CreateTestHierarchicalCollection(true, true);
+
+        // Act
+        var searchCollection = collection.ToSearchCollection("medicine", PageSize, 1, 1, CreateTestItems(),
+            pathGenerator);
+
+        // Assert
+        var view = searchCollection.View!;
+        view.TotalPages.Should().Be(1);
+        view.First.Should().BeNull();
+        view.Previous.Should().BeNull();
+        view.Next.Should().BeNull();
+        view.Last.Should().BeNull();
+    }
+
+    [Fact]
+    public void ToSearchCollection_ReturnsEmptyResults_WhenNoMatches()
+    {
+        // Arrange
+        var collection = CreateTestHierarchicalCollection(true, true);
+
+        // Act
+        var searchCollection = collection.ToSearchCollection("kerouac", PageSize, 1, 0, [], pathGenerator);
+
+        // Assert
+        searchCollection.TotalItems.Should().Be(0);
+        searchCollection.Items.Should().BeEmpty();
+        searchCollection.View!.TotalPages.Should().Be(1);
+    }
+
     private static List<Hierarchy> CreateTestItems()
     {
         var items = new List<Hierarchy>

--- a/src/IIIFPresentation/API.Tests/Features/Storage/Models/RequestModifiersTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Storage/Models/RequestModifiersTests.cs
@@ -1,0 +1,99 @@
+using API.Features.Storage.Models;
+using API.Settings;
+using AWS.Settings;
+using DLCS;
+
+namespace API.Tests.Features.Storage.Models;
+
+public class RequestModifiersTests
+{
+    private static ApiSettings Settings(int pageSize = 100, int maxPageSize = 1000) => new()
+    {
+        AWS = new AWSSettings(),
+        DLCS = new DlcsSettings { ApiUri = new Uri("https://localhost") },
+        PageSize = pageSize,
+        MaxPageSize = maxPageSize
+    };
+
+    private sealed record TestPagedRequest(int? Page, int? PageSize, string? OrderBy = null, bool Descending = false)
+        : IPagedRequest;
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(0)]
+    [InlineData(-5)]
+    public void Create_DefaultsPageSize_WhenNullOrNonPositive(int? pageSize)
+    {
+        var result = RequestModifiers.Create(new TestPagedRequest(1, pageSize), Settings(pageSize: 100));
+
+        result.PageSize.Should().Be(100);
+    }
+
+    [Fact]
+    public void Create_CapsPageSize_AtMaxPageSize()
+    {
+        var result = RequestModifiers.Create(new TestPagedRequest(1, 5000), Settings(maxPageSize: 1000));
+
+        result.PageSize.Should().Be(1000);
+    }
+
+    [Fact]
+    public void Create_KeepsPageSize_WhenWithinRange()
+    {
+        var result = RequestModifiers.Create(new TestPagedRequest(1, 50), Settings(pageSize: 100, maxPageSize: 1000));
+
+        result.PageSize.Should().Be(50);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Create_DefaultsPage_ToOne_WhenNullOrNonPositive(int? page)
+    {
+        var result = RequestModifiers.Create(new TestPagedRequest(page, 10), Settings());
+
+        result.Page.Should().Be(1);
+    }
+
+    [Fact]
+    public void Create_KeepsPage_WhenPositive()
+    {
+        var result = RequestModifiers.Create(new TestPagedRequest(7, 10), Settings());
+
+        result.Page.Should().Be(7);
+    }
+
+    [Fact]
+    public void Create_PassesOrderingThrough()
+    {
+        var result = RequestModifiers.Create(new TestPagedRequest(1, 10, "created", true), Settings());
+
+        result.OrderBy.Should().Be("created");
+        result.Descending.Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetOrderByParameter_ReturnsNull_WhenNoOrderBy()
+    {
+        var modifiers = RequestModifiers.Create(new TestPagedRequest(1, 10), Settings());
+
+        modifiers.GetOrderByParameter().Should().BeNull();
+    }
+
+    [Fact]
+    public void GetOrderByParameter_UsesOrderBy_WhenAscending()
+    {
+        var modifiers = RequestModifiers.Create(new TestPagedRequest(1, 10, "slug"), Settings());
+
+        modifiers.GetOrderByParameter().Should().Be("orderBy=slug");
+    }
+
+    [Fact]
+    public void GetOrderByParameter_UsesOrderByDescending_WhenDescending()
+    {
+        var modifiers = RequestModifiers.Create(new TestPagedRequest(1, 10, "slug", true), Settings());
+
+        modifiers.GetOrderByParameter().Should().Be("orderByDescending=slug");
+    }
+}

--- a/src/IIIFPresentation/API.Tests/Features/Storage/Requests/SearchCollectionHandlerTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Storage/Requests/SearchCollectionHandlerTests.cs
@@ -4,6 +4,7 @@ using API.Tests.Integration.Infrastructure;
 using AWS.Settings;
 using Core.Web;
 using IIIF.Presentation.V3.Strings;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Repository;
 using Services.Manifests.Helpers;
@@ -49,8 +50,8 @@ public class SearchCollectionHandlerTests
             DLCS = dlcsSettings
         });
 
-        return new SearchCollectionHandler(dbContext, settingsBasedPathGenerator, settingsBasedPathGenerator,
-            apiSettings);
+        return new SearchCollectionHandler(dbContext, settingsBasedPathGenerator, apiSettings,
+            new NullLogger<SearchCollectionHandler>());
     }
 
     [Fact]

--- a/src/IIIFPresentation/API.Tests/Features/Storage/Requests/SearchCollectionHandlerTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Storage/Requests/SearchCollectionHandlerTests.cs
@@ -1,0 +1,108 @@
+using API.Features.Storage.Requests;
+using API.Settings;
+using API.Tests.Integration.Infrastructure;
+using AWS.Settings;
+using Core.Web;
+using IIIF.Presentation.V3.Strings;
+using Microsoft.Extensions.Options;
+using Repository;
+using Services.Manifests.Helpers;
+using Services.Manifests.Settings;
+using Test.Helpers.Helpers;
+using Test.Helpers.Integration;
+
+namespace API.Tests.Features.Storage.Requests;
+
+[Trait("Category", "Database")]
+[Collection(CollectionDefinitions.DatabaseCollection.CollectionName)]
+public class SearchCollectionHandlerTests
+{
+    private readonly PresentationContextFixture dbFixture;
+    private const int Customer = 641;
+
+    public SearchCollectionHandlerTests(PresentationContextFixture dbFixture)
+    {
+        this.dbFixture = dbFixture;
+        dbFixture.CleanUp();
+    }
+
+    private PresentationContext GetScopedContext()
+    {
+        var provider = new TestCustomerIdProvider();
+        provider.SetCustomerId(Customer);
+        return dbFixture.GetNewPresentationContext(provider);
+    }
+
+    private static SearchCollectionHandler GetSut(PresentationContext dbContext)
+    {
+        var dlcsSettings = DefaultSettings.DlcsSettings();
+        var settingsBasedPathGenerator = new SettingsBasedPathGenerator(Options.Create(dlcsSettings),
+            new SettingsDrivenPresentationConfigGenerator(Options.Create(new PathSettings
+            {
+                PresentationApiUrl = new Uri("https://presentation.api"),
+                PathRules = PathRewriteOptions.Default
+            })));
+
+        var apiSettings = Options.Create(new ApiSettings
+        {
+            AWS = new AWSSettings(),
+            DLCS = dlcsSettings
+        });
+
+        return new SearchCollectionHandler(dbContext, settingsBasedPathGenerator, settingsBasedPathGenerator,
+            apiSettings);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsNotFound_WhenCollectionDoesNotExist()
+    {
+        // Arrange
+        await using var ctx = GetScopedContext();
+
+        // Act
+        var result = await GetSut(ctx).Handle(new SearchCollection("i-do-not-exist", "thompson", 1, 10),
+            CancellationToken.None);
+
+        // Assert
+        result.EntityNotFound.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsBadRequest_WhenCollectionIsNotStorageCollection()
+    {
+        // Arrange
+        await using var ctx = GetScopedContext();
+        await ctx.Collections.AddTestCollection(id: "iiif-coll", customer: Customer, parent: null, isStorage: false);
+        await ctx.SaveChangesAsync();
+
+        // Act - unreachable via the API today (search is root-only) but the handler must still refuse
+        var result = await GetSut(ctx).Handle(new SearchCollection("iiif-coll", "thompson", 1, 10),
+            CancellationToken.None);
+
+        // Assert
+        result.BadRequest.Should().BeTrue();
+        result.Error.Should().BeTrue("BadRequest must not be mistaken for success by callers that ignore it");
+        result.Entity.Should().BeNull();
+        result.ErrorMessage.Should().Be("Search is only supported for storage collections");
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsResults_WhenCollectionIsStorageCollection()
+    {
+        // Arrange
+        await using var ctx = GetScopedContext();
+        var storageCollection =
+            (await ctx.Collections.AddTestCollection(id: "storage-coll", customer: Customer, parent: null)).Entity;
+        storageCollection.Label = new LanguageMap("en", ["Hunter S. Thompson"]);
+        await ctx.SaveChangesAsync();
+
+        // Act
+        var result = await GetSut(ctx).Handle(new SearchCollection("storage-coll", "thompson", 1, 10),
+            CancellationToken.None);
+
+        // Assert
+        result.BadRequest.Should().BeFalse();
+        result.Error.Should().BeFalse();
+        result.Entity!.TotalItems.Should().Be(1);
+    }
+}

--- a/src/IIIFPresentation/API.Tests/Features/Storage/Requests/SearchCollectionHandlerTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Storage/Requests/SearchCollectionHandlerTests.cs
@@ -4,6 +4,7 @@ using API.Tests.Integration.Infrastructure;
 using AWS.Settings;
 using Core.Web;
 using IIIF.Presentation.V3.Strings;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Repository;
@@ -54,6 +55,22 @@ public class SearchCollectionHandlerTests
             new NullLogger<SearchCollectionHandler>());
     }
 
+    /// <summary>
+    /// Gets a context for the customer, ensuring they have the root collection they'd get on creation. CleanUp()
+    /// preserves 'root' for all customers, so this is idempotent across tests sharing the fixture.
+    /// </summary>
+    private async Task<PresentationContext> GetSeededContext()
+    {
+        var ctx = GetScopedContext();
+        if (!await ctx.Collections.AnyAsync(c => c.Id == RootCollection.Id))
+        {
+            await ctx.Collections.AddTestRootCollection(Customer);
+            await ctx.SaveChangesAsync();
+        }
+
+        return ctx;
+    }
+
     [Fact]
     public async Task Handle_ReturnsNotFound_WhenCollectionDoesNotExist()
     {
@@ -61,8 +78,8 @@ public class SearchCollectionHandlerTests
         await using var ctx = GetScopedContext();
 
         // Act
-        var result = await GetSut(ctx).Handle(new SearchCollection("i-do-not-exist", "thompson", 1, 10),
-            CancellationToken.None);
+        var result = await GetSut(ctx).Handle(
+            new SearchCollection("i-do-not-exist", "thompson", ["thompson"], 1, 10), CancellationToken.None);
 
         // Assert
         result.EntityNotFound.Should().BeTrue();
@@ -77,29 +94,47 @@ public class SearchCollectionHandlerTests
         await ctx.SaveChangesAsync();
 
         // Act - unreachable via the API today (search is root-only) but the handler must still refuse
-        var result = await GetSut(ctx).Handle(new SearchCollection("iiif-coll", "thompson", 1, 10),
+        var result = await GetSut(ctx).Handle(new SearchCollection("iiif-coll", "thompson", ["thompson"], 1, 10),
             CancellationToken.None);
 
         // Assert
         result.BadRequest.Should().BeTrue();
         result.Error.Should().BeTrue("BadRequest must not be mistaken for success by callers that ignore it");
         result.Entity.Should().BeNull();
-        result.ErrorMessage.Should().Be("Search is only supported for storage collections");
+        result.ErrorMessage.Should().Be("Search is only supported for the root storage collection");
     }
 
     [Fact]
-    public async Task Handle_ReturnsResults_WhenCollectionIsStorageCollection()
+    public async Task Handle_ReturnsBadRequest_WhenStorageCollectionIsNotRoot()
     {
         // Arrange
-        await using var ctx = GetScopedContext();
-        var storageCollection =
-            (await ctx.Collections.AddTestCollection(id: "storage-coll", customer: Customer, parent: null)).Entity;
+        await using var ctx = await GetSeededContext();
+        var storageCollection = (await ctx.Collections.AddTestCollection(id: "storage-coll", customer: Customer)).Entity;
         storageCollection.Label = new LanguageMap("en", ["Hunter S. Thompson"]);
         await ctx.SaveChangesAsync();
 
-        // Act
-        var result = await GetSut(ctx).Handle(new SearchCollection("storage-coll", "thompson", 1, 10),
+        // Act - the search query is customer-wide, so a non-root collection would return items from outside itself
+        var result = await GetSut(ctx).Handle(new SearchCollection("storage-coll", "thompson", ["thompson"], 1, 10),
             CancellationToken.None);
+
+        // Assert
+        result.BadRequest.Should().BeTrue();
+        result.Entity.Should().BeNull();
+        result.ErrorMessage.Should().Be("Search is only supported for the root storage collection");
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsResults_WhenCollectionIsRoot()
+    {
+        // Arrange
+        await using var ctx = await GetSeededContext();
+        await ctx.Manifests.AddTestManifest(id: "hst-man", customer: Customer,
+            label: new LanguageMap("en", ["Hunter S. Thompson"]));
+        await ctx.SaveChangesAsync();
+
+        // Act
+        var result = await GetSut(ctx).Handle(
+            new SearchCollection(RootCollection.Id, "thompson", ["thompson"], 1, 10), CancellationToken.None);
 
         // Assert
         result.BadRequest.Should().BeFalse();

--- a/src/IIIFPresentation/API.Tests/Helpers/PresentationX.cs
+++ b/src/IIIFPresentation/API.Tests/Helpers/PresentationX.cs
@@ -33,8 +33,8 @@ public class PresentationX
         public string? FlatId { get; set; }
         public string? Slug { get; set; }
         public string? Parent { get; set; }
-        public DateTime Created { get; set; }
-        public DateTime Modified { get; set; }
+        public DateTime? Created { get; set; }
+        public DateTime? Modified { get; set; }
         public string? CreatedBy { get; set; }
         public string? ModifiedBy { get; set; }
     }

--- a/src/IIIFPresentation/API.Tests/Helpers/SearchCollectionItemsTests.cs
+++ b/src/IIIFPresentation/API.Tests/Helpers/SearchCollectionItemsTests.cs
@@ -1,0 +1,297 @@
+#nullable disable
+
+using API.Features.Storage.Helpers;
+using API.Tests.Integration.Infrastructure;
+using IIIF.Presentation.V3.Strings;
+using Microsoft.EntityFrameworkCore;
+using Models.Database.General;
+using Repository;
+using Repository.Collections;
+using Test.Helpers.Helpers;
+using Test.Helpers.Integration;
+
+namespace API.Tests.Helpers;
+
+/// <summary>
+/// Tests for <see cref="PresentationContextX.SearchCollectionItems"/> - the raw jsonb label search. Split out from
+/// <see cref="PresentationContextXTests"/> as it needs its own seed data. Seeds under dedicated customers, each with
+/// their own root collection, and queries via a context scoped to that customer.
+/// </summary>
+[Trait("Category", "Database")]
+[Collection(CollectionDefinitions.DatabaseCollection.CollectionName)]
+public class SearchCollectionItemsTests
+{
+    private readonly PresentationContextFixture dbFixture;
+    private const int Customer = 9001;
+    private const int OtherCustomer = 9002;
+
+    public SearchCollectionItemsTests(PresentationContextFixture dbFixture)
+    {
+        this.dbFixture = dbFixture;
+        dbFixture.CleanUp();
+    }
+
+    private PresentationContext GetScopedContext(int customer = Customer)
+    {
+        var provider = new TestCustomerIdProvider();
+        provider.SetCustomerId(customer);
+        return dbFixture.GetNewPresentationContext(provider);
+    }
+
+    /// <summary>
+    /// Gets a context for the customer, ensuring they have the root collection they'd get on creation. CleanUp()
+    /// preserves 'root' for all customers, so this is idempotent across tests sharing the fixture.
+    /// </summary>
+    private async Task<PresentationContext> GetSeededContext(int customer = Customer)
+    {
+        var ctx = GetScopedContext(customer);
+        if (!await ctx.Collections.AnyAsync(c => c.Id == RootCollection.Id))
+        {
+            await ctx.Collections.AddTestRootCollection(customer);
+            await ctx.SaveChangesAsync();
+        }
+
+        return ctx;
+    }
+
+    private async Task Seed()
+    {
+        await using var ctx = await GetSeededContext();
+
+        var hunterCollection = (await ctx.Collections.AddTestCollection(id: "hst-coll", customer: Customer)).Entity;
+        hunterCollection.Label = new LanguageMap("en", ["Hunter S. Thompson"]);
+
+        // token order differs from search, and value sits alongside a non-matching value
+        await ctx.Manifests.AddTestManifest(id: "hst-man", customer: Customer,
+            label: new LanguageMap("en", ["Fear and Loathing", "Thompson, Hunter"]));
+
+        var emmaCollection = (await ctx.Collections.AddTestCollection(id: "emma-coll", customer: Customer)).Entity;
+        emmaCollection.Label = new LanguageMap("en", ["Emma Thompson"]); // missing 'hunter'
+
+        // 'hunter' and 'thompson' in *separate* values -> must NOT match under same-value AND
+        var split = new LanguageMap("none", ["Hunter"]);
+        split.Add("en", ["Thompson biography"]);
+        await ctx.Manifests.AddTestManifest(id: "split-man", customer: Customer, label: split);
+
+        await ctx.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task SearchCollectionItems_MatchesAllTokensInSingleValue_CaseInsensitive_OrderIndependent()
+    {
+        await Seed();
+        await using var ctx = GetScopedContext();
+
+        var results = await ctx.SearchCollectionItems("hunter thompson").ToListAsync();
+
+        results.Select(h => h.ResourceId).Should().BeEquivalentTo(["hst-coll", "hst-man"]);
+    }
+
+    [Fact]
+    public async Task SearchCollectionItems_ExcludesPartialAndCrossValueMatches()
+    {
+        await Seed();
+        await using var ctx = GetScopedContext();
+
+        var resourceIds = (await ctx.SearchCollectionItems("hunter thompson").ToListAsync())
+            .Select(h => h.ResourceId).ToList();
+
+        resourceIds.Should().NotContain("emma-coll", "'Emma Thompson' is missing the 'hunter' token");
+        resourceIds.Should().NotContain("split-man", "'hunter'/'thompson' are in separate label values");
+    }
+
+    [Fact]
+    public async Task SearchCollectionItems_ReturnsNothing_WhenNoMatch()
+    {
+        await Seed();
+        await using var ctx = GetScopedContext();
+
+        var results = await ctx.SearchCollectionItems("kerouac").ToListAsync();
+
+        results.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SearchCollectionItems_IsScopedToCustomer_ByGlobalQueryFilter()
+    {
+        await Seed(); // customer 9001 gets hst-coll / hst-man matching 'hunter thompson'
+
+        // an identically-labelled resource under a different customer
+        await using (var otherCtx = await GetSeededContext(OtherCustomer))
+        {
+            await otherCtx.Manifests.AddTestManifest(id: "other-hst", customer: OtherCustomer,
+                label: new LanguageMap("en", ["Hunter S. Thompson"]));
+            await otherCtx.SaveChangesAsync();
+        }
+
+        await using var ctx = GetScopedContext(Customer);
+        var resourceIds = (await ctx.SearchCollectionItems("hunter thompson").ToListAsync())
+            .Select(h => h.ResourceId).ToList();
+
+        resourceIds.Should().BeEquivalentTo(["hst-coll", "hst-man"]);
+        resourceIds.Should().NotContain("other-hst", "the global query filter scopes results to the customer");
+    }
+
+    [Fact]
+    public async Task SearchCollectionItems_ComposesOrderingAndPaging()
+    {
+        await Seed();
+        await using var ctx = GetScopedContext();
+
+        // single token 'thompson' matches every seeded item that has it in a value:
+        // hst-coll, hst-man, emma-coll and split-man ('Thompson biography')
+        var query = ctx.SearchCollectionItems("thompson");
+
+        var total = await query.CountAsync();
+        var firstPage = await query.AsOrderedCollectionItemsQuery(orderBy: "id").Skip(0).Take(2).ToListAsync();
+        var secondPage = await query.AsOrderedCollectionItemsQuery(orderBy: "id").Skip(2).Take(2).ToListAsync();
+
+        total.Should().Be(4);
+        firstPage.Should().HaveCount(2);
+        secondPage.Should().HaveCount(2);
+        firstPage.Concat(secondPage).Select(h => h.ResourceId).Should()
+            .BeEquivalentTo(["hst-coll", "hst-man", "emma-coll", "split-man"]);
+    }
+
+    [Fact]
+    public async Task SearchCollectionItems_MatchesResourcesAtAnyDepth()
+    {
+        await using (var seedCtx = await GetSeededContext())
+        {
+            var parent = (await seedCtx.Collections.AddTestCollection(id: "depth-parent", customer: Customer)).Entity;
+            parent.Label = new LanguageMap("en", ["Somewhere else entirely"]);
+
+            var child = (await seedCtx.Collections.AddTestCollection(id: "depth-child", customer: Customer,
+                parent: "depth-parent")).Entity;
+            child.Label = new LanguageMap("en", ["Kerouac letters"]);
+
+            await seedCtx.Manifests.AddTestManifest(id: "depth-man", customer: Customer, parent: "depth-child",
+                label: new LanguageMap("en", ["Kerouac scrolls"]));
+
+            await seedCtx.SaveChangesAsync();
+        }
+
+        await using var ctx = GetScopedContext();
+        var results = await ctx.SearchCollectionItems("kerouac").ToListAsync();
+
+        results.Select(h => h.ResourceId).Should()
+            .BeEquivalentTo(["depth-child", "depth-man"], "search is across all resources, regardless of nesting");
+    }
+
+    [Fact]
+    public async Task SearchCollectionItems_ExcludesNonCanonicalHierarchyRows()
+    {
+        await using (var seedCtx = await GetSeededContext())
+        {
+            await seedCtx.Manifests.AddTestManifest(id: "alias-man", customer: Customer,
+                label: new LanguageMap("en", ["Kerouac scrolls"]));
+
+            // a second, non-canonical path to the same manifest - it must not yield a duplicate result
+            seedCtx.Hierarchy.Add(new Hierarchy
+            {
+                ManifestId = "alias-man",
+                CustomerId = Customer,
+                Slug = "alias-man-alt",
+                Parent = RootCollection.Id,
+                Canonical = false,
+                Type = ResourceType.IIIFManifest
+            });
+
+            await seedCtx.SaveChangesAsync();
+        }
+
+        await using var ctx = GetScopedContext();
+        var results = await ctx.SearchCollectionItems("kerouac").ToListAsync();
+
+        results.Should().ContainSingle().Which.Canonical.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task SearchCollectionItems_MatchesLabelValue_InAnyLanguage()
+    {
+        await using (var seedCtx = await GetSeededContext())
+        {
+            await seedCtx.Manifests.AddTestManifest(id: "welsh-man", customer: Customer,
+                label: new LanguageMap("cy", ["Llyfr Kerouac"]));
+            await seedCtx.SaveChangesAsync();
+        }
+
+        await using var ctx = GetScopedContext();
+        var results = await ctx.SearchCollectionItems("kerouac").ToListAsync();
+
+        results.Select(h => h.ResourceId).Should().BeEquivalentTo(["welsh-man"],
+            "all label values are searched, whatever the language key");
+    }
+
+    [Theory]
+    [InlineData("a_c", "abc-man")] // '_' is a single-char ILIKE wildcard if not escaped
+    [InlineData("50%", "pct-man")] // '%' is a multi-char ILIKE wildcard if not escaped
+    public async Task SearchCollectionItems_TreatsWildcardCharacters_Literally(string term, string expectedMatch)
+    {
+        await using (var seedCtx = await GetSeededContext())
+        {
+            // would be matched by an unescaped 'a_c' / '50%' pattern
+            await seedCtx.Manifests.AddTestManifest(id: "abc-decoy", customer: Customer,
+                label: new LanguageMap("en", ["abc"]));
+            await seedCtx.Manifests.AddTestManifest(id: "pct-decoy", customer: Customer,
+                label: new LanguageMap("en", ["50 shades"]));
+
+            // contain the literal characters
+            await seedCtx.Manifests.AddTestManifest(id: "abc-man", customer: Customer,
+                label: new LanguageMap("en", ["file a_c backup"]));
+            await seedCtx.Manifests.AddTestManifest(id: "pct-man", customer: Customer,
+                label: new LanguageMap("en", ["50% proof"]));
+
+            await seedCtx.SaveChangesAsync();
+        }
+
+        await using var ctx = GetScopedContext();
+        var results = await ctx.SearchCollectionItems(term).ToListAsync();
+
+        results.Select(h => h.ResourceId).Should().BeEquivalentTo([expectedMatch]);
+    }
+
+    [Fact]
+    public async Task SearchCollectionItems_IncludesCollectionAndManifest_ForConversion()
+    {
+        await Seed();
+        await using var ctx = GetScopedContext();
+
+        var results = await ctx.SearchCollectionItems("hunter thompson").ToListAsync();
+
+        results.Single(h => h.ResourceId == "hst-coll").Collection.Should().NotBeNull();
+        results.Single(h => h.ResourceId == "hst-man").Manifest.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task SearchCollectionItems_IgnoresResourcesWithNoLabel()
+    {
+        await using (var seedCtx = await GetSeededContext())
+        {
+            // no label at all - must be skipped rather than blowing up the jsonb_each
+            await seedCtx.Collections.AddTestCollection(customer: Customer);
+            await seedCtx.Manifests.AddTestManifest(customer: Customer);
+            await seedCtx.SaveChangesAsync();
+        }
+
+        await using var ctx = GetScopedContext();
+
+        var results = await ctx.SearchCollectionItems("kerouac").ToListAsync();
+
+        results.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task SearchCollectionItems_ReturnsEmptyComposableQuery_WhenNoTokens(string term)
+    {
+        await Seed();
+        await using var ctx = GetScopedContext();
+
+        var query = ctx.SearchCollectionItems(term);
+
+        (await query.CountAsync()).Should().Be(0);
+        (await query.Skip(0).Take(10).ToListAsync()).Should().BeEmpty();
+    }
+}

--- a/src/IIIFPresentation/API.Tests/Helpers/SearchCollectionItemsTests.cs
+++ b/src/IIIFPresentation/API.Tests/Helpers/SearchCollectionItemsTests.cs
@@ -2,6 +2,7 @@
 
 using API.Features.Storage.Helpers;
 using API.Tests.Integration.Infrastructure;
+using Core.Helpers;
 using IIIF.Presentation.V3.Strings;
 using Microsoft.EntityFrameworkCore;
 using Models.Database.General;
@@ -82,7 +83,7 @@ public class SearchCollectionItemsTests
         await Seed();
         await using var ctx = GetScopedContext();
 
-        var results = await ctx.SearchCollectionItems("hunter thompson").ToListAsync();
+        var results = await ctx.SearchCollectionItems("hunter thompson".SplitOnWhitespace()).ToListAsync();
 
         results.Select(h => h.ResourceId).Should().BeEquivalentTo(["hst-coll", "hst-man"]);
     }
@@ -93,7 +94,7 @@ public class SearchCollectionItemsTests
         await Seed();
         await using var ctx = GetScopedContext();
 
-        var resourceIds = (await ctx.SearchCollectionItems("hunter thompson").ToListAsync())
+        var resourceIds = (await ctx.SearchCollectionItems("hunter thompson".SplitOnWhitespace()).ToListAsync())
             .Select(h => h.ResourceId).ToList();
 
         resourceIds.Should().NotContain("emma-coll", "'Emma Thompson' is missing the 'hunter' token");
@@ -106,7 +107,7 @@ public class SearchCollectionItemsTests
         await Seed();
         await using var ctx = GetScopedContext();
 
-        var results = await ctx.SearchCollectionItems("kerouac").ToListAsync();
+        var results = await ctx.SearchCollectionItems("kerouac".SplitOnWhitespace()).ToListAsync();
 
         results.Should().BeEmpty();
     }
@@ -125,7 +126,7 @@ public class SearchCollectionItemsTests
         }
 
         await using var ctx = GetScopedContext(Customer);
-        var resourceIds = (await ctx.SearchCollectionItems("hunter thompson").ToListAsync())
+        var resourceIds = (await ctx.SearchCollectionItems("hunter thompson".SplitOnWhitespace()).ToListAsync())
             .Select(h => h.ResourceId).ToList();
 
         resourceIds.Should().BeEquivalentTo(["hst-coll", "hst-man"]);
@@ -140,7 +141,7 @@ public class SearchCollectionItemsTests
 
         // single token 'thompson' matches every seeded item that has it in a value:
         // hst-coll, hst-man, emma-coll and split-man ('Thompson biography')
-        var query = ctx.SearchCollectionItems("thompson");
+        var query = ctx.SearchCollectionItems("thompson".SplitOnWhitespace());
 
         var total = await query.CountAsync();
         var firstPage = await query.AsOrderedCollectionItemsQuery(orderBy: "id").Skip(0).Take(2).ToListAsync();
@@ -172,7 +173,7 @@ public class SearchCollectionItemsTests
         }
 
         await using var ctx = GetScopedContext();
-        var results = await ctx.SearchCollectionItems("kerouac").ToListAsync();
+        var results = await ctx.SearchCollectionItems("kerouac".SplitOnWhitespace()).ToListAsync();
 
         results.Select(h => h.ResourceId).Should()
             .BeEquivalentTo(["depth-child", "depth-man"], "search is across all resources, regardless of nesting");
@@ -201,7 +202,7 @@ public class SearchCollectionItemsTests
         }
 
         await using var ctx = GetScopedContext();
-        var results = await ctx.SearchCollectionItems("kerouac").ToListAsync();
+        var results = await ctx.SearchCollectionItems("kerouac".SplitOnWhitespace()).ToListAsync();
 
         results.Should().ContainSingle().Which.Canonical.Should().BeTrue();
     }
@@ -217,7 +218,7 @@ public class SearchCollectionItemsTests
         }
 
         await using var ctx = GetScopedContext();
-        var results = await ctx.SearchCollectionItems("kerouac").ToListAsync();
+        var results = await ctx.SearchCollectionItems("kerouac".SplitOnWhitespace()).ToListAsync();
 
         results.Select(h => h.ResourceId).Should().BeEquivalentTo(["welsh-man"],
             "all label values are searched, whatever the language key");
@@ -246,7 +247,7 @@ public class SearchCollectionItemsTests
         }
 
         await using var ctx = GetScopedContext();
-        var results = await ctx.SearchCollectionItems(term).ToListAsync();
+        var results = await ctx.SearchCollectionItems(term.SplitOnWhitespace()).ToListAsync();
 
         results.Select(h => h.ResourceId).Should().BeEquivalentTo([expectedMatch]);
     }
@@ -257,7 +258,7 @@ public class SearchCollectionItemsTests
         await Seed();
         await using var ctx = GetScopedContext();
 
-        var results = await ctx.SearchCollectionItems("hunter thompson").ToListAsync();
+        var results = await ctx.SearchCollectionItems("hunter thompson".SplitOnWhitespace()).ToListAsync();
 
         results.Single(h => h.ResourceId == "hst-coll").Collection.Should().NotBeNull();
         results.Single(h => h.ResourceId == "hst-man").Manifest.Should().NotBeNull();
@@ -276,7 +277,7 @@ public class SearchCollectionItemsTests
 
         await using var ctx = GetScopedContext();
 
-        var results = await ctx.SearchCollectionItems("kerouac").ToListAsync();
+        var results = await ctx.SearchCollectionItems("kerouac".SplitOnWhitespace()).ToListAsync();
 
         results.Should().BeEmpty();
     }
@@ -289,7 +290,7 @@ public class SearchCollectionItemsTests
         await Seed();
         await using var ctx = GetScopedContext();
 
-        var query = ctx.SearchCollectionItems(term);
+        var query = ctx.SearchCollectionItems(term.SplitOnWhitespace());
 
         (await query.CountAsync()).Should().Be(0);
         (await query.Skip(0).Take(10).ToListAsync()).Should().BeEmpty();

--- a/src/IIIFPresentation/API.Tests/Infrastructure/ControllerBaseXTests.cs
+++ b/src/IIIFPresentation/API.Tests/Infrastructure/ControllerBaseXTests.cs
@@ -1,0 +1,122 @@
+using System.Net;
+using API.Infrastructure;
+using API.Infrastructure.Http;
+using API.Infrastructure.Requests;
+using IIIF.Presentation;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Routing;
+using Models.API.Collection;
+using Models.API.General;
+
+namespace API.Tests.Infrastructure;
+
+public class ControllerBaseXTests
+{
+    private readonly ControllerBase controller = GetController();
+
+    private static ControllerBase GetController()
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Scheme = "http";
+        httpContext.Request.Host = new HostString("localhost");
+
+        return new TestController
+        {
+            ControllerContext = new ControllerContext { HttpContext = httpContext }
+        };
+    }
+
+    [Fact]
+    public void FetchResultToHttpResult_Success_ReturnsPresentationContent()
+    {
+        // Arrange
+        var entity = new PresentationCollection { Id = "http://localhost/1/collections/root" };
+        var etag = Guid.NewGuid();
+
+        // Act
+        var result = controller.FetchResultToHttpResult(FetchEntityResult<PresentationCollection>.Success(entity, etag));
+
+        // Assert
+        var content = result.Should().BeOfType<CacheableContentResult>().Subject;
+        content.StatusCode.Should().Be((int)HttpStatusCode.OK);
+        content.ContentType.Should().Be(ContentTypes.V3, "the IIIF content type, not default JSON");
+        content.ETag.Should().Be(etag);
+        content.Content.Should().Contain("http://localhost/1/collections/root");
+    }
+
+    [Fact]
+    public void FetchResultToHttpResult_Success_NoETag_ReturnsPresentationContent()
+    {
+        // Arrange
+        var entity = new PresentationCollection { Id = "http://localhost/1/collections/root" };
+
+        // Act
+        var result = controller.FetchResultToHttpResult(FetchEntityResult<PresentationCollection>.Success(entity));
+
+        // Assert
+        var content = result.Should().BeOfType<ContentResult>().Subject;
+        content.StatusCode.Should().Be((int)HttpStatusCode.OK);
+        content.ContentType.Should().Be(ContentTypes.V3);
+    }
+
+    [Fact]
+    public void FetchResultToHttpResult_Matched_ReturnsNotModified()
+    {
+        // Arrange
+        var etag = Guid.NewGuid();
+
+        // Act
+        var result = controller.FetchResultToHttpResult(FetchEntityResult<PresentationCollection>.Matched(etag));
+
+        // Assert - NotModifiedResult holds the etag privately, so execute it to see what it emits
+        var notModified = result.Should().BeOfType<NotModifiedResult>().Subject;
+        notModified.ExecuteResult(new ActionContext(controller.HttpContext, new RouteData(), new ActionDescriptor()));
+
+        controller.Response.StatusCode.Should().Be((int)HttpStatusCode.NotModified);
+        controller.Response.Headers.ETag.ToString().Should().Be($"\"{etag:N}\"");
+    }
+
+    [Fact]
+    public void FetchResultToHttpResult_Invalid_ReturnsBadRequest()
+    {
+        // Act
+        var result = controller.FetchResultToHttpResult(
+            FetchEntityResult<PresentationCollection>.Invalid("only storage collections"), errorTitle: "Search failed");
+
+        // Assert
+        var error = GetError(result, HttpStatusCode.BadRequest);
+        error.Detail.Should().Be("only storage collections");
+        error.Title.Should().Be("Search failed: Bad request");
+    }
+
+    [Fact]
+    public void FetchResultToHttpResult_Failure_ReturnsInternalServerError()
+    {
+        // Act
+        var result = controller.FetchResultToHttpResult(FetchEntityResult<PresentationCollection>.Failure("boom"));
+
+        // Assert
+        GetError(result, HttpStatusCode.InternalServerError).Detail.Should().Be("boom");
+    }
+
+    [Fact]
+    public void FetchResultToHttpResult_NotFound_ReturnsNotFound()
+    {
+        // Act
+        var result = controller.FetchResultToHttpResult(FetchEntityResult<PresentationCollection>.NotFound());
+
+        // Assert
+        GetError(result, HttpStatusCode.NotFound).Title.Should().Be("Not Found");
+    }
+
+    private static Error GetError(IActionResult result, HttpStatusCode expectedStatus)
+    {
+        var objectResult = result.Should().BeOfType<ObjectResult>().Subject;
+        objectResult.StatusCode.Should().Be((int)expectedStatus);
+        return objectResult.Value.Should().BeOfType<Error>().Subject;
+    }
+
+    private class TestController : ControllerBase;
+}

--- a/src/IIIFPresentation/API.Tests/Infrastructure/Filters/RequireShowExtrasAttributeTests.cs
+++ b/src/IIIFPresentation/API.Tests/Infrastructure/Filters/RequireShowExtrasAttributeTests.cs
@@ -1,0 +1,75 @@
+using System.Net;
+using API.Infrastructure.Filters;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+using Models.API.General;
+
+namespace API.Tests.Infrastructure.Filters;
+
+public class RequireShowExtrasAttributeTests
+{
+    private readonly RequireShowExtrasAttribute sut = new();
+
+    [Fact]
+    public void OnActionExecuting_DoesNotShortCircuit_IfShowExtrasHeaderPresent()
+    {
+        // Arrange
+        var context = GetActionExecutingContext("All");
+
+        // Act
+        sut.OnActionExecuting(context);
+
+        // Assert
+        context.Result.Should().BeNull("action is allowed to run");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("What")]
+    [InlineData(null)]
+    public void OnActionExecuting_Returns403_IfShowExtrasHeaderMissingOrUnknown(string? showExtrasVal)
+    {
+        // Arrange
+        var context = GetActionExecutingContext(showExtrasVal);
+
+        // Act
+        sut.OnActionExecuting(context);
+
+        // Assert
+        var result = context.Result.Should().BeOfType<ObjectResult>().Subject;
+        result.StatusCode.Should().Be((int)HttpStatusCode.Forbidden);
+
+        var error = result.Value.Should().BeOfType<Error>().Subject;
+        error.Status.Should().Be((int)HttpStatusCode.Forbidden);
+        error.Instance.Should().Be("http://localhost/1/collections/root/search?label=medicine");
+    }
+
+    [Fact]
+    public void Order_IsAfterVaryHeader_SoVaryIsEmittedOnShortCircuit()
+    {
+        // A short-circuiting filter skips its own OnActionExecuted, but not that of filters that
+        // already ran - VaryHeaderAttribute must run first for Vary to be set on the 403
+        sut.Order.Should().BeGreaterThan(new VaryHeaderAttribute().Order);
+    }
+
+    private static ActionExecutingContext GetActionExecutingContext(string? showExtrasVal)
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Scheme = "http";
+        httpContext.Request.Host = new HostString("localhost");
+        httpContext.Request.Path = "/1/collections/root/search";
+        httpContext.Request.QueryString = new QueryString("?label=medicine");
+
+        if (showExtrasVal != null)
+        {
+            httpContext.Request.Headers.Append("X-IIIF-CS-Show-Extras", showExtrasVal);
+        }
+
+        return new ActionExecutingContext(
+            new ActionContext(httpContext, new RouteData(), new ControllerActionDescriptor()),
+            [], new Dictionary<string, object?>(), controller: null!);
+    }
+}

--- a/src/IIIFPresentation/API.Tests/Infrastructure/Validation/PresentationValidationTests.cs
+++ b/src/IIIFPresentation/API.Tests/Infrastructure/Validation/PresentationValidationTests.cs
@@ -83,8 +83,8 @@ public class TestPresentation : IPresentation
     public string? FlatId { get; set; }
     public string? Slug { get; set; }
     public string? Parent { get; set; }
-    public DateTime Created { get; set; }
-    public DateTime Modified { get; set; }
+    public DateTime? Created { get; set; }
+    public DateTime? Modified { get; set; }
     public string? CreatedBy { get; set; }
     public string? ModifiedBy { get; set; }
 }

--- a/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/GetCollectionTests.cs
@@ -18,12 +18,10 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
 {
     private readonly HttpClient httpClient;
     private const int TotalDatabaseChildItems = 6;
-    private readonly IAmazonS3 amazonS3;
     private const int ExampleCustomer = 601;
 
     public GetCollectionTests(StorageFixture storageFixture, PresentationAppFactory<Program> factory)
     {
-        amazonS3 = storageFixture.LocalStackFixture.AWSS3ClientFactory();
         httpClient = factory.ConfigureBasicIntegrationTestHttpClient(storageFixture.DbFixture,
             appFactory => appFactory.WithLocalStack(storageFixture.LocalStackFixture));
         storageFixture.DbFixture.CleanUp();
@@ -307,7 +305,40 @@ public class GetCollectionTests : IClassFixture<PresentationAppFactory<Program>>
         var fifthItem = (Manifest)collection.Items[4];
         fifthItem.Id.Should().Be("http://localhost/1/manifests/FirstChildManifest");
     }
-    
+
+    [Fact]
+    public async Task Get_RootFlat_AdvertisesSearchService()
+    {
+        // Arrange
+        var requestMessage =
+            HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get, $"1/collections/{RootCollection.Id}");
+
+        // Act
+        var response = await httpClient.AsCustomer().SendAsync(requestMessage);
+        var collection = await response.ReadAsPresentationJsonAsync<PresentationCollection>();
+
+        // Assert
+        var service = collection!.Service!.OfType<ExternalService>().Single();
+        service.Id.Should().Be("http://localhost/1/collections/root/search");
+        service.Type.Should().Be("IIIFCS-Search");
+        service.Profile.Should().Be("level0");
+    }
+
+    [Fact]
+    public async Task Get_ChildCollectionFlat_DoesNotAdvertiseSearchService()
+    {
+        // Arrange
+        var requestMessage =
+            HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get, "1/collections/FirstChildCollection");
+
+        // Act
+        var response = await httpClient.AsCustomer().SendAsync(requestMessage);
+        var collection = await response.ReadAsPresentationJsonAsync<PresentationCollection>();
+
+        // Assert
+        collection!.Service.Should().BeNull("search-across can only be run from root");
+    }
+
     [Fact]
     public async Task Get_ChildFlat_ReturnsEntryPointFlat_WhenCalledByChildId()
     {

--- a/src/IIIFPresentation/API.Tests/Integration/SearchCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/SearchCollectionTests.cs
@@ -24,6 +24,9 @@ public class SearchCollectionTests : IClassFixture<PresentationAppFactory<Progra
     /// <summary>Search results are seeded under their own customer, so they don't leak into other test classes</summary>
     private const int SearchCustomer = 631;
 
+    /// <summary>A second customer, holding resources that match the same search terms as <see cref="SearchCustomer"/></summary>
+    private const int OtherCustomer = 632;
+
     public SearchCollectionTests(StorageFixture storageFixture, PresentationAppFactory<Program> factory)
     {
         dbFixture = storageFixture.DbFixture;
@@ -32,18 +35,46 @@ public class SearchCollectionTests : IClassFixture<PresentationAppFactory<Progra
         dbFixture.CleanUp();
     }
 
-    private async Task SeedSearchCustomer()
+    /// <summary>
+    /// Seeds resources under <see cref="OtherCustomer"/> that match the same terms as those under
+    /// <see cref="SearchCustomer"/>, so a search that isn't customer-scoped would pick them up
+    /// </summary>
+    private async Task SeedOtherCustomer()
+    {
+        await using var ctx = await GetSeededContext(OtherCustomer);
+
+        var hunterCollection =
+            (await ctx.Collections.AddTestCollection(id: "other-hst-coll", customer: OtherCustomer)).Entity;
+        hunterCollection.Label = new LanguageMap("en", ["Hunter S. Thompson"]);
+
+        await ctx.Manifests.AddTestManifest(id: "other-hst-man", customer: OtherCustomer,
+            label: new LanguageMap("en", ["Thompson, Hunter"]));
+
+        await ctx.SaveChangesAsync();
+    }
+
+    /// <summary>
+    /// Gets a context scoped to the customer, ensuring they have the root collection they'd get on creation.
+    /// CleanUp() preserves 'root' for all customers, so this is idempotent across tests sharing the fixture.
+    /// </summary>
+    private async Task<PresentationContext> GetSeededContext(int customer)
     {
         var provider = new TestCustomerIdProvider();
-        provider.SetCustomerId(SearchCustomer);
-        await using var ctx = dbFixture.GetNewPresentationContext(provider);
+        provider.SetCustomerId(customer);
+        var ctx = dbFixture.GetNewPresentationContext(provider);
 
-        // CleanUp() preserves 'root' for all customers, so only add it if this is the first test to run
         if (!await ctx.Collections.AnyAsync(c => c.Id == RootCollection.Id))
         {
-            await ctx.Collections.AddTestRootCollection(SearchCustomer);
+            await ctx.Collections.AddTestRootCollection(customer);
             await ctx.SaveChangesAsync();
         }
+
+        return ctx;
+    }
+
+    private async Task SeedSearchCustomer()
+    {
+        await using var ctx = await GetSeededContext(SearchCustomer);
 
         var hunterCollection =
             (await ctx.Collections.AddTestCollection(id: "hst-coll", customer: SearchCustomer)).Entity;
@@ -68,12 +99,26 @@ public class SearchCollectionTests : IClassFixture<PresentationAppFactory<Progra
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
+    
+    [Fact]
+    public async Task Search_ReturnsForbidden_WhenCalledWithoutShowExtras()
+    {
+        // Act
+        var response = await httpClient.AsCustomer().GetAsync($"1/collections/{RootCollection.Id}/search?label=medicine");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        response.Headers.Vary.Should().Contain("X-IIIF-CS-Show-Extras",
+            "the 403 is a function of the header, so must not be cached in place of a 200");
+    }
 
     [Fact]
     public async Task Search_ReturnsNotFound_WhenCollectionNotRoot()
     {
         // Act
-        var response = await httpClient.AsCustomer().GetAsync("1/collections/not-root/search?label=medicine");
+        var request =
+            HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get, "1/collections/not-root/search?label=medicine"); 
+        var response = await httpClient.AsCustomer().SendAsync(request);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
@@ -83,7 +128,9 @@ public class SearchCollectionTests : IClassFixture<PresentationAppFactory<Progra
     public async Task Search_ReturnsBadRequest_WhenLabelMissing()
     {
         // Act
-        var response = await httpClient.AsCustomer().GetAsync($"1/collections/{RootCollection.Id}/search");
+        var request =
+            HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get, $"1/collections/{RootCollection.Id}/search"); 
+        var response = await httpClient.AsCustomer().SendAsync(request);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
@@ -99,8 +146,10 @@ public class SearchCollectionTests : IClassFixture<PresentationAppFactory<Progra
     public async Task Search_ReturnsBadRequest_WhenLabelBelowMinimumLength(string label)
     {
         // Act
-        var response = await httpClient.AsCustomer()
-            .GetAsync($"1/collections/{RootCollection.Id}/search?label={Uri.EscapeDataString(label)}");
+        var request =
+            HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get,
+                $"1/collections/{RootCollection.Id}/search?label={Uri.EscapeDataString(label)}"); 
+        var response = await httpClient.AsCustomer().SendAsync(request);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
@@ -113,8 +162,10 @@ public class SearchCollectionTests : IClassFixture<PresentationAppFactory<Progra
         await SeedSearchCustomer();
 
         // Act
-        var response = await httpClient.AsCustomer(SearchCustomer)
-            .GetAsync($"{SearchCustomer}/collections/{RootCollection.Id}/search?label=hunter+thompson");
+        var request =
+            HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get,
+                $"{SearchCustomer}/collections/{RootCollection.Id}/search?label=hunter+thompson");
+        var response = await httpClient.AsCustomer(SearchCustomer).SendAsync(request);
         var rawBody = await response.Content.ReadAsStringAsync();
         var collection = await response.ReadAsPresentationJsonAsync<PresentationCollection>();
 
@@ -127,7 +178,7 @@ public class SearchCollectionTests : IClassFixture<PresentationAppFactory<Progra
             .Be($"http://localhost/{SearchCustomer}/collections/{RootCollection.Id}", "links back to what was searched");
         collection.TotalItems.Should().Be(2, "'Emma Thompson' is not a match");
 
-        collection.Items.OfType<Collection>().Single().Id.Should()
+        collection.Items!.OfType<Collection>().Single().Id.Should()
             .Be($"http://localhost/{SearchCustomer}/collections/hst-coll");
         collection.Items.OfType<Manifest>().Single().Id.Should()
             .Be($"http://localhost/{SearchCustomer}/manifests/hst-man");
@@ -140,14 +191,16 @@ public class SearchCollectionTests : IClassFixture<PresentationAppFactory<Progra
         await SeedSearchCustomer();
 
         // Act - "s." is under the minimum length, but "thompson" makes the search selective
-        var response = await httpClient.AsCustomer(SearchCustomer)
-            .GetAsync($"{SearchCustomer}/collections/{RootCollection.Id}/search?label=thompson+s.");
+        var request =
+            HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get,
+                $"{SearchCustomer}/collections/{RootCollection.Id}/search?label=thompson+s.");
+        var response = await httpClient.AsCustomer(SearchCustomer).SendAsync(request);
         var collection = await response.ReadAsPresentationJsonAsync<PresentationCollection>();
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         collection!.TotalItems.Should().Be(1, "the short term still narrows the search - 'Thompson, Hunter' has no 's.'");
-        collection.Items.OfType<Collection>().Single().Id.Should()
+        collection.Items!.OfType<Collection>().Single().Id.Should()
             .Be($"http://localhost/{SearchCustomer}/collections/hst-coll");
     }
 
@@ -158,14 +211,47 @@ public class SearchCollectionTests : IClassFixture<PresentationAppFactory<Progra
         await SeedSearchCustomer();
 
         // Act
-        var response = await httpClient.AsCustomer(SearchCustomer)
-            .GetAsync($"{SearchCustomer}/collections/{RootCollection.Id}/search?label=kerouac");
+        var request =
+            HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get,
+                $"{SearchCustomer}/collections/{RootCollection.Id}/search?label=kerouac");
+        var response = await httpClient.AsCustomer(SearchCustomer).SendAsync(request);
         var collection = await response.ReadAsPresentationJsonAsync<PresentationCollection>();
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         collection!.TotalItems.Should().Be(0);
         collection.Items.Should().BeNullOrEmpty("an empty items list isn't serialised");
+    }
+
+    [Fact]
+    public async Task Search_OnlyReturnsItemsForAuthenticatedCustomer()
+    {
+        // Arrange - both customers have resources matching 'hunter thompson'
+        await SeedSearchCustomer();
+        await SeedOtherCustomer();
+
+        // Act - each customer searches their own root for the terms both of them match
+        var searchCustomerResults = await SearchAsCustomer(SearchCustomer);
+        var otherCustomerResults = await SearchAsCustomer(OtherCustomer);
+
+        // Assert - each sees only their own 2 matches. Asserting both directions means a seed that silently
+        // did nothing can't pass this test
+        searchCustomerResults.Should().HaveCount(2, "the other customer's matches are not visible")
+            .And.OnlyContain(id => id.Contains($"/{SearchCustomer}/"));
+        otherCustomerResults.Should().HaveCount(2, "the other customer has matches of their own to leak")
+            .And.OnlyContain(id => id.Contains($"/{OtherCustomer}/"));
+        return;
+
+        async Task<IEnumerable<string>> SearchAsCustomer(int customer)
+        {
+            var request = HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get,
+                $"{customer}/collections/{RootCollection.Id}/search?label=hunter+thompson");
+            var response = await httpClient.AsCustomer(customer).SendAsync(request);
+            var collection = await response.ReadAsPresentationJsonAsync<PresentationCollection>();
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            return collection!.Items!.OfType<ResourceBase>().Select(i => i.Id);
+        }
     }
 
     [Theory]
@@ -177,13 +263,15 @@ public class SearchCollectionTests : IClassFixture<PresentationAppFactory<Progra
         await SeedSearchCustomer();
 
         // Act
-        var response = await httpClient.AsCustomer(SearchCustomer).GetAsync(
-            $"{SearchCustomer}/collections/{RootCollection.Id}/search?label=hunter+thompson&{orderQueryParam}");
+        var request =
+            HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get,
+                $"{SearchCustomer}/collections/{RootCollection.Id}/search?label=hunter+thompson&{orderQueryParam}");
+        var response = await httpClient.AsCustomer(SearchCustomer).SendAsync(request);
         var collection = await response.ReadAsPresentationJsonAsync<PresentationCollection>();
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        collection!.Items.OfType<ResourceBase>().Select(i => i.Id).Should()
+        collection!.Items!.OfType<ResourceBase>().Select(i => i.Id).Should()
             .ContainInOrder(GetFlatId(firstId), GetFlatId(secondId));
         return;
 
@@ -200,13 +288,15 @@ public class SearchCollectionTests : IClassFixture<PresentationAppFactory<Progra
         var searchPath = $"http://localhost/{SearchCustomer}/collections/{RootCollection.Id}/search";
 
         // Act - pageSize of 1 forces a second page, so paging links are generated
-        var response = await httpClient.AsCustomer(SearchCustomer).GetAsync(
-            $"{SearchCustomer}/collections/{RootCollection.Id}/search?label=hunter+thompson&pageSize=1&orderByDescending=id");
+        var request =
+            HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get,
+                $"{SearchCustomer}/collections/{RootCollection.Id}/search?label=hunter+thompson&pageSize=1&orderByDescending=id");
+        var response = await httpClient.AsCustomer(SearchCustomer).SendAsync(request);
         var collection = await response.ReadAsPresentationJsonAsync<PresentationCollection>();
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        collection!.View.Id.Should()
+        collection!.View!.Id.Should()
             .Be($"{searchPath}?label=hunter%20thompson&page=1&pageSize=1&orderByDescending=id");
         collection.View.Next.Should()
             .Be(new Uri($"{searchPath}?label=hunter%20thompson&page=2&pageSize=1&orderByDescending=id"));
@@ -220,13 +310,15 @@ public class SearchCollectionTests : IClassFixture<PresentationAppFactory<Progra
         var searchPath = $"http://localhost/{SearchCustomer}/collections/{RootCollection.Id}/search";
 
         // Act - pageSize of 1 forces a second page
-        var response = await httpClient.AsCustomer(SearchCustomer)
-            .GetAsync($"{SearchCustomer}/collections/{RootCollection.Id}/search?label=hunter+thompson&pageSize=1");
+        var request =
+            HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get,
+                $"{SearchCustomer}/collections/{RootCollection.Id}/search?label=hunter+thompson&pageSize=1");
+        var response = await httpClient.AsCustomer(SearchCustomer).SendAsync(request);
         var collection = await response.ReadAsPresentationJsonAsync<PresentationCollection>();
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        collection!.View.Id.Should().Be($"{searchPath}?label=hunter%20thompson&page=1&pageSize=1");
+        collection!.View!.Id.Should().Be($"{searchPath}?label=hunter%20thompson&page=1&pageSize=1");
         collection.View.TotalPages.Should().Be(2);
         collection.View.Next.Should().Be(new Uri($"{searchPath}?label=hunter%20thompson&page=2&pageSize=1"));
         collection.View.Last.Should().Be(new Uri($"{searchPath}?label=hunter%20thompson&page=2&pageSize=1"));

--- a/src/IIIFPresentation/API.Tests/Integration/SearchCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/SearchCollectionTests.cs
@@ -117,7 +117,9 @@ public class SearchCollectionTests : IClassFixture<PresentationAppFactory<Progra
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        collection!.Id.Should().Be($"http://localhost/{SearchCustomer}/collections/{RootCollection.Id}");
+        collection!.Id.Should().Be($"http://localhost/{SearchCustomer}/collections/{RootCollection.Id}/search");
+        collection.SeeAlso.Should().ContainSingle().Which.Id.Should()
+            .Be($"http://localhost/{SearchCustomer}/collections/{RootCollection.Id}", "links back to what was searched");
         collection.TotalItems.Should().Be(2, "'Emma Thompson' is not a match");
 
         collection.Items.OfType<Collection>().Single().Id.Should()

--- a/src/IIIFPresentation/API.Tests/Integration/SearchCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/SearchCollectionTests.cs
@@ -1,0 +1,80 @@
+#nullable disable
+
+using System.Net;
+using API.Tests.Integration.Infrastructure;
+using Test.Helpers.Helpers;
+using Test.Helpers.Integration;
+
+namespace API.Tests.Integration;
+
+[Trait("Category", "Integration")]
+[Collection(CollectionDefinitions.StorageCollection.CollectionName)]
+public class SearchCollectionTests : IClassFixture<PresentationAppFactory<Program>>
+{
+    private readonly HttpClient httpClient;
+
+    public SearchCollectionTests(StorageFixture storageFixture, PresentationAppFactory<Program> factory)
+    {
+        httpClient = factory.ConfigureBasicIntegrationTestHttpClient(storageFixture.DbFixture,
+            appFactory => appFactory.WithLocalStack(storageFixture.LocalStackFixture));
+        storageFixture.DbFixture.CleanUp();
+    }
+
+    [Fact]
+    public async Task Search_ReturnsUnauthorized_WhenCalledWithoutAuth()
+    {
+        // Act
+        var response = await httpClient.GetAsync($"1/collections/{RootCollection.Id}/search?label=medicine");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Search_ReturnsNotFound_WhenCollectionNotRoot()
+    {
+        // Act
+        var response = await httpClient.AsCustomer().GetAsync("1/collections/not-root/search?label=medicine");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Search_ReturnsBadRequest_WhenLabelMissing()
+    {
+        // Act
+        var response = await httpClient.AsCustomer().GetAsync($"1/collections/{RootCollection.Id}/search");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("a")]
+    [InlineData("ab")]
+    [InlineData("  ab  ")]
+    public async Task Search_ReturnsBadRequest_WhenLabelBelowMinimumLength(string label)
+    {
+        // Act
+        var response =
+            await httpClient.AsCustomer().GetAsync($"1/collections/{RootCollection.Id}/search?label={label}");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Theory]
+    [InlineData("abc")]
+    [InlineData("medicine")]
+    public async Task Search_ReturnsNotImplemented_WhenLabelMeetsMinimumLength(string label)
+    {
+        // Act
+        var response =
+            await httpClient.AsCustomer().GetAsync($"1/collections/{RootCollection.Id}/search?label={label}");
+
+        // Assert - placeholder until label search is implemented
+        response.StatusCode.Should().Be(HttpStatusCode.NotImplemented);
+    }
+}

--- a/src/IIIFPresentation/API.Tests/Integration/SearchCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/SearchCollectionTests.cs
@@ -2,8 +2,15 @@
 
 using System.Net;
 using API.Tests.Integration.Infrastructure;
+using Core.Response;
+using IIIF.Presentation.V3;
+using IIIF.Presentation.V3.Strings;
+using Microsoft.EntityFrameworkCore;
+using Models.API.Collection;
+using Repository;
 using Test.Helpers.Helpers;
 using Test.Helpers.Integration;
+using Collection = IIIF.Presentation.V3.Collection;
 
 namespace API.Tests.Integration;
 
@@ -12,12 +19,44 @@ namespace API.Tests.Integration;
 public class SearchCollectionTests : IClassFixture<PresentationAppFactory<Program>>
 {
     private readonly HttpClient httpClient;
+    private readonly PresentationContextFixture dbFixture;
+
+    /// <summary>Search results are seeded under their own customer, so they don't leak into other test classes</summary>
+    private const int SearchCustomer = 631;
 
     public SearchCollectionTests(StorageFixture storageFixture, PresentationAppFactory<Program> factory)
     {
-        httpClient = factory.ConfigureBasicIntegrationTestHttpClient(storageFixture.DbFixture,
+        dbFixture = storageFixture.DbFixture;
+        httpClient = factory.ConfigureBasicIntegrationTestHttpClient(dbFixture,
             appFactory => appFactory.WithLocalStack(storageFixture.LocalStackFixture));
-        storageFixture.DbFixture.CleanUp();
+        dbFixture.CleanUp();
+    }
+
+    private async Task SeedSearchCustomer()
+    {
+        var provider = new TestCustomerIdProvider();
+        provider.SetCustomerId(SearchCustomer);
+        await using var ctx = dbFixture.GetNewPresentationContext(provider);
+
+        // CleanUp() preserves 'root' for all customers, so only add it if this is the first test to run
+        if (!await ctx.Collections.AnyAsync(c => c.Id == RootCollection.Id))
+        {
+            await ctx.Collections.AddTestRootCollection(SearchCustomer);
+            await ctx.SaveChangesAsync();
+        }
+
+        var hunterCollection =
+            (await ctx.Collections.AddTestCollection(id: "hst-coll", customer: SearchCustomer)).Entity;
+        hunterCollection.Label = new LanguageMap("en", ["Hunter S. Thompson"]);
+
+        await ctx.Manifests.AddTestManifest(id: "hst-man", customer: SearchCustomer,
+            label: new LanguageMap("en", ["Thompson, Hunter"]));
+
+        var emmaCollection =
+            (await ctx.Collections.AddTestCollection(id: "emma-coll", customer: SearchCustomer)).Entity;
+        emmaCollection.Label = new LanguageMap("en", ["Emma Thompson"]);
+
+        await ctx.SaveChangesAsync();
     }
 
     [Fact]
@@ -65,16 +104,63 @@ public class SearchCollectionTests : IClassFixture<PresentationAppFactory<Progra
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
-    [Theory]
-    [InlineData("abc")]
-    [InlineData("medicine")]
-    public async Task Search_ReturnsNotImplemented_WhenLabelMeetsMinimumLength(string label)
+    [Fact]
+    public async Task Search_ReturnsMatchingItems_UsingFlatIds()
     {
-        // Act
-        var response =
-            await httpClient.AsCustomer().GetAsync($"1/collections/{RootCollection.Id}/search?label={label}");
+        // Arrange
+        await SeedSearchCustomer();
 
-        // Assert - placeholder until label search is implemented
-        response.StatusCode.Should().Be(HttpStatusCode.NotImplemented);
+        // Act
+        var response = await httpClient.AsCustomer(SearchCustomer)
+            .GetAsync($"{SearchCustomer}/collections/{RootCollection.Id}/search?label=hunter+thompson");
+        var collection = await response.ReadAsPresentationJsonAsync<PresentationCollection>();
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        collection!.Id.Should().Be($"http://localhost/{SearchCustomer}/collections/{RootCollection.Id}");
+        collection.TotalItems.Should().Be(2, "'Emma Thompson' is not a match");
+
+        collection.Items.OfType<Collection>().Single().Id.Should()
+            .Be($"http://localhost/{SearchCustomer}/collections/hst-coll");
+        collection.Items.OfType<Manifest>().Single().Id.Should()
+            .Be($"http://localhost/{SearchCustomer}/manifests/hst-man");
+    }
+
+    [Fact]
+    public async Task Search_ReturnsEmptyCollection_WhenNoMatches()
+    {
+        // Arrange
+        await SeedSearchCustomer();
+
+        // Act
+        var response = await httpClient.AsCustomer(SearchCustomer)
+            .GetAsync($"{SearchCustomer}/collections/{RootCollection.Id}/search?label=kerouac");
+        var collection = await response.ReadAsPresentationJsonAsync<PresentationCollection>();
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        collection!.TotalItems.Should().Be(0);
+        collection.Items.Should().BeNullOrEmpty("an empty items list isn't serialised");
+    }
+
+    [Fact]
+    public async Task Search_ViewPointsAtSearchEndpoint_PreservingSearchTerm()
+    {
+        // Arrange
+        await SeedSearchCustomer();
+        var searchPath = $"http://localhost/{SearchCustomer}/collections/{RootCollection.Id}/search";
+
+        // Act - pageSize of 1 forces a second page
+        var response = await httpClient.AsCustomer(SearchCustomer)
+            .GetAsync($"{SearchCustomer}/collections/{RootCollection.Id}/search?label=hunter+thompson&pageSize=1");
+        var collection = await response.ReadAsPresentationJsonAsync<PresentationCollection>();
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        collection!.View.Id.Should().Be($"{searchPath}?label=hunter%20thompson&page=1&pageSize=1");
+        collection.View.TotalPages.Should().Be(2);
+        collection.View.Next.Should().Be(new Uri($"{searchPath}?label=hunter%20thompson&page=2&pageSize=1"));
+        collection.View.Last.Should().Be(new Uri($"{searchPath}?label=hunter%20thompson&page=2&pageSize=1"));
+        collection.View.Previous.Should().BeNull();
     }
 }

--- a/src/IIIFPresentation/API.Tests/Integration/SearchCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/SearchCollectionTests.cs
@@ -145,6 +145,50 @@ public class SearchCollectionTests : IClassFixture<PresentationAppFactory<Progra
         collection.Items.Should().BeNullOrEmpty("an empty items list isn't serialised");
     }
 
+    [Theory]
+    [InlineData("orderBy=id", "hst-coll", "hst-man")]
+    [InlineData("orderByDescending=id", "hst-man", "hst-coll")]
+    public async Task Search_OrdersResults(string orderQueryParam, string firstId, string secondId)
+    {
+        // Arrange
+        await SeedSearchCustomer();
+
+        // Act
+        var response = await httpClient.AsCustomer(SearchCustomer).GetAsync(
+            $"{SearchCustomer}/collections/{RootCollection.Id}/search?label=hunter+thompson&{orderQueryParam}");
+        var collection = await response.ReadAsPresentationJsonAsync<PresentationCollection>();
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        collection!.Items.OfType<ResourceBase>().Select(i => i.Id).Should()
+            .ContainInOrder(GetFlatId(firstId), GetFlatId(secondId));
+        return;
+
+        string GetFlatId(string id) => id.EndsWith("-man")
+            ? $"http://localhost/{SearchCustomer}/manifests/{id}"
+            : $"http://localhost/{SearchCustomer}/collections/{id}";
+    }
+
+    [Fact]
+    public async Task Search_ViewPreservesOrdering()
+    {
+        // Arrange
+        await SeedSearchCustomer();
+        var searchPath = $"http://localhost/{SearchCustomer}/collections/{RootCollection.Id}/search";
+
+        // Act - pageSize of 1 forces a second page, so paging links are generated
+        var response = await httpClient.AsCustomer(SearchCustomer).GetAsync(
+            $"{SearchCustomer}/collections/{RootCollection.Id}/search?label=hunter+thompson&pageSize=1&orderByDescending=id");
+        var collection = await response.ReadAsPresentationJsonAsync<PresentationCollection>();
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        collection!.View.Id.Should()
+            .Be($"{searchPath}?label=hunter%20thompson&page=1&pageSize=1&orderByDescending=id");
+        collection.View.Next.Should()
+            .Be(new Uri($"{searchPath}?label=hunter%20thompson&page=2&pageSize=1&orderByDescending=id"));
+    }
+
     [Fact]
     public async Task Search_ViewPointsAtSearchEndpoint_PreservingSearchTerm()
     {

--- a/src/IIIFPresentation/API.Tests/Integration/SearchCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/SearchCollectionTests.cs
@@ -94,11 +94,13 @@ public class SearchCollectionTests : IClassFixture<PresentationAppFactory<Progra
     [InlineData("a")]
     [InlineData("ab")]
     [InlineData("  ab  ")]
+    [InlineData("a b")] // no single term is selective, despite the label as a whole being over the minimum length
+    [InlineData("  a   b  ")]
     public async Task Search_ReturnsBadRequest_WhenLabelBelowMinimumLength(string label)
     {
         // Act
-        var response =
-            await httpClient.AsCustomer().GetAsync($"1/collections/{RootCollection.Id}/search?label={label}");
+        var response = await httpClient.AsCustomer()
+            .GetAsync($"1/collections/{RootCollection.Id}/search?label={Uri.EscapeDataString(label)}");
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
@@ -113,10 +115,13 @@ public class SearchCollectionTests : IClassFixture<PresentationAppFactory<Progra
         // Act
         var response = await httpClient.AsCustomer(SearchCustomer)
             .GetAsync($"{SearchCustomer}/collections/{RootCollection.Id}/search?label=hunter+thompson");
+        var rawBody = await response.Content.ReadAsStringAsync();
         var collection = await response.ReadAsPresentationJsonAsync<PresentationCollection>();
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
+        rawBody.Should().NotContain("\"created\"", "audit props are meaningless on a synthetic search collection")
+            .And.NotContain("\"modified\"");
         collection!.Id.Should().Be($"http://localhost/{SearchCustomer}/collections/{RootCollection.Id}/search");
         collection.SeeAlso.Should().ContainSingle().Which.Id.Should()
             .Be($"http://localhost/{SearchCustomer}/collections/{RootCollection.Id}", "links back to what was searched");
@@ -126,6 +131,24 @@ public class SearchCollectionTests : IClassFixture<PresentationAppFactory<Progra
             .Be($"http://localhost/{SearchCustomer}/collections/hst-coll");
         collection.Items.OfType<Manifest>().Single().Id.Should()
             .Be($"http://localhost/{SearchCustomer}/manifests/hst-man");
+    }
+
+    [Fact]
+    public async Task Search_AllowsShortTerm_WhenAnotherTermIsLongEnough()
+    {
+        // Arrange
+        await SeedSearchCustomer();
+
+        // Act - "s." is under the minimum length, but "thompson" makes the search selective
+        var response = await httpClient.AsCustomer(SearchCustomer)
+            .GetAsync($"{SearchCustomer}/collections/{RootCollection.Id}/search?label=thompson+s.");
+        var collection = await response.ReadAsPresentationJsonAsync<PresentationCollection>();
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        collection!.TotalItems.Should().Be(1, "the short term still narrows the search - 'Thompson, Hunter' has no 's.'");
+        collection.Items.OfType<Collection>().Single().Id.Should()
+            .Be($"http://localhost/{SearchCustomer}/collections/hst-coll");
     }
 
     [Fact]

--- a/src/IIIFPresentation/API/Converters/CollectionConverter.cs
+++ b/src/IIIFPresentation/API/Converters/CollectionConverter.cs
@@ -1,5 +1,6 @@
 ﻿using API.Helpers;
 using Core.Helpers;
+using IIIF;
 using Core.IIIF;
 using Core.Infrastructure;
 using IIIF.Presentation;
@@ -7,6 +8,7 @@ using IIIF.Presentation.V3;
 using IIIF.Presentation.V3.Content;
 using IIIF.Presentation.V3.Strings;
 using Models.API.Collection;
+using Models.Database.Collections;
 using Models.Database.General;
 using Repository.Helpers;
 using Repository.Paths;
@@ -136,6 +138,7 @@ public static class CollectionConverter
         GenerateCommonFields(collection, dbCollection, hierarchy,  parentCollection, pathGenerator, settingsBasedPathGenerator);
         
         collection.SeeAlso = GenerateSeeAlso(dbCollection, settingsBasedPathGenerator, pathGenerator);
+        collection.Service = GenerateService(dbCollection, pathGenerator);
         collection.Behavior = GenerateBehavior(dbCollection);
         collection.Totals = GetDescendantCounts(dbCollection, items);
         collection.Label = dbCollection.Label;
@@ -303,6 +306,27 @@ public static class CollectionConverter
                 Label = collection.Label,
                 Profile = profile,
             });
+    }
+
+    /// <summary>
+    /// Generates the Service part of a collection, currently only advertising the search-across capability
+    /// </summary>
+    /// <param name="collection">The collection to use in generation</param>
+    /// <param name="pathGenerator">Generates paths for collections</param>
+    /// <returns>A list of services, or null if none available</returns>
+    private static List<IService>? GenerateService(DbCollection collection, IPathGenerator pathGenerator)
+    {
+        // only the root storage collection can be searched for now
+        if (!collection.IsStorageCollection || !collection.IsRoot()) return null;
+
+        return
+        [
+            new ExternalService(PresentationServices.Search)
+            {
+                Id = pathGenerator.GenerateFlatCollectionSearchId(collection),
+                Profile = PresentationServices.SearchLevel0
+            }
+        ];
     }
 
     /// <summary>

--- a/src/IIIFPresentation/API/Converters/CollectionConverter.cs
+++ b/src/IIIFPresentation/API/Converters/CollectionConverter.cs
@@ -5,6 +5,7 @@ using Core.Infrastructure;
 using IIIF.Presentation;
 using IIIF.Presentation.V3;
 using IIIF.Presentation.V3.Content;
+using IIIF.Presentation.V3.Strings;
 using Models.API.Collection;
 using Models.Database.General;
 using Repository.Helpers;
@@ -43,21 +44,38 @@ public static class CollectionConverter
 
     /// <summary>
     /// Converts a db collection to a synthetic <see cref="PresentationCollection"/> holding a page of search results
-    /// (see RFC 0008). Differs from <see cref="ToPresentationCollection"/> in that the View points at the search
-    /// endpoint, carrying the search term, and 'totals' is omitted - descendant counts of the searched collection
-    /// can't be derived from a page of search results.
+    /// (see RFC 0008).
     /// </summary>
+    /// <remarks>
+    /// Deliberately does NOT share <see cref="EnrichPresentationCollection"/>: the returned resource is not the
+    /// searched collection, it's a synthetic rendering of some of its contents, so properties that describe the
+    /// collection itself (created/modified, slug, parent, partOf, publicId, behavior, totals...) do not belong on it.
+    /// Only the Id (which is the search endpoint), the searched collection's Tags, and a SeeAlso pointing back at
+    /// the collection being searched are carried over.
+    /// </remarks>
     public static PresentationCollection ToSearchCollection(this DbCollection dbAsset, string label, int pageSize,
-        int currentPage, int totalItems, IList<Hierarchy> items, DbCollection? parentCollection,
-        IPathGenerator pathGenerator, SettingsBasedPathGenerator settingsBasedPathGenerator,
+        int currentPage, int totalItems, IList<Hierarchy> items, IPathGenerator pathGenerator,
         string? orderQueryParam = null)
     {
-        var collection = new PresentationCollection().EnrichPresentationCollection(dbAsset, pageSize, currentPage,
-            totalItems, items, parentCollection, pathGenerator, settingsBasedPathGenerator, orderQueryParam);
-
-        collection.Totals = null;
-        collection.View = GenerateSearchView(dbAsset, label, pathGenerator, pageSize, currentPage,
-            GenerateTotalPages(pageSize, totalItems), GenerateOrderQueryParamConverted(orderQueryParam));
+        var collection = new PresentationCollection
+        {
+            Id = pathGenerator.GenerateFlatCollectionSearchId(dbAsset),
+            Context = GenerateContext(),
+            Label = new LanguageMap("en", $"Search results for '{label}' in '{dbAsset.Id}'"),
+            Tags = dbAsset.Tags,
+            SeeAlso =
+            [
+                new ExternalResource(nameof(PresentationType.Collection))
+                {
+                    Id = pathGenerator.GenerateFlatCollectionId(dbAsset),
+                    Label = dbAsset.Label
+                }
+            ],
+            Items = GenerateItems(pathGenerator, items),
+            TotalItems = totalItems,
+            View = GenerateSearchView(dbAsset, label, pathGenerator, pageSize, currentPage,
+                GenerateTotalPages(pageSize, totalItems), GenerateOrderQueryParamConverted(orderQueryParam))
+        };
 
         return collection;
     }

--- a/src/IIIFPresentation/API/Converters/CollectionConverter.cs
+++ b/src/IIIFPresentation/API/Converters/CollectionConverter.cs
@@ -38,7 +38,7 @@ public static class CollectionConverter
     public static PresentationCollection ToPresentationCollection(this DbCollection dbAsset,
         int pageSize, int currentPage, int totalItems, IList<Hierarchy>? items, DbCollection? parentCollection,
         IPathGenerator pathGenerator, SettingsBasedPathGenerator settingsBasedPathGenerator, string? orderQueryParam = null) =>
-        EnrichPresentationCollection(new PresentationCollection(), dbAsset, pageSize, currentPage, totalItems, items,
+        new PresentationCollection().EnrichPresentationCollection(dbAsset, pageSize, currentPage, totalItems, items,
             parentCollection, pathGenerator, settingsBasedPathGenerator, orderQueryParam);
 
     /// <summary>

--- a/src/IIIFPresentation/API/Converters/CollectionConverter.cs
+++ b/src/IIIFPresentation/API/Converters/CollectionConverter.cs
@@ -42,6 +42,27 @@ public static class CollectionConverter
             parentCollection, pathGenerator, settingsBasedPathGenerator, orderQueryParam);
 
     /// <summary>
+    /// Converts a db collection to a synthetic <see cref="PresentationCollection"/> holding a page of search results
+    /// (see RFC 0008). Differs from <see cref="ToPresentationCollection"/> in that the View points at the search
+    /// endpoint, carrying the search term, and 'totals' is omitted - descendant counts of the searched collection
+    /// can't be derived from a page of search results.
+    /// </summary>
+    public static PresentationCollection ToSearchCollection(this DbCollection dbAsset, string label, int pageSize,
+        int currentPage, int totalItems, IList<Hierarchy> items, DbCollection? parentCollection,
+        IPathGenerator pathGenerator, SettingsBasedPathGenerator settingsBasedPathGenerator,
+        string? orderQueryParam = null)
+    {
+        var collection = new PresentationCollection().EnrichPresentationCollection(dbAsset, pageSize, currentPage,
+            totalItems, items, parentCollection, pathGenerator, settingsBasedPathGenerator, orderQueryParam);
+
+        collection.Totals = null;
+        collection.View = GenerateSearchView(dbAsset, label, pathGenerator, pageSize, currentPage,
+            GenerateTotalPages(pageSize, totalItems), GenerateOrderQueryParamConverted(orderQueryParam));
+
+        return collection;
+    }
+
+    /// <summary>
     /// Sets generated fields on a IIIF collection
     /// </summary>
     /// <param name="collection">The collection to set fields on</param>
@@ -315,6 +336,40 @@ public static class CollectionConverter
         return view;
     }
     
+    /// <summary>
+    /// Generates the view component of a page of search results - as <see cref="GenerateView"/> but all links point
+    /// back at the search endpoint, preserving the search term
+    /// </summary>
+    private static View GenerateSearchView(DbCollection collection, string label, IPathGenerator pathGenerator,
+        int pageSize, int currentPage, int totalPages, string? orderQueryParam)
+    {
+        var view = new View
+        {
+            Id = SearchViewId(currentPage),
+            Type = PresentationType.PartialCollectionView,
+            Page = currentPage,
+            PageSize = pageSize,
+            TotalPages = totalPages,
+        };
+
+        if (currentPage > 1)
+        {
+            view.First = new Uri(SearchViewId(1));
+            view.Previous = new Uri(SearchViewId(currentPage - 1));
+        }
+
+        if (totalPages > currentPage)
+        {
+            view.Next = new Uri(SearchViewId(currentPage + 1));
+            view.Last = new Uri(SearchViewId(totalPages));
+        }
+
+        return view;
+
+        string SearchViewId(int page) =>
+            pathGenerator.GenerateFlatCollectionSearchView(collection, label, page, pageSize, orderQueryParam);
+    }
+
     private static DescendantCounts? GetDescendantCounts(DbCollection dbAsset, IList<Hierarchy>? items)
     {
         if (!dbAsset.IsStorageCollection) return null;

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestController.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestController.cs
@@ -63,6 +63,7 @@ public class ManifestController(
     /// Create a new Manifest on Flat URL
     /// </summary>
     [Authorize]
+    [RequireShowExtras]
     [HttpPost("manifests")]
     public async Task<IActionResult> CreateManifest(
         [FromRoute] int customerId,
@@ -79,6 +80,7 @@ public class ManifestController(
     /// If id exists valid E-Tag must be provided 
     /// </summary>
     [Authorize]
+    [RequireShowExtras]
     [HttpPut("manifests/{id}")]
     public async Task<IActionResult> UpsertManifest(
         [FromRoute] int customerId,
@@ -94,11 +96,10 @@ public class ManifestController(
             cancellationToken: cancellationToken);
 
     [Authorize]
+    [RequireShowExtras]
     [HttpDelete("manifests/{id}")]
     public async Task<IActionResult> Delete(int customerId, string id)
     {
-        if (!Request.HasShowExtraHeader()) return this.Forbidden();
-
         return await HandleDelete(new DeleteManifest(customerId, id, Request.Headers.IfMatch));
     }
 
@@ -112,8 +113,6 @@ public class ManifestController(
         where T : JsonLdBase
         where TEnum : Enum
     {
-        if (!Request.HasShowExtraHeader()) return this.Forbidden();
-
         var rawRequestBody = await Request.GetRawRequestBodyAsync(cancellationToken);
         var presentationManifest = await rawRequestBody.TryDeserializePresentation<PresentationManifest>(logger);
 

--- a/src/IIIFPresentation/API/Features/Storage/CollectionController.cs
+++ b/src/IIIFPresentation/API/Features/Storage/CollectionController.cs
@@ -61,7 +61,9 @@ public class CollectionController(
     }
 
     [Authorize]
+    [RequireShowExtras]
     [HttpGet("collections/{id}/search")]
+    [VaryHeader]
     public async Task<IActionResult> Search(int customerId, string id, string? label = null, int? page = 1,
         int? pageSize = -1, string? orderBy = null, string? orderByDescending = null)
     {
@@ -86,6 +88,7 @@ public class CollectionController(
     }
 
     [Authorize]
+    [RequireShowExtras]
     [HttpPost("collections")]
     public async Task<IActionResult> Post(int customerId, [FromServices] PresentationValidator validator)
     {
@@ -97,6 +100,7 @@ public class CollectionController(
     }
 
     [Authorize]
+    [RequireShowExtras]
     [HttpPut("collections/{id}")]
     public async Task<IActionResult> Put(int customerId, string id,
         [FromServices] RootCollectionValidator rootValidator,
@@ -114,11 +118,6 @@ public class CollectionController(
     private async Task<DeserializeValidationResult<PresentationCollection>> DeserializeAndValidate(
         PresentationValidator presentationValidator, string? id, RootCollectionValidator? rootValidator)
     {
-        if (!Request.HasShowExtraHeader())
-        {
-            return DeserializeValidationResult<PresentationCollection>.Failure(this.Forbidden());
-        }
-
         var rawRequestBody = await Request.GetRawRequestBodyAsync();
 
         var deserializedCollection =
@@ -143,11 +142,10 @@ public class CollectionController(
 
 
     [Authorize]
+    [RequireShowExtras]
     [HttpDelete("collections/{id}")]
     public async Task<IActionResult> Delete(int customerId, string id)
     {
-        if (!Request.HasShowExtraHeader()) return this.Forbidden();
-
         return await HandleDelete(new DeleteCollection(customerId, id, Request.Headers.IfMatch));
     }
 

--- a/src/IIIFPresentation/API/Features/Storage/CollectionController.cs
+++ b/src/IIIFPresentation/API/Features/Storage/CollectionController.cs
@@ -62,7 +62,7 @@ public class CollectionController(
     [Authorize]
     [HttpGet("collections/{id}/search")]
     public async Task<IActionResult> Search(int customerId, string id, string? label = null, int? page = 1,
-        int? pageSize = -1)
+        int? pageSize = -1, string? orderBy = null, string? orderByDescending = null)
     {
         // MVP: only the root collection supports search-across
         if (!KnownCollections.IsRoot(id)) return this.PresentationNotFound();
@@ -76,7 +76,10 @@ public class CollectionController(
                 this.GetErrorType(ModifyCollectionType.ValidationFailed));
         }
 
-        return await HandleFetch(new SearchCollection(id, term, page, pageSize), errorTitle: "Search failed");
+        var orderByField = this.GetOrderBy(orderBy, orderByDescending, out var descending);
+
+        return await HandleFetch(new SearchCollection(id, term, page, pageSize, orderByField, descending),
+            errorTitle: "Search failed");
     }
 
     [Authorize]

--- a/src/IIIFPresentation/API/Features/Storage/CollectionController.cs
+++ b/src/IIIFPresentation/API/Features/Storage/CollectionController.cs
@@ -10,6 +10,7 @@ using API.Infrastructure.Helpers;
 using API.Infrastructure.Http;
 using API.Infrastructure.Requests;
 using API.Settings;
+using Core.Helpers;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -67,18 +68,20 @@ public class CollectionController(
         // MVP: only the root collection supports search-across
         if (!KnownCollections.IsRoot(id)) return this.PresentationNotFound();
 
-        // Validate search term length (configurable minimum, default 3)
+        // Validate search term length, at least one must match minimum length
         var term = label?.Trim() ?? string.Empty;
-        if (term.Length < Settings.MinSearchLength)
+        var terms = term.SplitOnWhitespace();
+        if (!terms.Any(t => t.Length >= Settings.MinSearchLength))
         {
-            return this.PresentationProblem($"Search term must be at least {Settings.MinSearchLength} characters",
+            return this.PresentationProblem(
+                $"At least one search term must be {Settings.MinSearchLength} characters or more",
                 null, (int)HttpStatusCode.BadRequest, "Bad request",
                 this.GetErrorType(ModifyCollectionType.ValidationFailed));
         }
 
         var orderByField = this.GetOrderBy(orderBy, orderByDescending, out var descending);
 
-        return await HandleFetch(new SearchCollection(id, term, page, pageSize, orderByField, descending),
+        return await HandleFetch(new SearchCollection(id, term, terms, page, pageSize, orderByField, descending),
             errorTitle: "Search failed");
     }
 

--- a/src/IIIFPresentation/API/Features/Storage/CollectionController.cs
+++ b/src/IIIFPresentation/API/Features/Storage/CollectionController.cs
@@ -35,14 +35,10 @@ public class CollectionController(
     public async Task<IActionResult> Get(int customerId, string id, int? page = 1, int? pageSize = -1,
         string? orderBy = null, string? orderByDescending = null)
     {
-        if (pageSize is null or <= 0) pageSize = Settings.PageSize;
-        if (pageSize > Settings.MaxPageSize) pageSize = Settings.MaxPageSize;
-        if (page is null or <= 0) page = 1;
-
         var orderByField = this.GetOrderBy(orderBy, orderByDescending, out var descending);
 
-        var entityResult = await Mediator.Send(new GetCollection(id, Request.Headers.IfNoneMatch.AsETagValues(),
-            page.Value, pageSize.Value, orderByField, descending));
+        var entityResult = await Mediator.Send(new GetCollection(id, Request.Headers.IfNoneMatch.AsETagValues(), page,
+            pageSize, orderByField, descending));
 
         if (entityResult.ETagMatch)
             return new NotModifiedResult(entityResult.ETag!.Value);

--- a/src/IIIFPresentation/API/Features/Storage/CollectionController.cs
+++ b/src/IIIFPresentation/API/Features/Storage/CollectionController.cs
@@ -61,7 +61,8 @@ public class CollectionController(
 
     [Authorize]
     [HttpGet("collections/{id}/search")]
-    public IActionResult Search(int customerId, string id, string? label = null, int? page = 1, int? pageSize = -1)
+    public async Task<IActionResult> Search(int customerId, string id, string? label = null, int? page = 1,
+        int? pageSize = -1)
     {
         // MVP: only the root collection supports search-across
         if (!KnownCollections.IsRoot(id)) return this.PresentationNotFound();
@@ -69,14 +70,13 @@ public class CollectionController(
         // Validate search term length (configurable minimum, default 3)
         var term = label?.Trim() ?? string.Empty;
         if (term.Length < Settings.MinSearchLength)
+        {
             return this.PresentationProblem($"Search term must be at least {Settings.MinSearchLength} characters",
                 null, (int)HttpStatusCode.BadRequest, "Bad request",
                 this.GetErrorType(ModifyCollectionType.ValidationFailed));
+        }
 
-        // TODO (next slice, GH #631): normalise paging (shared with GetCollection) + run label
-        // search, return synthetic paged Collection
-        return this.PresentationProblem("Search is not yet implemented", null,
-            (int)HttpStatusCode.NotImplemented, "Not implemented");
+        return await HandleFetch(new SearchCollection(id, term, page, pageSize), errorTitle: "Search failed");
     }
 
     [Authorize]

--- a/src/IIIFPresentation/API/Features/Storage/CollectionController.cs
+++ b/src/IIIFPresentation/API/Features/Storage/CollectionController.cs
@@ -64,6 +64,26 @@ public class CollectionController(
     }
 
     [Authorize]
+    [HttpGet("collections/{id}/search")]
+    public IActionResult Search(int customerId, string id, string? label = null, int? page = 1, int? pageSize = -1)
+    {
+        // MVP: only the root collection supports search-across
+        if (!KnownCollections.IsRoot(id)) return this.PresentationNotFound();
+
+        // Validate search term length (configurable minimum, default 3)
+        var term = label?.Trim() ?? string.Empty;
+        if (term.Length < Settings.MinSearchLength)
+            return this.PresentationProblem($"Search term must be at least {Settings.MinSearchLength} characters",
+                null, (int)HttpStatusCode.BadRequest, "Bad request",
+                this.GetErrorType(ModifyCollectionType.ValidationFailed));
+
+        // TODO (next slice, GH #631): normalise paging (shared with GetCollection) + run label
+        // search, return synthetic paged Collection
+        return this.PresentationProblem("Search is not yet implemented", null,
+            (int)HttpStatusCode.NotImplemented, "Not implemented");
+    }
+
+    [Authorize]
     [HttpPost("collections")]
     public async Task<IActionResult> Post(int customerId, [FromServices] PresentationValidator validator)
     {

--- a/src/IIIFPresentation/API/Features/Storage/Helpers/PresentationContextX.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Helpers/PresentationContextX.cs
@@ -1,4 +1,5 @@
-﻿using API.Infrastructure.Requests;
+﻿using System.Text;
+using API.Infrastructure.Requests;
 using Core;
 using IIIF;
 using Microsoft.EntityFrameworkCore;
@@ -166,6 +167,62 @@ public static class PresentationContextX
 
         return hierarchy;
     }
+
+    /// <summary>
+    /// Searches across all resources (Collections + Manifests) in the customer by label value, regardless of
+    /// nesting depth, returning the matching canonical <see cref="Hierarchy"/> rows so they can be shaped into
+    /// a Collection via the CollectionConverter. Customer scoping is applied automatically by the global query
+    /// filter; the returned query is composable, so callers add ordering/paging on top.
+    /// </summary>
+    /// <remarks>
+    /// Label is jsonb but persisted via a value converter, so a LINQ predicate won't translate. This uses raw
+    /// SQL following RFC 0008 (docs/rfcs/0008-search-across-mvp.md): the term is split into whitespace tokens
+    /// and, case-insensitively and language-agnostically, ALL tokens must appear within a single label value
+    /// (same-value AND). e.g. "Hunter Thompson" matches "Thompson, Hunter" but not "Emma Thompson".
+    /// </remarks>
+    public static IQueryable<Hierarchy> SearchCollectionItems(this PresentationContext dbContext, string label)
+    {
+        var tokens = label
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(EscapeForILike)
+            .Distinct()
+            .ToList();
+
+        // Nothing searchable (e.g. all-whitespace) - return an empty, still-composable query
+        if (tokens.Count == 0) return dbContext.Hierarchy.Where(_ => false);
+
+        var sql = new StringBuilder(
+            """
+            SELECT h.* FROM hierarchy h
+            LEFT JOIN collections c ON c.id = h.collection_id AND c.customer_id = h.customer_id
+            LEFT JOIN manifests m ON m.id = h.manifest_id AND m.customer_id = h.customer_id
+            WHERE h.canonical
+              AND EXISTS (
+                SELECT 1
+                FROM jsonb_each(COALESCE(c.label, m.label)) AS kv,
+                     LATERAL jsonb_array_elements_text(kv.value) AS val
+                WHERE
+            """);
+
+        var parameters = new List<object>();
+        for (var i = 0; i < tokens.Count; i++)
+        {
+            sql.Append(i == 0 ? " " : " AND ");
+            sql.Append($"val ILIKE {{{parameters.Count}}}");
+            parameters.Add($"%{tokens[i]}%");
+        }
+
+        sql.Append(')');
+
+        return dbContext.Hierarchy
+            .FromSqlRaw(sql.ToString(), parameters.ToArray())
+            .Include(h => h.Collection)
+            .Include(h => h.Manifest);
+    }
+
+    // Escapes LIKE/ILIKE wildcards so user input matches literally (default '\' escape char).
+    private static string EscapeForILike(string token) =>
+        token.Replace("\\", "\\\\").Replace("%", "\\%").Replace("_", "\\_");
 
     public static async Task<int> GetTotalItemCountForCollection(this PresentationContext dbContext,
         Collection collection, int itemCount, int pageSize, int pageNo, CancellationToken cancellationToken = default)

--- a/src/IIIFPresentation/API/Features/Storage/Helpers/PresentationContextX.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Helpers/PresentationContextX.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text;
 using API.Infrastructure.Requests;
+using API.Settings;
 using Core;
 using IIIF;
 using Microsoft.EntityFrameworkCore;
@@ -180,10 +181,14 @@ public static class PresentationContextX
     /// and, case-insensitively and language-agnostically, ALL tokens must appear within a single label value
     /// (same-value AND). e.g. "Hunter Thompson" matches "Thompson, Hunter" but not "Emma Thompson".
     /// </remarks>
-    public static IQueryable<Hierarchy> SearchCollectionItems(this PresentationContext dbContext, string label)
+    /// <param name="dbContext">Current db context</param>
+    /// <param name="terms">
+    /// Search terms, already tokenised - each is matched as a substring. Every term is scanned with an unindexed
+    /// ILIKE, so callers must reject terms too short to be selective (see <see cref="ApiSettings.MinSearchLength"/>)
+    /// </param>
+    public static IQueryable<Hierarchy> SearchCollectionItems(this PresentationContext dbContext, string[] terms)
     {
-        var tokens = label
-            .Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+        var tokens = terms
             .Select(EscapeForILike)
             .Distinct()
             .ToList();
@@ -216,6 +221,7 @@ public static class PresentationContextX
 
         return dbContext.Hierarchy
             .FromSqlRaw(sql.ToString(), parameters.ToArray())
+            .AsNoTracking()
             .Include(h => h.Collection)
             .Include(h => h.Manifest);
     }

--- a/src/IIIFPresentation/API/Features/Storage/Models/IPagedRequest.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Models/IPagedRequest.cs
@@ -1,0 +1,22 @@
+using API.Settings;
+
+namespace API.Features.Storage.Models;
+
+/// <summary>
+/// A request that carries raw paging/ordering query values, which can be normalised into
+/// <see cref="RequestModifiers"/> via <see cref="IPagedRequestX.GetRequestModifiers"/>.
+/// </summary>
+public interface IPagedRequest
+{
+    public int? Page { get; }
+    public int? PageSize { get; }
+    public string? OrderBy { get; }
+    public bool Descending { get; }
+}
+
+public static class IPagedRequestX
+{
+    // This is a very thin wrapper around <see cref="RequestModifiers.Create"/> but keeps consuming code clean.
+    public static RequestModifiers GetRequestModifiers(this IPagedRequest pagedRequest, ApiSettings settings)
+        => RequestModifiers.Create(pagedRequest, settings);
+}

--- a/src/IIIFPresentation/API/Features/Storage/Models/RequestModifiers.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Models/RequestModifiers.cs
@@ -1,10 +1,39 @@
-﻿namespace API.Features.Storage.Models;
+﻿using API.Settings;
 
+namespace API.Features.Storage.Models;
+
+/// <summary>
+/// Class that contains the normalised values of a <see cref="IPagedRequest"/>, used to modify request results
+/// </summary>
 public class RequestModifiers
 {
-    public int Page { get; init; }
-    public int PageSize { get; init; }
-    public string? OrderBy { get; init; }
-    public bool Descending { get; init; }
+    public int Page { get; private init; }
+    public int PageSize { get; private init; }
+    public string? OrderBy { get; private init; }
+    public bool Descending { get; private init; }
+
+    public string? GetOrderByParameter() => OrderBy != null
+        ? $"{(Descending ? "orderByDescending" : "orderBy")}={OrderBy}"
+        : null;
+
+    /// <summary>
+    /// Create an instances from a <see cref="IPagedRequest"/>, clamping paging values if required
+    /// </summary>
+    public static RequestModifiers Create(IPagedRequest pagedRequest, ApiSettings settings)
+    {
+        var normalisedPageSize = pagedRequest.PageSize is null or <= 0
+            ? settings.PageSize
+            : Math.Min(pagedRequest.PageSize.Value, settings.MaxPageSize);
+
+        var normalisedPage = pagedRequest.Page is null or <= 0 ? 1 : pagedRequest.Page.Value;
+
+        return new RequestModifiers
+        {
+            Descending = pagedRequest.Descending,
+            OrderBy = pagedRequest.OrderBy,
+            Page = normalisedPage,
+            PageSize = normalisedPageSize
+        };
+    }
 }
  

--- a/src/IIIFPresentation/API/Features/Storage/Requests/GetCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/GetCollection.cs
@@ -48,13 +48,13 @@ public class GetCollectionHandler(PresentationContext dbContext, IIIIFS3Service 
         if (collection is null) return FetchEntityResult<PresentationCollection>.NotFound();
 
         if (request.IfNoneMatch.Contains(collection.Etag))
+        {
             return FetchEntityResult<PresentationCollection>.Matched(collection.Etag);
+        }
 
         var hierarchy = collection.Hierarchy.GetCanonical();
 
         var parentCollection = collection.Hierarchy?.SingleOrDefault()?.ParentCollection;
-
-        var requestModifiers = request.GetRequestModifiers(options.Value);
 
         if (hierarchy.Parent != null)
         {
@@ -64,6 +64,8 @@ public class GetCollectionHandler(PresentationContext dbContext, IIIIFS3Service 
 
         if (collection.IsStorageCollection)
         {
+            var requestModifiers = request.GetRequestModifiers(options.Value);
+            
             var items = await dbContext.RetrieveCollectionItems(collection.Id)
                 .AsOrderedCollectionItemsQuery(requestModifiers.OrderBy, requestModifiers.Descending)
                 .Skip((requestModifiers.Page - 1) * requestModifiers.PageSize)

--- a/src/IIIFPresentation/API/Features/Storage/Requests/GetCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/GetCollection.cs
@@ -2,12 +2,12 @@
 using API.Converters;
 using API.Features.Storage.Helpers;
 using API.Features.Storage.Models;
-using API.Infrastructure.Helpers;
 using API.Infrastructure.Requests;
+using API.Settings;
 using AWS.Helpers;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Primitives;
+using Microsoft.Extensions.Options;
 using Models.API.Collection;
 using Repository;
 using Repository.Collections;
@@ -20,26 +20,23 @@ namespace API.Features.Storage.Requests;
 public class GetCollection(
     string id,
     IImmutableSet<Guid> eTags,
-    int page,
-    int pageSize,
+    int? page,
+    int? pageSize,
     string? orderBy = null,
-    bool descending = false) : IRequest<FetchEntityResult<PresentationCollection>>
+    bool descending = false) : IRequest<FetchEntityResult<PresentationCollection>>, IPagedRequest
 {
     public string Id { get; } = id;
 
     public IImmutableSet<Guid> IfNoneMatch { get; } = eTags;
 
-    public RequestModifiers RequestModifiers { get; } = new()
-    {
-        PageSize = pageSize,
-        Page = page,
-        OrderBy = orderBy,
-        Descending = descending
-    };
+    public int? Page { get; } = page;
+    public int? PageSize { get; } = pageSize;
+    public string? OrderBy { get; } = orderBy;
+    public bool Descending { get; } = descending;
 }
 
 public class GetCollectionHandler(PresentationContext dbContext, IIIIFS3Service iiifS3, IPathGenerator pathGenerator, 
-    SettingsBasedPathGenerator settingsBasedPathGenerator) 
+    SettingsBasedPathGenerator settingsBasedPathGenerator, IOptions<ApiSettings> options) 
     : IRequestHandler<GetCollection, FetchEntityResult<PresentationCollection>>
 {
     public async Task<FetchEntityResult<PresentationCollection>> Handle(GetCollection request,
@@ -57,9 +54,7 @@ public class GetCollectionHandler(PresentationContext dbContext, IIIIFS3Service 
 
         var parentCollection = collection.Hierarchy?.SingleOrDefault()?.ParentCollection;
 
-        var orderByParameter = request.RequestModifiers.OrderBy != null
-            ? $"{(request.RequestModifiers.Descending ? "orderByDescending" : "orderBy")}={request.RequestModifiers.OrderBy}"
-            : null;
+        var requestModifiers = request.GetRequestModifiers(options.Value);
 
         if (hierarchy.Parent != null)
         {
@@ -70,22 +65,22 @@ public class GetCollectionHandler(PresentationContext dbContext, IIIIFS3Service 
         if (collection.IsStorageCollection)
         {
             var items = await dbContext.RetrieveCollectionItems(collection.Id)
-                .AsOrderedCollectionItemsQuery(request.RequestModifiers.OrderBy, request.RequestModifiers.Descending)
-                .Skip((request.RequestModifiers.Page - 1) * request.RequestModifiers.PageSize)
-                .Take(request.RequestModifiers.PageSize)
+                .AsOrderedCollectionItemsQuery(requestModifiers.OrderBy, requestModifiers.Descending)
+                .Skip((requestModifiers.Page - 1) * requestModifiers.PageSize)
+                .Take(requestModifiers.PageSize)
                 .ToListAsync(cancellationToken: cancellationToken);
 
             var total = await dbContext.GetTotalItemCountForCollection(collection, items.Count,
-                request.RequestModifiers.PageSize,
-                request.RequestModifiers.Page, cancellationToken);
+                requestModifiers.PageSize,
+                requestModifiers.Page, cancellationToken);
 
             // We know the fullPath of parent collection so we can use that as the base for child items
             items.ForEach(item =>
                 item.FullPath = pathGenerator.GenerateFullPath(item, hierarchy));
 
-            var presentationCollection = collection.ToPresentationCollection(request.RequestModifiers.PageSize,
-                request.RequestModifiers.Page, total, items, parentCollection, pathGenerator,
-                settingsBasedPathGenerator, orderByParameter);
+            var presentationCollection = collection.ToPresentationCollection(requestModifiers.PageSize,
+                requestModifiers.Page, total, items, parentCollection, pathGenerator,
+                settingsBasedPathGenerator, requestModifiers.GetOrderByParameter());
 
             return FetchEntityResult<PresentationCollection>.Success(presentationCollection, collection.Etag);
         }

--- a/src/IIIFPresentation/API/Features/Storage/Requests/SearchCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/SearchCollection.cs
@@ -8,6 +8,7 @@ using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using Models.API.Collection;
+using Models.Database.Collections;
 using Repository;
 using Repository.Collections;
 using Repository.Paths;
@@ -17,6 +18,7 @@ namespace API.Features.Storage.Requests;
 public class SearchCollection(
     string id,
     string label,
+    string[] terms,
     int? page,
     int? pageSize,
     string? orderBy = null,
@@ -25,7 +27,11 @@ public class SearchCollection(
 {
     public string Id { get; } = id;
 
+    /// <summary>The search term as supplied, used to label and link the results</summary>
     public string Label { get; } = label;
+
+    /// <summary>The search term tokenised into the individual terms to match on</summary>
+    public string[] Terms { get; } = terms;
 
     public int? Page { get; } = page;
 
@@ -54,12 +60,15 @@ public class SearchCollectionHandler(
 
         if (collection is null) return FetchEntityResult<PresentationCollection>.NotFound();
 
-        // Only storage collections can be searched - their items are db records, whereas an IIIF collection's items
-        // are stored in S3. Currently unreachable as callers restrict search to 'root', but the guard belongs here.
-        if (!collection.IsStorageCollection)
-            return FetchEntityResult<PresentationCollection>.Invalid("Search is only supported for storage collections");
+        // For MVP SearchCollectionItems searches every resource in the customer, so it only gives the right answer for
+        // the root collection, guard here.
+        if (!collection.IsStorageCollection || !collection.IsRoot())
+        {
+            return FetchEntityResult<PresentationCollection>.Invalid(
+                "Search is only supported for the root storage collection");
+        }
 
-        var searchQuery = dbContext.SearchCollectionItems(request.Label);
+        var searchQuery = dbContext.SearchCollectionItems(request.Terms);
 
         // Label search is an un-indexed ILIKE scan (see RFC 0008), so time the 2 queries it runs separately - the
         // count has no LIMIT to short-circuit it, so is expected to be the more expensive of the pair

--- a/src/IIIFPresentation/API/Features/Storage/Requests/SearchCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/SearchCollection.cs
@@ -1,0 +1,76 @@
+using API.Converters;
+using API.Features.Storage.Helpers;
+using API.Features.Storage.Models;
+using API.Infrastructure.Requests;
+using API.Settings;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Models.API.Collection;
+using Repository;
+using Repository.Collections;
+using Repository.Paths;
+using Services.Manifests.Helpers;
+
+namespace API.Features.Storage.Requests;
+
+public class SearchCollection(string id, string label, int? page, int? pageSize)
+    : IRequest<FetchEntityResult<PresentationCollection>>, IPagedRequest
+{
+    public string Id { get; } = id;
+
+    public string Label { get; } = label;
+
+    public int? Page { get; } = page;
+
+    public int? PageSize { get; } = pageSize;
+
+    // Search does not expose ordering yet (see RFC 0008); results use the default order.
+    public string? OrderBy => null;
+
+    public bool Descending => false;
+}
+
+public class SearchCollectionHandler(
+    PresentationContext dbContext,
+    IPathGenerator pathGenerator,
+    SettingsBasedPathGenerator settingsBasedPathGenerator,
+    IOptions<ApiSettings> options)
+    : IRequestHandler<SearchCollection, FetchEntityResult<PresentationCollection>>
+{
+    public async Task<FetchEntityResult<PresentationCollection>> Handle(SearchCollection request,
+        CancellationToken cancellationToken)
+    {
+        var collection = await dbContext.RetrieveCollectionWithParentAsync(request.Id,
+            cancellationToken: cancellationToken);
+
+        if (collection is null) return FetchEntityResult<PresentationCollection>.NotFound();
+
+        // Only storage collections can be searched - their items are db records, whereas an IIIF collection's items
+        // are stored in S3. Currently unreachable as callers restrict search to 'root', but the guard belongs here.
+        if (!collection.IsStorageCollection)
+            return FetchEntityResult<PresentationCollection>.Invalid("Search is only supported for storage collections");
+
+        var parentCollection = collection.Hierarchy?.SingleOrDefault()?.ParentCollection;
+
+        var searchQuery = dbContext.SearchCollectionItems(request.Label);
+
+        var total = await searchQuery.CountAsync(cancellationToken);
+
+        var requestModifiers = request.GetRequestModifiers(options.Value);
+        var items = await searchQuery
+            .AsOrderedCollectionItemsQuery(requestModifiers.OrderBy, requestModifiers.Descending)
+            .Skip((requestModifiers.Page - 1) * requestModifiers.PageSize)
+            .Take(requestModifiers.PageSize)
+            .ToListAsync(cancellationToken);
+
+        // Results can sit at any depth, so items are identified by their flat id (see RFC 0008) - no full path
+        // is required
+        var presentationCollection = collection.ToSearchCollection(request.Label, requestModifiers.PageSize,
+            requestModifiers.Page, total, items, parentCollection, pathGenerator, settingsBasedPathGenerator,
+            requestModifiers.GetOrderByParameter());
+
+        // no etag - it's the collection's, and would be unchanged by results changing beneath it
+        return FetchEntityResult<PresentationCollection>.Success(presentationCollection);
+    }
+}

--- a/src/IIIFPresentation/API/Features/Storage/Requests/SearchCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/SearchCollection.cs
@@ -14,7 +14,13 @@ using Repository.Paths;
 
 namespace API.Features.Storage.Requests;
 
-public class SearchCollection(string id, string label, int? page, int? pageSize)
+public class SearchCollection(
+    string id,
+    string label,
+    int? page,
+    int? pageSize,
+    string? orderBy = null,
+    bool descending = false)
     : IRequest<FetchEntityResult<PresentationCollection>>, IPagedRequest
 {
     public string Id { get; } = id;
@@ -25,10 +31,9 @@ public class SearchCollection(string id, string label, int? page, int? pageSize)
 
     public int? PageSize { get; } = pageSize;
 
-    // Search does not expose ordering yet (see RFC 0008); results use the default order.
-    public string? OrderBy => null;
+    public string? OrderBy { get; } = orderBy;
 
-    public bool Descending => false;
+    public bool Descending { get; } = descending;
 }
 
 public class SearchCollectionHandler(

--- a/src/IIIFPresentation/API/Features/Storage/Requests/SearchCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/SearchCollection.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using API.Converters;
 using API.Features.Storage.Helpers;
 using API.Features.Storage.Models;
@@ -10,7 +11,6 @@ using Models.API.Collection;
 using Repository;
 using Repository.Collections;
 using Repository.Paths;
-using Services.Manifests.Helpers;
 
 namespace API.Features.Storage.Requests;
 
@@ -34,15 +34,18 @@ public class SearchCollection(string id, string label, int? page, int? pageSize)
 public class SearchCollectionHandler(
     PresentationContext dbContext,
     IPathGenerator pathGenerator,
-    SettingsBasedPathGenerator settingsBasedPathGenerator,
-    IOptions<ApiSettings> options)
+    IOptions<ApiSettings> options,
+    ILogger<SearchCollectionHandler> logger)
     : IRequestHandler<SearchCollection, FetchEntityResult<PresentationCollection>>
 {
+    private readonly ApiSettings settings = options.Value;
+
     public async Task<FetchEntityResult<PresentationCollection>> Handle(SearchCollection request,
         CancellationToken cancellationToken)
     {
-        var collection = await dbContext.RetrieveCollectionWithParentAsync(request.Id,
-            cancellationToken: cancellationToken);
+        // Only the collection itself is required - the search result is synthetic, so it carries none of the
+        // collection's hierarchy (slug, parent, publicId etc)
+        var collection = await dbContext.Collections.Retrieve(request.Id, cancellationToken: cancellationToken);
 
         if (collection is null) return FetchEntityResult<PresentationCollection>.NotFound();
 
@@ -51,26 +54,48 @@ public class SearchCollectionHandler(
         if (!collection.IsStorageCollection)
             return FetchEntityResult<PresentationCollection>.Invalid("Search is only supported for storage collections");
 
-        var parentCollection = collection.Hierarchy?.SingleOrDefault()?.ParentCollection;
-
         var searchQuery = dbContext.SearchCollectionItems(request.Label);
 
+        // Label search is an un-indexed ILIKE scan (see RFC 0008), so time the 2 queries it runs separately - the
+        // count has no LIMIT to short-circuit it, so is expected to be the more expensive of the pair
+        var countStopwatch = Stopwatch.StartNew();
         var total = await searchQuery.CountAsync(cancellationToken);
+        countStopwatch.Stop();
 
-        var requestModifiers = request.GetRequestModifiers(options.Value);
+        var requestModifiers = request.GetRequestModifiers(settings);
+
+        var pageStopwatch = Stopwatch.StartNew();
         var items = await searchQuery
             .AsOrderedCollectionItemsQuery(requestModifiers.OrderBy, requestModifiers.Descending)
             .Skip((requestModifiers.Page - 1) * requestModifiers.PageSize)
             .Take(requestModifiers.PageSize)
             .ToListAsync(cancellationToken);
+        pageStopwatch.Stop();
+
+        LogSearchTimings(request, requestModifiers, total, countStopwatch.ElapsedMilliseconds,
+            pageStopwatch.ElapsedMilliseconds);
 
         // Results can sit at any depth, so items are identified by their flat id (see RFC 0008) - no full path
         // is required
         var presentationCollection = collection.ToSearchCollection(request.Label, requestModifiers.PageSize,
-            requestModifiers.Page, total, items, parentCollection, pathGenerator, settingsBasedPathGenerator,
-            requestModifiers.GetOrderByParameter());
+            requestModifiers.Page, total, items, pathGenerator, requestModifiers.GetOrderByParameter());
 
         // no etag - it's the collection's, and would be unchanged by results changing beneath it
         return FetchEntityResult<PresentationCollection>.Success(presentationCollection);
+    }
+
+    /// <summary>
+    /// Logs how long the search queries took, as a warning if over <see cref="ApiSettings.SlowSearchThresholdMs"/> so
+    /// that slow searches surface without Debug logging enabled
+    /// </summary>
+    private void LogSearchTimings(SearchCollection request, RequestModifiers requestModifiers, int total,
+        long countElapsed, long pageElapsed)
+    {
+        var level = countElapsed + pageElapsed >= settings.SlowSearchThresholdMs ? LogLevel.Warning : LogLevel.Debug;
+
+        logger.Log(level,
+            "Searched {CollectionId} for '{SearchTerm}' (count {CountElapsed}ms, page {PageElapsed}ms). {TotalMatches} matches page {Page} of {PageSize}",
+            request.Id, request.Label, countElapsed, pageElapsed, total, requestModifiers.Page,
+            requestModifiers.PageSize);
     }
 }

--- a/src/IIIFPresentation/API/Infrastructure/ControllerBaseX.cs
+++ b/src/IIIFPresentation/API/Infrastructure/ControllerBaseX.cs
@@ -203,12 +203,6 @@ public static class ControllerBaseX
     }
 
     /// <summary>
-    /// Create an <see cref="ObjectResult"/> that produced a 403 response
-    /// </summary>
-    public static ObjectResult Forbidden(this ControllerBase controller)
-        => controller.PresentationProblem(statusCode: (int)HttpStatusCode.Forbidden);
-
-    /// <summary>
     /// Creates a result with serialised <see cref="JsonLdBase"/> body, specified status code and Location header set
     /// </summary>
     public static ActionResult PresentationWithLocationHeader(this ControllerBase controller, string? uri,

--- a/src/IIIFPresentation/API/Infrastructure/ControllerBaseX.cs
+++ b/src/IIIFPresentation/API/Infrastructure/ControllerBaseX.cs
@@ -24,23 +24,36 @@ public static class ControllerBaseX
     /// </summary>
     /// <param name="controller">Current controllerBase object</param>
     /// <param name="entityResult">Result to transform</param>
-    /// <typeparam name="T">Type of entity being upserted</typeparam>
+    /// <param name="instance">The value for <see cref="Error.Instance" />.</param>
+    /// <param name="errorTitle">The value for <see cref="Error.Title" />.</param>
+    /// <typeparam name="T">Type of entity being fetched</typeparam>
     /// <returns>
     ///     ActionResult generated from FetchEntityResult
     /// </returns>
     public static IActionResult FetchResultToHttpResult<T>(this ControllerBase controller,
-        FetchEntityResult<T> entityResult)
-        where T : class
+        FetchEntityResult<T> entityResult,
+        string? instance = null,
+        string? errorTitle = "Fetch failed")
+        where T : JsonLdBase
     {
+        // BadRequest is checked ahead of Error as FetchEntityResult.Invalid() sets both
+        if (entityResult.BadRequest)
+        {
+            return controller.PresentationProblem(entityResult.ErrorMessage, instance,
+                (int)HttpStatusCode.BadRequest, $"{errorTitle}: Bad request");
+        }
+
         if (entityResult.Error)
         {
-            return controller.PresentationProblem(detail: entityResult.ErrorMessage,
-                statusCode: (int)HttpStatusCode.InternalServerError);
+            return controller.PresentationProblem(entityResult.ErrorMessage, instance,
+                (int)HttpStatusCode.InternalServerError, errorTitle);
         }
+
+        if (entityResult is { ETagMatch: true, ETag: { } matchedETag }) return new NotModifiedResult(matchedETag);
 
         if (entityResult.EntityNotFound || entityResult.Entity == null) return controller.PresentationNotFound();
 
-        return controller.Ok(entityResult.Entity);
+        return controller.PresentationContent(entityResult.Entity, etag: entityResult.ETag);
     }
 
     /// <summary>

--- a/src/IIIFPresentation/API/Infrastructure/Filters/RequireShowExtrasAttribute.cs
+++ b/src/IIIFPresentation/API/Infrastructure/Filters/RequireShowExtrasAttribute.cs
@@ -1,0 +1,40 @@
+using System.Net;
+using API.Infrastructure.Helpers;
+using API.Infrastructure.Requests;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Models.API.General;
+
+namespace API.Infrastructure.Filters;
+
+/// <summary>
+/// Requires request to have the "show extras" header, short-circuiting with a 403 if it is absent.
+/// </summary>
+/// <remarks>
+/// Runs after <see cref="VaryHeaderAttribute"/> (Order 0) so that Vary is still emitted when this
+/// short-circuits - whether the response is a 403 or a 200 depends on the header.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+public class RequireShowExtrasAttribute : ActionFilterAttribute
+{
+    public RequireShowExtrasAttribute()
+    {
+        Order = 10;
+    }
+
+    public override void OnActionExecuting(ActionExecutingContext context)
+    {
+        var request = context.HttpContext.Request;
+        if (request.HasShowExtraHeader()) return;
+
+        var error = new Error
+        {
+            // GetDisplayUrl() takes the path as an arg rather than reading Request.Path, so pass it
+            // explicitly - without it the instance is just host + query string
+            Instance = request.GetDisplayUrl(request.Path),
+            Status = (int)HttpStatusCode.Forbidden
+        };
+
+        context.Result = new ObjectResult(error) { StatusCode = error.Status };
+    }
+}

--- a/src/IIIFPresentation/API/Infrastructure/PresentationController.cs
+++ b/src/IIIFPresentation/API/Infrastructure/PresentationController.cs
@@ -160,13 +160,13 @@ public abstract class PresentationController : Controller
         string? instance = null,
         string? errorTitle = "Fetch failed",
         CancellationToken cancellationToken = default)
-        where T : class
+        where T : JsonLdBase
     {
         return await HandleRequest(async () =>
         {
             var result = await Mediator.Send(request, cancellationToken);
 
-            return this.FetchResultToHttpResult(result);
+            return this.FetchResultToHttpResult(result, instance, errorTitle);
         }, errorTitle);
     }
 

--- a/src/IIIFPresentation/API/Infrastructure/Requests/FetchEntityResult.cs
+++ b/src/IIIFPresentation/API/Infrastructure/Requests/FetchEntityResult.cs
@@ -28,6 +28,12 @@ public class FetchEntityResult<T>
     public bool EntityNotFound { get; private init; }
 
     /// <summary>
+    ///     If true the request itself was invalid, so cannot be satisfied. <see cref="Error"/> is also true, so
+    ///     callers that don't handle this specifically will fail rather than treat it as a success.
+    /// </summary>
+    public bool BadRequest { get; private init; }
+
+    /// <summary>
     ///     If true entity is NOT returned, because ETag was matched. <see cref="ETag"/> is not null.
     /// </summary>
     public bool ETagMatch { get; private init; }
@@ -37,6 +43,14 @@ public class FetchEntityResult<T>
     public static FetchEntityResult<T> Failure(string? errorMessage)
     {
         return new FetchEntityResult<T> { ErrorMessage = errorMessage, Error = true };
+    }
+
+    /// <summary>
+    ///     Request cannot be satisfied as provided - results in a 400
+    /// </summary>
+    public static FetchEntityResult<T> Invalid(string? errorMessage)
+    {
+        return new FetchEntityResult<T> { ErrorMessage = errorMessage, Error = true, BadRequest = true };
     }
 
     public static FetchEntityResult<T> NotFound(string? errorMessage = null)

--- a/src/IIIFPresentation/API/Settings/ApiSettings.cs
+++ b/src/IIIFPresentation/API/Settings/ApiSettings.cs
@@ -16,6 +16,11 @@ public class ApiSettings
     /// The maximum size of a page
     /// </summary>
     public int MaxPageSize { get; set; } = 1000;
+
+    /// <summary>
+    /// Minimum number of characters required in a search term before a search is run
+    /// </summary>
+    public int MinSearchLength { get; set; } = 3;
     
     public string? PathBase { get; set; }
     

--- a/src/IIIFPresentation/API/Settings/ApiSettings.cs
+++ b/src/IIIFPresentation/API/Settings/ApiSettings.cs
@@ -21,6 +21,11 @@ public class ApiSettings
     /// Minimum number of characters required in a search term before a search is run
     /// </summary>
     public int MinSearchLength { get; set; } = 3;
+
+    /// <summary>
+    /// Search queries taking longer than this, in milliseconds, are logged as a warning
+    /// </summary>
+    public int SlowSearchThresholdMs { get; set; } = 1000;
     
     public string? PathBase { get; set; }
     

--- a/src/IIIFPresentation/Core.Tests/Helpers/StringXTests.cs
+++ b/src/IIIFPresentation/Core.Tests/Helpers/StringXTests.cs
@@ -132,4 +132,17 @@ public class StringXTests
         // Assert
         result.Should().Be(expected);
     }
+
+    [Theory]
+    [InlineData("foo\tbar")]
+    [InlineData("foo  bar")]
+    [InlineData("foo\nbar")]
+    public void SplitOnWhitespace_SplitsOnAllWhitespace(string input)
+    {
+        string[] expected = ["foo", "bar"];
+        
+        var result = input.SplitOnWhitespace();
+        
+        result.Should().BeEquivalentTo(expected);
+    }
 }

--- a/src/IIIFPresentation/Core/Helpers/StringX.cs
+++ b/src/IIIFPresentation/Core/Helpers/StringX.cs
@@ -66,5 +66,13 @@ public static class StringX
         }
 
         return sb.ToString();
-    }    
+    }
+
+    /// <summary>
+    /// Splits string into tokens on any whitespace, dropping empty entries
+    /// </summary>
+    /// <param name="str">String to split</param>
+    /// <returns>Tokens found in string; empty if string is null, empty or whitespace</returns>
+    public static string[] SplitOnWhitespace(this string? str) =>
+        str?.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries) ?? [];
 }

--- a/src/IIIFPresentation/Core/Infrastructure/PresentationServices.cs
+++ b/src/IIIFPresentation/Core/Infrastructure/PresentationServices.cs
@@ -1,0 +1,17 @@
+namespace Core.Infrastructure;
+
+/// <summary>
+/// Custom IIIF-Presentation services, advertised in the "service" block of a resource
+/// </summary>
+public static class PresentationServices
+{
+    /// <summary>
+    /// Search-across, run from a storage collection (see RFC 0008)
+    /// </summary>
+    public const string Search = "IIIFCS-Search";
+
+    /// <summary>
+    /// Search-across supporting label search only
+    /// </summary>
+    public const string SearchLevel0 = "level0";
+}

--- a/src/IIIFPresentation/Models/API/Collection/PresentationCollection.cs
+++ b/src/IIIFPresentation/Models/API/Collection/PresentationCollection.cs
@@ -18,9 +18,9 @@ public class PresentationCollection : IIIF.Presentation.V3.Collection, IPresenta
     [JsonProperty(Order = 6)] public string? Slug { get; set; }
     [JsonProperty(Order = 7)] public string? PublicId { get; set; }
     [JsonProperty(Order = 8)] public string? Parent { get; set; }
-    [JsonProperty(Order = 9)] public DateTime Created { get; set; }
+    [JsonProperty(Order = 9)] public DateTime? Created { get; set; }
 
-    [JsonProperty(Order = 9)] public DateTime Modified { get; set; }
+    [JsonProperty(Order = 9)] public DateTime? Modified { get; set; }
 
     [JsonProperty(Order = 10)] public string? CreatedBy { get; set; }
 

--- a/src/IIIFPresentation/Models/API/Collection/PresentationCollection.cs
+++ b/src/IIIFPresentation/Models/API/Collection/PresentationCollection.cs
@@ -1,4 +1,6 @@
 ﻿
+using Newtonsoft.Json;
+
 namespace Models.API.Collection;
 
 public class PresentationCollection : IIIF.Presentation.V3.Collection, IPresentation
@@ -13,28 +15,25 @@ public class PresentationCollection : IIIF.Presentation.V3.Collection, IPresenta
         "created", "modified", "createdBy", "modifiedBy", "tags", "totals", "view"
     ];
 
-    public string? PublicId { get; set; }
-    public string? FlatId { get; set; }
+    [JsonProperty(Order = 6)] public string? Slug { get; set; }
+    [JsonProperty(Order = 7)] public string? PublicId { get; set; }
+    [JsonProperty(Order = 8)] public string? Parent { get; set; }
+    [JsonProperty(Order = 9)] public DateTime Created { get; set; }
+
+    [JsonProperty(Order = 9)] public DateTime Modified { get; set; }
+
+    [JsonProperty(Order = 10)] public string? CreatedBy { get; set; }
+
+    [JsonProperty(Order = 10)] public string? ModifiedBy { get; set; }
+    [JsonProperty(Order = 11)] public string? FlatId { get; set; }
     
-    public string? Slug { get; set; }
+    [JsonProperty(Order = 12)] public int? ItemsOrder { get; set; }
+
+    [JsonProperty(Order = 13)] public int? TotalItems { get; set; }
     
-    public string? Parent { get; set; }
+    [JsonProperty(Order = 14)] public string? Tags { get; set; }
     
-    public int? ItemsOrder { get; set; }
+    [JsonProperty(Order = 15)] public DescendantCounts? Totals { get; set; }
 
-    public int? TotalItems { get; set; }
-
-    public View? View { get; set; }
-
-    public DateTime Created { get; set; }
-
-    public DateTime Modified { get; set; }
-
-    public string? CreatedBy { get; set; }
-
-    public string? ModifiedBy { get; set; }
-
-    public string? Tags { get; set; }
-    
-    public DescendantCounts? Totals { get; set; }
+    [JsonProperty(Order = 20)] public View? View { get; set; }
 }

--- a/src/IIIFPresentation/Models/API/IPresentation.cs
+++ b/src/IIIFPresentation/Models/API/IPresentation.cs
@@ -10,9 +10,9 @@ public interface IPresentation
     public string? FlatId { get; set; }
     string? Slug { get; set; }
     string? Parent { get; set; }
-    public DateTime Created { get; set; }
+    public DateTime? Created { get; set; }
 
-    public DateTime Modified { get; set; }
+    public DateTime? Modified { get; set; }
 
     public string? CreatedBy { get; set; }
 

--- a/src/IIIFPresentation/Models/API/Manifest/PresentationManifest.cs
+++ b/src/IIIFPresentation/Models/API/Manifest/PresentationManifest.cs
@@ -20,8 +20,8 @@ public class PresentationManifest : IIIF.Presentation.V3.Manifest, IPresentation
     [JsonProperty(Order = 6)] public string? Slug { get; set; }
     [JsonProperty(Order = 7)] public string? PublicId { get; set; }
     [JsonProperty(Order = 8)] public string? Parent { get; set; }
-    [JsonProperty(Order = 9)] public DateTime Created { get; set; }
-    [JsonProperty(Order = 9)] public DateTime Modified { get; set; }
+    [JsonProperty(Order = 9)] public DateTime? Created { get; set; }
+    [JsonProperty(Order = 9)] public DateTime? Modified { get; set; }
     [JsonProperty(Order = 10)] public string? CreatedBy { get; set; }
     [JsonProperty(Order = 10)] public string? ModifiedBy { get; set; }
     [JsonProperty(Order = 11)] public string? FlatId { get; set; }

--- a/src/IIIFPresentation/Repository.Tests/Paths/PathGeneratorTests.cs
+++ b/src/IIIFPresentation/Repository.Tests/Paths/PathGeneratorTests.cs
@@ -173,6 +173,23 @@ public class PathGeneratorTests
         id.Should().Be("http://base/0/collections/test?page=1&pageSize=10&test");
     }
 
+    [Fact]
+    public void GenerateFlatCollectionSearchId_CreatesSearchId()
+    {
+        // Arrange
+        var collection = new Collection
+        {
+            Id = "test",
+            Hierarchy = GetDefaultHierarchyList()
+        };
+
+        // Act
+        var id = pathGenerator.GenerateFlatCollectionSearchId(collection);
+
+        // Assert
+        id.Should().Be("http://base/0/collections/test/search");
+    }
+
     [Theory]
     [InlineData("&test")]
     [InlineData(null)]

--- a/src/IIIFPresentation/Repository.Tests/Paths/PathGeneratorTests.cs
+++ b/src/IIIFPresentation/Repository.Tests/Paths/PathGeneratorTests.cs
@@ -174,6 +174,45 @@ public class PathGeneratorTests
     }
 
     [Theory]
+    [InlineData("&test")]
+    [InlineData(null)]
+    public void GenerateFlatCollectionSearchView_CreatesSearchViewId(string? orderQueryParam)
+    {
+        // Arrange
+        var collection = new Collection
+        {
+            Id = "test",
+            Hierarchy = GetDefaultHierarchyList()
+        };
+
+        // Act
+        var id = pathGenerator.GenerateFlatCollectionSearchView(collection, "medicine", 2, 10, orderQueryParam);
+
+        // Assert
+        id.Should().Be($"http://base/0/collections/test/search?label=medicine&page=2&pageSize=10{orderQueryParam}");
+    }
+
+    [Theory]
+    [InlineData("hunter thompson", "hunter%20thompson")]
+    [InlineData("19th century & co", "19th%20century%20%26%20co")]
+    [InlineData("100%", "100%25")]
+    public void GenerateFlatCollectionSearchView_EscapesSearchTerm(string label, string expected)
+    {
+        // Arrange
+        var collection = new Collection
+        {
+            Id = "test",
+            Hierarchy = GetDefaultHierarchyList()
+        };
+
+        // Act
+        var id = pathGenerator.GenerateFlatCollectionSearchView(collection, label, 1, 10, null);
+
+        // Assert
+        id.Should().Be($"http://base/0/collections/test/search?label={expected}&page=1&pageSize=10");
+    }
+
+    [Theory]
     [InlineData("")]
     [InlineData(null)]
     public void GenerateFullPath_Correct_ParentFullPathNullOrEmpty(string? path)
@@ -493,8 +532,6 @@ public class PathGeneratorTests
     public void GetModifiedImageRequest_SetsSizeParam_WhenRewritten(string input, string expected)
     {
         // Verify that we can handle image paths for "rewritten" (non standard) asset paths
-        const int customerId = 123;
-        const int spaceId = 456;
         const int width = 75;
         const int height = 50;
 

--- a/src/IIIFPresentation/Repository/Migrations/20260713084444_Manifest label is jsonb.Designer.cs
+++ b/src/IIIFPresentation/Repository/Migrations/20260713084444_Manifest label is jsonb.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Repository;
@@ -11,9 +12,11 @@ using Repository;
 namespace Repository.Migrations
 {
     [DbContext(typeof(PresentationContext))]
-    partial class PresentationContextModelSnapshot : ModelSnapshot
+    [Migration("20260713084444_Manifest label is jsonb")]
+    partial class Manifestlabelisjsonb
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/IIIFPresentation/Repository/Migrations/20260713084444_Manifest label is jsonb.cs
+++ b/src/IIIFPresentation/Repository/Migrations/20260713084444_Manifest label is jsonb.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Repository.Migrations
+{
+    /// <inheritdoc />
+    public partial class Manifestlabelisjsonb : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Postgres cannot implicitly cast text -> jsonb, so an explicit USING clause is required
+            migrationBuilder.Sql("ALTER TABLE manifests ALTER COLUMN label TYPE jsonb USING label::jsonb;");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("ALTER TABLE manifests ALTER COLUMN label TYPE text USING label::text;");
+        }
+    }
+}

--- a/src/IIIFPresentation/Repository/Paths/IPathGenerator.cs
+++ b/src/IIIFPresentation/Repository/Paths/IPathGenerator.cs
@@ -56,6 +56,11 @@ public interface IPathGenerator
         string orderQueryParam);
 
     /// <summary>
+    /// Get the search endpoint for the given collection, e.g. {collection}/search
+    /// </summary>
+    string GenerateFlatCollectionSearchId(Collection collection);
+
+    /// <summary>
     /// Get the id for a page of search results for the given collection, e.g.
     /// {collection}/search?label=medicine&amp;page=1&amp;pageSize=100
     /// </summary>

--- a/src/IIIFPresentation/Repository/Paths/IPathGenerator.cs
+++ b/src/IIIFPresentation/Repository/Paths/IPathGenerator.cs
@@ -56,7 +56,14 @@ public interface IPathGenerator
         string orderQueryParam);
 
     /// <summary>
-    /// Get the FullPath of an item, using Canonical slug of attached Hierarchy collection and parent FullPath, if set 
+    /// Get the id for a page of search results for the given collection, e.g.
+    /// {collection}/search?label=medicine&amp;page=1&amp;pageSize=100
+    /// </summary>
+    string GenerateFlatCollectionSearchView(Collection collection, string label, int page, int pageSize,
+        string? orderQueryParam);
+
+    /// <summary>
+    /// Get the FullPath of an item, using Canonical slug of attached Hierarchy collection and parent FullPath, if set
     /// </summary>
     string GenerateFullPath(Hierarchy collection, Hierarchy parent);
 

--- a/src/IIIFPresentation/Repository/Paths/PathGeneratorBase.cs
+++ b/src/IIIFPresentation/Repository/Paths/PathGeneratorBase.cs
@@ -59,9 +59,12 @@ public abstract class PathGeneratorBase(IPresentationPathGenerator presentationP
         string orderQueryParam) => new(
         $"{GenerateFlatCollectionId(collection)}?page={lastPage}&pageSize={pageSize}{orderQueryParam}");
     
+    public string GenerateFlatCollectionSearchId(Collection collection) =>
+        $"{GenerateFlatCollectionId(collection)}/search";
+
     public string GenerateFlatCollectionSearchView(Collection collection, string label, int page, int pageSize,
         string? orderQueryParam) =>
-        $"{GenerateFlatCollectionId(collection)}/search?label={Uri.EscapeDataString(label)}&page={page}&pageSize={pageSize}{orderQueryParam}";
+        $"{GenerateFlatCollectionSearchId(collection)}?label={Uri.EscapeDataString(label)}&page={page}&pageSize={pageSize}{orderQueryParam}";
 
     public string GenerateFullPath(Hierarchy collection, Hierarchy parent)
         => GenerateFullPath(collection, parent.FullPath);

--- a/src/IIIFPresentation/Repository/Paths/PathGeneratorBase.cs
+++ b/src/IIIFPresentation/Repository/Paths/PathGeneratorBase.cs
@@ -59,6 +59,10 @@ public abstract class PathGeneratorBase(IPresentationPathGenerator presentationP
         string orderQueryParam) => new(
         $"{GenerateFlatCollectionId(collection)}?page={lastPage}&pageSize={pageSize}{orderQueryParam}");
     
+    public string GenerateFlatCollectionSearchView(Collection collection, string label, int page, int pageSize,
+        string? orderQueryParam) =>
+        $"{GenerateFlatCollectionId(collection)}/search?label={Uri.EscapeDataString(label)}&page={page}&pageSize={pageSize}{orderQueryParam}";
+
     public string GenerateFullPath(Hierarchy collection, Hierarchy parent)
         => GenerateFullPath(collection, parent.FullPath);
     

--- a/src/IIIFPresentation/Repository/PresentationContext.cs
+++ b/src/IIIFPresentation/Repository/PresentationContext.cs
@@ -84,6 +84,8 @@ public class PresentationContext : DbContext
         modelBuilder.Entity<Manifest>(entity =>
         {
             entity.HasKey(e => new { e.Id, e.CustomerId });
+            
+            entity.Property(e => e.Label).HasColumnType("jsonb");
 
             entity.HasMany(e => e.Hierarchy)
                 .WithOne(e => e.Manifest)

--- a/src/IIIFPresentation/Test.Helpers/Integration/PresentationContextFixture.cs
+++ b/src/IIIFPresentation/Test.Helpers/Integration/PresentationContextFixture.cs
@@ -354,10 +354,17 @@ public class PresentationContextFixture : IAsyncLifetime
         DbContext = GetNewPresentationContext(customerIdProvider, QueryTrackingBehavior.NoTracking);
     }
 
+    private const string PreservedCollections =
+        "'root','FirstChildCollection','SecondChildCollection', 'NonPublic', 'IiifCollection'";
+
     public void CleanUp()
     {
+        // Remove hierarchy rows hanging off a collection that's about to be deleted first.
+        // hierarchy.parent=>collections does not cascade delete, hierarcy.collection_id=>collections does
         DbContext.Database.ExecuteSqlRaw(
-            "DELETE FROM collections WHERE customer_id != 1 AND id NOT IN ('root','FirstChildCollection','SecondChildCollection', 'NonPublic', 'IiifCollection')");
+            $"DELETE FROM hierarchy WHERE customer_id != 1 AND parent IN (SELECT id FROM collections WHERE customer_id != 1 AND id NOT IN ({PreservedCollections}))");
+        DbContext.Database.ExecuteSqlRaw(
+            $"DELETE FROM collections WHERE customer_id != 1 AND id NOT IN ({PreservedCollections})");
         DbContext.Database.ExecuteSqlRaw(
             "DELETE FROM manifests WHERE customer_id != 1 AND id NOT IN ('FirstChildManifest', 'FirstChildManifestProcessing')");
     }


### PR DESCRIPTION
## What does this change?

Implements #632
Implements #631
Fixes #466 

Adds a new search endpoint for root collection, `{customer}/collections/root/search` with paging and ordering. This is surfaced as a `"service"` on the root collection. Summary of changes

* Slight refactoring of `GetCollection` to have some shared helpers for dealing with paged and orderable collections. We can take this further if more endpoints will use. Allowed pagination processing out of controller to keep it thin.
* Audit dates on `IPresentation` are now nullable, as the synthetic search-results collection won't have them.
* `CollectionController` uses `HandleFetch()` handler. This is the only place these are used so had to alter to fit our needs, I suspect they were migrated from Protagonist but never used.
* Added `[RequiredShowExtras]` attribute, which allowed removal of `if (!Request.HasShowExtraHeader()) return this.Forbidden();` in a few places. 
  * Also noticed a bug in the generated problem `Instance` value, which is resolved. Previously it was just the hostname and wouldn't output the path.

> [!WARNING]
> Search is MVP implementation and runs unindexed scan twice per search - once for count and once for getting the actual results. For large result sets and deeper pages we will need to monitor performance.

## Database Migration

> [!NOTE]
> Details of migration. What does it change? Is it breaking/non-breaking?
>
> - **Migration name:** `20260713084444_Manifest label is jsonb`
> - **What it does:** Converts `manifest.label` to `jsonb` type. Note that this takes an `ACCESS EXCLUSIVE` lock and rewrites the whole table, this is a write-blocking outage for the duration.
> - **Breaking Change?** No. 

## Configuration Changes

> [!NOTE]
> This PR introduces configuration changes.
>
> |Service | AppSetting | Required? | Description | Default |
> |---|---|---|---|---|
> | API | `MinSearchLength` | N | Minimum characters required for a search term to be run | `3` |
> | API | `SlowSearchThresholdMs` | N | Search queries taking longer than this are logged as a warning | `1000` |