### PR TITLE
Resolve issues with generated error URIs containing queryparams

### DIFF
--- a/src/IIIFPresentation/API.Tests/Infrastructure/ControllerBaseXTests.cs
+++ b/src/IIIFPresentation/API.Tests/Infrastructure/ControllerBaseXTests.cs
@@ -119,7 +119,6 @@ public class ControllerBaseXTests
     [Fact]
     public void PresentationProblem_Correct_WithDefaults_RequestHasPathBase()
     {
-        // Setup a basic request with no query params
         var sut = GetController(request =>
         {
             request.Scheme = "https";
@@ -142,7 +141,6 @@ public class ControllerBaseXTests
     [Fact]
     public void PresentationProblem_Correct_WithDefaults_RequestHasQueryParam()
     {
-        // Setup a basic request with no query params
         var sut = GetController(request =>
         {
             request.Scheme = "https";
@@ -163,7 +161,6 @@ public class ControllerBaseXTests
     [Fact]
     public void PresentationProblem_Correct_AllValuesProvidedValues()
     {
-        // Setup a basic request with no query params
         var sut = GetController(request =>
         {
             request.Scheme = "https";

--- a/src/IIIFPresentation/API.Tests/Infrastructure/ControllerBaseXTests.cs
+++ b/src/IIIFPresentation/API.Tests/Infrastructure/ControllerBaseXTests.cs
@@ -16,11 +16,16 @@ public class ControllerBaseXTests
 {
     private readonly ControllerBase controller = GetController();
 
-    private static ControllerBase GetController()
+    private static ControllerBase GetController(Action<HttpRequest>? setupRequest = null)
     {
         var httpContext = new DefaultHttpContext();
-        httpContext.Request.Scheme = "http";
-        httpContext.Request.Host = new HostString("localhost");
+
+        if (setupRequest == null)
+        {
+            httpContext.Request.Scheme = "http";
+            httpContext.Request.Host = new HostString("localhost");
+        }
+        else setupRequest(httpContext.Request);
 
         return new TestController
         {
@@ -109,6 +114,72 @@ public class ControllerBaseXTests
 
         // Assert
         GetError(result, HttpStatusCode.NotFound).Title.Should().Be("Not Found");
+    }
+
+    [Fact]
+    public void PresentationProblem_Correct_WithDefaults_RequestHasPathBase()
+    {
+        // Setup a basic request with no query params
+        var sut = GetController(request =>
+        {
+            request.Scheme = "https";
+            request.Host = new HostString("localhost");
+            request.Path = "/manifest/1234";
+            request.PathBase = "/v1";
+        });
+        var result = sut.PresentationProblem();
+        
+        var error = GetError(result, HttpStatusCode.InternalServerError);
+        error.Detail.Should().BeNull();
+        error.Title.Should().BeNull();
+        error.Status.Should().Be(500);
+        error.ErrorTypeUri.Should().BeNull();
+        
+        // PathBase cannot be set in API, there is no configuration for it but included test as this is the behaviour using the helpers provided
+        error.Instance.Should().Be("https://localhost/v1", "Instance defaults to {scheme}:{host}{pathBase}");
+    }
+    
+    [Fact]
+    public void PresentationProblem_Correct_WithDefaults_RequestHasQueryParam()
+    {
+        // Setup a basic request with no query params
+        var sut = GetController(request =>
+        {
+            request.Scheme = "https";
+            request.Host = new HostString("localhost");
+            request.Path = "/manifest/1234";
+            request.QueryString = new QueryString("?foo=bar");
+        });
+        var result = sut.PresentationProblem();
+        
+        var error = GetError(result, HttpStatusCode.InternalServerError);
+        error.Detail.Should().BeNull();
+        error.Title.Should().BeNull();
+        error.Status.Should().Be(500);
+        error.ErrorTypeUri.Should().BeNull();
+        error.Instance.Should().Be("https://localhost", "Query params are not included");
+    }
+    
+    [Fact]
+    public void PresentationProblem_Correct_AllValuesProvidedValues()
+    {
+        // Setup a basic request with no query params
+        var sut = GetController(request =>
+        {
+            request.Scheme = "https";
+            request.Host = new HostString("localhost");
+            request.Path = "/manifest/1234";
+            request.QueryString = new QueryString("?foo=bar");
+        });
+        var result =
+            sut.PresentationProblem("Details", "https://error-instance", 429, "I am title", "https://error-type");
+        
+        var error = GetError(result, HttpStatusCode.TooManyRequests);
+        error.Detail.Should().Be("Details");
+        error.Title.Should().Be("I am title");
+        error.Status.Should().Be(429);
+        error.ErrorTypeUri.Should().Be("https://error-type");
+        error.Instance.Should().Be("https://error-instance");
     }
 
     private static Error GetError(IActionResult result, HttpStatusCode expectedStatus)

--- a/src/IIIFPresentation/API.Tests/Infrastructure/ControllerBaseXTests.cs
+++ b/src/IIIFPresentation/API.Tests/Infrastructure/ControllerBaseXTests.cs
@@ -182,6 +182,34 @@ public class ControllerBaseXTests
         error.Instance.Should().Be("https://error-instance");
     }
 
+    [Fact]
+    public void GetErrorType_Correct_ForType_RequestHasPathBase()
+    {
+        var sut = GetController(request =>
+        {
+            request.Scheme = "https";
+            request.Host = new HostString("localhost");
+            request.Path = "/manifest/1234";
+            request.PathBase = "/v1";
+        });
+        var error = sut.GetErrorType(TestEnum.Value1); 
+        error.Should().Be("https://localhost/v1/errors/TestEnum/Value1");
+    }
+    
+    [Fact]
+    public void GetErrorType_Correct_ForType_RequestHasQueryParam()
+    {
+        var sut = GetController(request =>
+        {
+            request.Scheme = "https";
+            request.Host = new HostString("localhost");
+            request.Path = "/manifest/1234";
+            request.QueryString = new QueryString("?foo=bar");
+        });
+        var error = sut.GetErrorType(TestEnum.Value1); 
+        error.Should().Be("https://localhost/errors/TestEnum/Value1");
+    }
+
     private static Error GetError(IActionResult result, HttpStatusCode expectedStatus)
     {
         var objectResult = result.Should().BeOfType<ObjectResult>().Subject;
@@ -190,4 +218,6 @@ public class ControllerBaseXTests
     }
 
     private class TestController : ControllerBase;
+
+    private enum TestEnum { Value1 = 1, }
 }

--- a/src/IIIFPresentation/API.Tests/Infrastructure/Helpers/HttpRequestXTests.cs
+++ b/src/IIIFPresentation/API.Tests/Infrastructure/Helpers/HttpRequestXTests.cs
@@ -100,7 +100,6 @@ public class HttpRequestXTests
         customerId.Should().BeNull();
     }
     
-    
     [Fact]
     public void GetCustomerId_ReturnsCustomerId_WhenCustomerRouteValueNotInteger()
     {

--- a/src/IIIFPresentation/API.Tests/Infrastructure/Requests/HttpRequestX.cs
+++ b/src/IIIFPresentation/API.Tests/Infrastructure/Requests/HttpRequestX.cs
@@ -1,0 +1,163 @@
+﻿using API.Infrastructure.Requests;
+using Microsoft.AspNetCore.Http;
+
+namespace API.Tests.Infrastructure.Requests;
+
+public class HttpRequestX
+{
+    [Fact]
+    public void GetDisplayUrl_ReturnsFullUrl_WhenCalledWithDefaultParams()
+    {
+        // Arrange
+        var httpRequest = new DefaultHttpContext().Request;
+        httpRequest.Path = new PathString("/anything");
+        httpRequest.QueryString = new QueryString("?foo=bar");
+        httpRequest.Host = new HostString("test.example");
+        httpRequest.Scheme = "https";
+
+        const string expected = "https://test.example?foo=bar";
+
+        // Act
+        var result = httpRequest.GetDisplayUrl();
+        
+        // Assert
+        result.Should().Be(expected);
+    }
+    
+    [Fact]
+    public void GetDisplayUrl_WithPathBase_ReturnsFullUrl_WhenCalledWithDefaultParams()
+    {
+        // Arrange
+        var httpRequest = new DefaultHttpContext().Request;
+        httpRequest.Path = new PathString("/anything");
+        httpRequest.QueryString = new QueryString("?foo=bar");
+        httpRequest.Host = new HostString("test.example");
+        httpRequest.PathBase = new PathString("/v2");
+        httpRequest.Scheme = "https";
+
+        const string expected = "https://test.example/v2?foo=bar";
+
+        // Act
+        var result = httpRequest.GetDisplayUrl();
+        
+        // Assert
+        result.Should().Be(expected);
+    }
+    
+    [Fact]
+    public void GetDisplayUrl_ReturnsFullUrl_WhenCalledWithPath()
+    {
+        // Arrange
+        var httpRequest = new DefaultHttpContext().Request;
+        httpRequest.Path = new PathString("/anything");
+        httpRequest.QueryString = new QueryString("?foo=bar");
+        httpRequest.Host = new HostString("test.example");
+        httpRequest.Scheme = "https";
+
+        const string expected = "https://test.example/my-path/one/two?foo=bar";
+
+        // Act
+        var result = httpRequest.GetDisplayUrl("/my-path/one/two");
+        
+        // Assert
+        result.Should().Be(expected);
+    }
+    
+    [Fact]
+    public void GetDisplayUrl_WithPathBase_ReturnsFullUrl_WhenCalledWithWithPath()
+    {
+        // Arrange
+        var httpRequest = new DefaultHttpContext().Request;
+        httpRequest.Path = new PathString("/anything");
+        httpRequest.QueryString = new QueryString("?foo=bar");
+        httpRequest.Host = new HostString("test.example");
+        httpRequest.PathBase = new PathString("/v2");
+        httpRequest.Scheme = "https";
+
+        const string expected = "https://test.example/v2/my-path/one/two?foo=bar";
+
+        // Act
+        var result = httpRequest.GetDisplayUrl("/my-path/one/two");
+        
+        // Assert
+        result.Should().Be(expected);
+    }
+    
+    [Fact]
+    public void GetDisplayUrl_ReturnsFullUrl_WithoutQueryParam_WhenCalledWithDoNotIncludeQueryParams()
+    {
+        // Arrange
+        var httpRequest = new DefaultHttpContext().Request;
+        httpRequest.Path = new PathString("/anything");
+        httpRequest.QueryString = new QueryString("?foo=bar");
+        httpRequest.Host = new HostString("test.example");
+        httpRequest.Scheme = "https";
+
+        const string expected = "https://test.example";
+
+        // Act
+        var result = httpRequest.GetDisplayUrl(includeQueryParams: false);
+        
+        // Assert
+        result.Should().Be(expected);
+    }
+    
+    [Fact]
+    public void GetDisplayUrl_WithPathBase_ReturnsFullUrl_WithoutQueryParam_WhenCalledWithDoNotIncludeQueryParams()
+    {
+        // Arrange
+        var httpRequest = new DefaultHttpContext().Request;
+        httpRequest.Path = new PathString("/anything");
+        httpRequest.QueryString = new QueryString("?foo=bar");
+        httpRequest.Host = new HostString("test.example");
+        httpRequest.PathBase = new PathString("/v2");
+        httpRequest.Scheme = "https";
+
+        const string expected = "https://test.example/v2";
+
+        // Act
+        var result = httpRequest.GetDisplayUrl(includeQueryParams: false);
+        
+        // Assert
+        result.Should().Be(expected);
+    }
+    
+    [Fact]
+    public void GetBaseUrl_ReturnsFullUrl_WithoutQueryParam()
+    {
+        // Arrange
+        var httpRequest = new DefaultHttpContext().Request;
+        httpRequest.Path = new PathString("/anything");
+        httpRequest.QueryString = new QueryString("?foo=bar");
+        httpRequest.Host = new HostString("test.example");
+        httpRequest.Scheme = "https";
+
+        const string expected = "https://test.example";
+
+        // Act
+        var result = httpRequest.GetBaseUrl();
+        
+        // Assert
+        result.Should().Be(expected);
+    }
+    
+    [Fact]
+    public void GetBaseUrl_WithPathBase_ReturnsFullUrl_WithoutQueryParam_WhenCalledWithDoNotIncludeQueryParams()
+    {
+        // Arrange
+        var httpRequest = new DefaultHttpContext().Request;
+        httpRequest.Path = new PathString("/anything");
+        httpRequest.QueryString = new QueryString("?foo=bar");
+        httpRequest.Host = new HostString("test.example");
+        httpRequest.PathBase = new PathString("/v2");
+        httpRequest.Scheme = "https";
+
+        const string expected = "https://test.example/v2";
+
+        // Act
+        var result = httpRequest.GetBaseUrl();
+        
+        // Assert
+        result.Should().Be(expected);
+    }
+}

--- a/src/IIIFPresentation/API.Tests/Integration/SearchCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/SearchCollectionTests.cs
@@ -132,7 +132,6 @@ public class SearchCollectionTests : IClassFixture<PresentationAppFactory<Progra
             HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get, $"1/collections/{RootCollection.Id}/search"); 
         var response = await httpClient.AsCustomer().SendAsync(request);
         
-
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }

--- a/src/IIIFPresentation/API.Tests/Integration/SearchCollectionTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/SearchCollectionTests.cs
@@ -131,6 +131,7 @@ public class SearchCollectionTests : IClassFixture<PresentationAppFactory<Progra
         var request =
             HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get, $"1/collections/{RootCollection.Id}/search"); 
         var response = await httpClient.AsCustomer().SendAsync(request);
+        
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);

--- a/src/IIIFPresentation/API/Features/Storage/CollectionController.cs
+++ b/src/IIIFPresentation/API/Features/Storage/CollectionController.cs
@@ -78,7 +78,7 @@ public class CollectionController(
             return this.PresentationProblem(
                 $"At least one search term must be {Settings.MinSearchLength} characters or more",
                 null, (int)HttpStatusCode.BadRequest, "Bad request",
-                this.GetErrorType(ModifyCollectionType.ValidationFailed));
+                this.GetErrorType(ModifyCollectionType.InvalidSearchQuery));
         }
 
         var orderByField = this.GetOrderBy(orderBy, orderByDescending, out var descending);

--- a/src/IIIFPresentation/API/Infrastructure/ControllerBaseX.cs
+++ b/src/IIIFPresentation/API/Infrastructure/ControllerBaseX.cs
@@ -144,9 +144,10 @@ public static class ControllerBaseX
     /// <summary>
     /// Creates an <see cref="ObjectResult"/> that produces a <see cref="Error"/> response.
     /// </summary>
-    /// <param name="statusCode">The value for <see cref="Error.Status" />.</param>
+    /// <param name="controller">Current controller</param>
     /// <param name="detail">The value for <see cref="Error.Detail" />.</param>
     /// <param name="instance">The value for <see cref="Error.Instance" />.</param>
+    /// <param name="statusCode">The value for <see cref="Error.Status" />.</param>
     /// <param name="title">The value for <see cref="Error.Title" />.</param>
     /// <param name="type">The value for <see cref="Type" />.</param>
     /// <returns>The created <see cref="ObjectResult"/> for the response.</returns>
@@ -161,7 +162,7 @@ public static class ControllerBaseX
         var error = new Error
         {
             Detail = detail,
-            Instance = instance ?? controller.Request.GetDisplayUrl(),
+            Instance = instance ?? controller.Request.GetDisplayUrl(includeQueryParams: false),
             Status = statusCode ?? 500,
             Title = title,
             ErrorTypeUri = type

--- a/src/IIIFPresentation/API/Infrastructure/ControllerBaseX.cs
+++ b/src/IIIFPresentation/API/Infrastructure/ControllerBaseX.cs
@@ -174,9 +174,12 @@ public static class ControllerBaseX
         };
     }
 
-    public static string GetErrorType<TType>(this ControllerBase controller, TType type) =>
-        $"{controller.Request.GetDisplayUrl()}/errors/{type?.GetType().Name}/{type}";
-
+    /// <summary>
+    /// Generate URI for use as "type" in error response
+    /// </summary>
+    public static string GetErrorType<TType>(this ControllerBase controller, TType? type)
+        where TType : Enum
+        => controller.Request.GetDisplayUrl($"/errors/{type?.GetType().Name}/{type}", false);
 
     /// <summary> 
     /// Creates an <see cref="ObjectResult"/> that produces a <see cref="Error"/> response with 404 status code.

--- a/src/IIIFPresentation/API/Infrastructure/Requests/HttpRequestX.cs
+++ b/src/IIIFPresentation/API/Infrastructure/Requests/HttpRequestX.cs
@@ -43,10 +43,7 @@ public static class HttpRequestX
     /// <summary>
     /// Generate a display URL, deriving values from specified HttpRequest. Omitting path and query string
     /// </summary>
-    public static string GetBaseUrl(this HttpRequest request)
-    {
-        return request.GetDisplayUrl(null, false);
-    }
+    public static string GetBaseUrl(this HttpRequest request) => request.GetDisplayUrl(null, false);
 
     /// <summary>
     /// Get <see cref="HttpRequest"/> body as string

--- a/src/IIIFPresentation/API/Infrastructure/Requests/ModifyEntityResult.cs
+++ b/src/IIIFPresentation/API/Infrastructure/Requests/ModifyEntityResult.cs
@@ -1,4 +1,5 @@
-﻿using Core;
+﻿using System.Diagnostics.CodeAnalysis;
+using Core;
 using IIIF;
 
 namespace API.Infrastructure.Requests;
@@ -7,8 +8,10 @@ namespace API.Infrastructure.Requests;
 ///     Represents the result of a request to modify an entity
 /// </summary>
 /// <typeparam name="T">Type of entity being modified</typeparam>
-public class ModifyEntityResult<T, TEnum> : IModifyRequest
+/// <typeparam name="TError">Type of error</typeparam>
+public class ModifyEntityResult<T, TError> : IModifyRequest
     where T : JsonLdBase
+    where TError : Enum
 {
     /// <summary>
     /// Enum representing overall result of operation
@@ -28,21 +31,23 @@ public class ModifyEntityResult<T, TEnum> : IModifyRequest
     /// <summary>
     /// Explicit value stating success or failure
     /// </summary>
+    [MemberNotNullWhen(false, nameof(ErrorType))]
+    [MemberNotNullWhen(true, nameof(Entity))]
     public bool IsSuccess { get; private init; }
     
-    public TEnum? ErrorType { get; private init; }
+    public TError? ErrorType { get; private init; }
     
     public Guid? ETag { get; private init; }
 
-    public static ModifyEntityResult<T, TEnum> Failure(string error, TEnum? errorType, WriteResult result = WriteResult.Unknown)
+    public static ModifyEntityResult<T, TError> Failure(string error, TError errorType, WriteResult result = WriteResult.Unknown)
     {
-        return new ModifyEntityResult<T, TEnum>
+        return new ModifyEntityResult<T, TError>
             { Error = error, WriteResult = result, IsSuccess = false, ErrorType = errorType };
     }
     
-    public static ModifyEntityResult<T, TEnum> Success(T entity, WriteResult result = WriteResult.Updated, Guid? etag = null)
+    public static ModifyEntityResult<T, TError> Success(T entity, WriteResult result = WriteResult.Updated, Guid? etag = null)
     {
-        return new ModifyEntityResult<T, TEnum>
+        return new ModifyEntityResult<T, TError>
             { Entity = entity, WriteResult = result, IsSuccess = true, ETag = etag };
     }
 

--- a/src/IIIFPresentation/API/Settings/ApiSettings.cs
+++ b/src/IIIFPresentation/API/Settings/ApiSettings.cs
@@ -27,8 +27,6 @@ public class ApiSettings
     /// </summary>
     public int SlowSearchThresholdMs { get; set; } = 1000;
     
-    public string? PathBase { get; set; }
-    
     /// <summary>
     /// Forces reingestion to always occur
     /// </summary>

--- a/src/IIIFPresentation/Models/API/General/ModifyCollectionType.cs
+++ b/src/IIIFPresentation/Models/API/General/ModifyCollectionType.cs
@@ -31,5 +31,6 @@ public enum ModifyCollectionType
     AssetsAdjunctsDoNotMatch = 27,
     ManifestCurrentlyIngesting = 28,
     CannotConnectToTextService = 29,
+    InvalidSearchQuery = 30,
     Unknown = 1000
 }


### PR DESCRIPTION
## What does this change?

Resolves #637 

Resolve issue where automatically generated "instance" and "type" URLs will include query-parameters. For the latter, also tweak how URL is constructed to avoid using simple string concatenation, which resulted in query-param being output mid-url.

Also removed `PathBase` appSetting. This isn't used anywhere (ie `.UsePathBase()` isn't called) but inclusion in settings makes it look like it could be.

Not strictly part of fix but switched failed collection searches to use a custom type, InvalidSearchQuery, rather than generic validation error (felt okay to add as bug was found as part of testing search).