### PR TITLE
Housekeeping - tidy usages of ModifyEntityResult

### DIFF
--- a/src/IIIFPresentation/API.Tests/Features/Common/Helpers/ParentValidatorTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Common/Helpers/ParentValidatorTests.cs
@@ -1,6 +1,5 @@
 ﻿using API.Features.Common.Helpers;
 using FakeItEasy;
-using Models.API.Collection;
 using Models.Database.Collections;
 using Repository.Paths;
 
@@ -19,7 +18,7 @@ public class ParentValidatorTests
         };
         
         // Act
-        var parentCollectionError = ParentValidator.ValidateParentCollection<PresentationCollection>(parentCollection);
+        var parentCollectionError = ParentValidator.ValidateParentCollection(parentCollection);
 
         // Assert
         parentCollectionError.Should().BeNull();
@@ -35,7 +34,7 @@ public class ParentValidatorTests
         };
         
         // Act
-        var parentCollectionError = ParentValidator.ValidateParentCollection<PresentationCollection>(parentCollection);
+        var parentCollectionError = ParentValidator.ValidateParentCollection(parentCollection);
 
         // Assert
         parentCollectionError.Should().NotBeNull();
@@ -45,7 +44,7 @@ public class ParentValidatorTests
     public void ValidateParentCollection_Error_WhenParentNull()
     {
         // Arrange and Act
-        var parentCollectionError = ParentValidator.ValidateParentCollection<PresentationCollection>(null);
+        var parentCollectionError = ParentValidator.ValidateParentCollection(null);
 
         // Assert
         parentCollectionError.Should().NotBeNull();

--- a/src/IIIFPresentation/API.Tests/Features/Manifest/ManifestWriteServiceTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Manifest/ManifestWriteServiceTests.cs
@@ -151,7 +151,7 @@ public class ManifestWriteServiceTests
                 A<CancellationToken>._)).ReturnsLazily(
             (PresentationManifest presentationManifest, int customerId, string data,
                     CancellationToken cancellationToken) =>
-                ParsedParentSlugResult<PresentationManifest>.Success(new ParsedParentSlug(parentCollection,
+                ParsedParentSlugResult.Success(new ParsedParentSlug(parentCollection,
                     presentationManifest.Slug!)));
         
         // Always return Space 500 when call to create space
@@ -200,10 +200,11 @@ public class ManifestWriteServiceTests
         // Assert
         ingestedManifest.Should().NotBeNull();
         ingestedManifest.Error.Should().BeNull();
-        ingestedManifest.Entity.PaintedResources.Should().HaveCount(2);
-        
+        var entityManifest = (PresentationManifest)ingestedManifest.Entity!;
+        entityManifest.PaintedResources.Should().HaveCount(2);
+
         var dbManifest = presentationContext.Manifests.Include(m => m.CanvasPaintings)
-            .First(x => x.Id == ingestedManifest.Entity.FlatId);
+            .First(x => x.Id == entityManifest.FlatId);
         dbManifest.CanvasPaintings.Should().HaveCount(2);
 
         // Saved to staging with an original payload stored - must not attempt to delete any original payload
@@ -301,10 +302,11 @@ public class ManifestWriteServiceTests
         // Assert
         ingestedManifest.Should().NotBeNull();
         ingestedManifest.Error.Should().BeNull();
-        ingestedManifest.Entity.PaintedResources.Should().HaveCount(2);
-        
+        var entityManifest = (PresentationManifest)ingestedManifest.Entity!;
+        entityManifest.PaintedResources.Should().HaveCount(2);
+
         var dbManifest = presentationContext.Manifests.Include(m => m.CanvasPaintings)
-            .First(x => x.Id == ingestedManifest.Entity.FlatId);
+            .First(x => x.Id == entityManifest.FlatId);
         dbManifest.CanvasPaintings.Should().HaveCount(2);
         dbManifest.CanvasPaintings.Count(cp=>cp.AssetId.Equals(imageAssetId)).Should().Be(1);
 
@@ -486,10 +488,11 @@ public class ManifestWriteServiceTests
         // Assert
         ingestedManifest.Should().NotBeNull();
         ingestedManifest.Error.Should().BeNull();
-        ingestedManifest.Entity.PaintedResources.Should().HaveCount(1);
+        var entityManifest = (PresentationManifest)ingestedManifest.Entity!;
+        entityManifest.PaintedResources.Should().HaveCount(1);
 
         var dbManifest = presentationContext.Manifests.Include(m => m.CanvasPaintings)
-            .First(x => x.Id == ingestedManifest.Entity.FlatId);
+            .First(x => x.Id == entityManifest.FlatId);
         dbManifest.CanvasPaintings.Should().HaveCount(1);
     }
     
@@ -591,9 +594,10 @@ public class ManifestWriteServiceTests
         // Assert
         ingestedManifest.Should().NotBeNull();
         ingestedManifest.Error.Should().BeNull();
-        ingestedManifest.Entity!.PaintedResources.Should().HaveCount(1);
-        ingestedManifest.Entity.Items!.First().Id.Should().Be("https://presentation.api/1/canvases/shortCanvas");
-        var paintedResource = ingestedManifest.Entity.PaintedResources!.First();
+        var entityManifest = (PresentationManifest)ingestedManifest.Entity!;
+        entityManifest.PaintedResources.Should().HaveCount(1);
+        entityManifest.Items!.First().Id.Should().Be("https://presentation.api/1/canvases/shortCanvas");
+        var paintedResource = entityManifest.PaintedResources!.First();
         paintedResource.CanvasPainting!.CanvasId.Should().Be($"https://localhost:5000/{Customer}/canvases/shortCanvas");
         paintedResource.CanvasPainting.CanvasOriginalId.Should().BeNull();
     }
@@ -743,16 +747,17 @@ public class ManifestWriteServiceTests
 
         // Assert
         result.Error.Should().BeNull();
-        result.Entity.SeeAlso.Should()
+        var entityManifest = (PresentationManifest)result.Entity!;
+        entityManifest.SeeAlso.Should()
             .Contain(s => s.Id == userSeeAlsoId, "user-set seeAlso must not be lost when stub canvas adjuncts are merged").And
             .Contain(s => s.Id == stubSeeAlsoId, "stub canvas seeAlso must be added alongside user-set values");
-        result.Entity.Rendering.Should()
+        entityManifest.Rendering.Should()
             .Contain(r => r.Id == userRenderingId, "user-set rendering must not be lost when stub canvas adjuncts are merged").And
             .Contain(r => r.Id == stubRenderingId, "stub canvas rendering must be added alongside user-set values");
-        result.Entity.Annotations.Should()
+        entityManifest.Annotations.Should()
             .Contain(a => a.Id == userAnnotationId, "user-set annotations must not be lost when stub canvas adjuncts are merged").And
             .Contain(a => a.Id == stubAnnotationId, "stub canvas annotations must be added alongside user-set values");
-        result.Entity.Adjuncts.Should().ContainSingle()
+        entityManifest.Adjuncts.Should().ContainSingle()
             .Which.Value<string>("id").Should().Be(stubManifestAdjunctId,
                 "manifest-level adjuncts from the DLCS stub asset must be returned when Adjuncts was null on the request");
     }
@@ -812,10 +817,11 @@ public class ManifestWriteServiceTests
 
         // Assert: empty lists from the base manifest are passed through unchanged
         result.Error.Should().BeNull();
-        result.Entity.SeeAlso.Should().BeEmpty();
-        result.Entity.Rendering.Should().BeEmpty();
-        result.Entity.Annotations.Should().BeEmpty();
-        result.Entity.Adjuncts.Should().BeNull("no stub asset carries adjuncts so Adjuncts should not be populated");
+        var entityManifest = (PresentationManifest)result.Entity!;
+        entityManifest.SeeAlso.Should().BeEmpty();
+        entityManifest.Rendering.Should().BeEmpty();
+        entityManifest.Annotations.Should().BeEmpty();
+        entityManifest.Adjuncts.Should().BeNull("no stub asset carries adjuncts so Adjuncts should not be populated");
     }
 
     [Fact]
@@ -859,7 +865,8 @@ public class ManifestWriteServiceTests
 
         // Assert
         result.Error.Should().BeNull();
-        result.Entity.Adjuncts.Should().ContainSingle()
+        var entityManifest = (PresentationManifest)result.Entity!;
+        entityManifest.Adjuncts.Should().ContainSingle()
             .Which.Value<string>("id").Should().Be(existingAdjunctId,
                 "existing adjuncts from the DLCS stub asset must be returned when Adjuncts was null on the request");
         A.CallTo(() => dlcsManifestMerger.Augment(
@@ -890,7 +897,8 @@ public class ManifestWriteServiceTests
 
         // Assert
         result.Error.Should().BeNull();
-        result.Entity.Adjuncts.Should().BeNull("no DLCS content exists so the stub asset has no adjuncts to return");
+        var entityManifest = (PresentationManifest)result.Entity!;
+        entityManifest.Adjuncts.Should().BeNull("no DLCS content exists so the stub asset has no adjuncts to return");
         A.CallTo(() => dlcsManifestMerger.Augment(
                 A<IIIFManifest>._, A<DbManifest>._, A<CancellationToken>._))
             .MustNotHaveHappened();
@@ -930,7 +938,8 @@ public class ManifestWriteServiceTests
 
         // Assert
         result.Error.Should().BeNull();
-        result.Entity.Adjuncts.Should().BeEmpty("Adjuncts=[] (explicit clear) is preserved — stub lookup finds no adjuncts so the value is unchanged");
+        var entityManifest = (PresentationManifest)result.Entity!;
+        entityManifest.Adjuncts.Should().BeEmpty("Adjuncts=[] (explicit clear) is preserved — stub lookup finds no adjuncts so the value is unchanged");
         A.CallTo(() => dlcsManifestMerger.Augment(
                 A<IIIFManifest>._, A<DbManifest>._, A<CancellationToken>._))
             .MustHaveHappenedOnceExactly();
@@ -1133,10 +1142,11 @@ public class ManifestWriteServiceTests
         // Assert
         ingestedManifest.Should().NotBeNull();
         ingestedManifest.Error.Should().BeNull();
-        ingestedManifest.Entity.PaintedResources.Should().HaveCount(4);
-        
+        var entityManifest = (PresentationManifest)ingestedManifest.Entity!;
+        entityManifest.PaintedResources.Should().HaveCount(4);
+
         var dbManifest = presentationContext.Manifests.Include(m => m.CanvasPaintings)
-            .First(x => x.Id == ingestedManifest.Entity.FlatId);
+            .First(x => x.Id == entityManifest.FlatId);
         dbManifest.CanvasPaintings.Should().HaveCount(4);
         dbManifest.CanvasPaintings[0].CanvasOriginalId.Should().Be( $"https://base/0/canvases/{canvasId}_1");
         dbManifest.CanvasPaintings[1].Id.Should().Be( $"{canvasId}_2");
@@ -1182,13 +1192,14 @@ public class ManifestWriteServiceTests
         A.CallTo(() => textBuilderClient.UpsertJob(A<DbManifest>._, A<PipelineJob>._, A<CancellationToken>._))
             .MustHaveHappenedOnceExactly();
 
-        var flatId = result.Entity.FlatId;
+        var entityManifest = (PresentationManifest)result.Entity!;
+        var flatId = entityManifest.FlatId;
         var pipelineJob = presentationContext.PipelineJobs.FirstOrDefault(p => p.ManifestId == flatId);
         pipelineJob.Should().NotBeNull();
         pipelineJob!.Status.Should().Be(PipelineJobStatus.Waiting);
         pipelineJob.Config!.Action.Should().Be("Index");
         pipelineJob.GetJobId().ToString().Should().Be($"{Customer}/iiif/{flatId}");
-        result.Entity.Pipeline.Should().ContainSingle(p => p.Name == PipelineHelper.TextPipeline.Name && p.Status == "Waiting");
+        entityManifest.Pipeline.Should().ContainSingle(p => p.Name == PipelineHelper.TextPipeline.Name && p.Status == "Waiting");
     }
 
     [Fact]
@@ -1247,7 +1258,7 @@ public class ManifestWriteServiceTests
             .MustNotHaveHappened();
 
         // Pipeline job must be persisted so the batch-completion handler can submit it later
-        var flatId = result.Entity.FlatId;
+        var flatId = ((PresentationManifest)result.Entity!).FlatId;
         var pipelineJob = presentationContext.PipelineJobs.FirstOrDefault(p => p.ManifestId == flatId);
         pipelineJob.Should().NotBeNull("pipeline job must be registered even when submission is deferred");
         pipelineJob!.Status.Should().Be(PipelineJobStatus.NotSubmitted);
@@ -1262,7 +1273,7 @@ public class ManifestWriteServiceTests
         var createManifest = new PresentationManifest { Slug = slug };
         var createRequest = new UpsertManifestRequest(resourceId, null, Customer, createManifest, createManifest.AsJson(), true);
         var createResult = await sut.Create(createRequest, CancellationToken.None);
-        var flatId = createResult.Entity.FlatId;
+        var flatId = ((PresentationManifest)createResult.Entity!).FlatId;
         var etag = presentationContext.Manifests.First(m => m.Id == flatId).Etag.ToString();
 
         // Return an ingesting batch so canBeBuiltUpfront=false — the asset is being processed by DLCS
@@ -1410,7 +1421,7 @@ public class ManifestWriteServiceTests
         };
         var request = new UpsertManifestRequest(resourceId, null, Customer, manifest, manifest.AsJson(), true);
         var firstResult = await sut.Create(request, CancellationToken.None);
-        var flatId = firstResult.Entity.FlatId;
+        var flatId = ((PresentationManifest)firstResult.Entity!).FlatId;
 
         // Second create (update path) — resubmit the same manifest with pipeline
         var updateManifest = new PresentationManifest

--- a/src/IIIFPresentation/API/Features/Common/Helpers/ParentValidator.cs
+++ b/src/IIIFPresentation/API/Features/Common/Helpers/ParentValidator.cs
@@ -1,8 +1,6 @@
 using API.Features.Storage.Helpers;
 using API.Infrastructure.Requests;
 using API.Infrastructure.Validation;
-using Models.API.Collection;
-using Models.API.General;
 using Models.Database.Collections;
 using Repository.Paths;
 
@@ -13,7 +11,7 @@ public static class ParentValidator
     /// <summary>
     /// Validates that a parent collection is not null or a IIIF collection
     /// </summary>
-    public static ModifyEntityResult<ModifyCollectionType>? ValidateParentCollection(Collection? parentCollection)
+    public static PresentationResult? ValidateParentCollection(Collection? parentCollection)
     {
         if (parentCollection == null) return UpsertErrorHelper.NullParentResponse();
 

--- a/src/IIIFPresentation/API/Features/Common/Helpers/ParentValidator.cs
+++ b/src/IIIFPresentation/API/Features/Common/Helpers/ParentValidator.cs
@@ -1,7 +1,6 @@
-﻿using API.Features.Storage.Helpers;
+using API.Features.Storage.Helpers;
 using API.Infrastructure.Requests;
 using API.Infrastructure.Validation;
-using IIIF;
 using Models.API.Collection;
 using Models.API.General;
 using Models.Database.Collections;
@@ -14,11 +13,10 @@ public static class ParentValidator
     /// <summary>
     /// Validates that a parent collection is not null or a IIIF collection
     /// </summary>
-    public static ModifyEntityResult<TCollection, ModifyCollectionType>? ValidateParentCollection<TCollection>(Collection? parentCollection) 
-        where TCollection : JsonLdBase
+    public static ModifyEntityResult<ModifyCollectionType>? ValidateParentCollection(Collection? parentCollection)
     {
-        if (parentCollection == null) return UpsertErrorHelper.NullParentResponse<TCollection>();
-        
-        return !parentCollection.IsStorageCollection ? UpsertErrorHelper.ParentMustBeStorageCollection<TCollection>() : null;
+        if (parentCollection == null) return UpsertErrorHelper.NullParentResponse();
+
+        return !parentCollection.IsStorageCollection ? UpsertErrorHelper.ParentMustBeStorageCollection() : null;
     }
 }

--- a/src/IIIFPresentation/API/Features/Common/Helpers/UpsertErrorHelper.cs
+++ b/src/IIIFPresentation/API/Features/Common/Helpers/UpsertErrorHelper.cs
@@ -1,6 +1,5 @@
-﻿using API.Infrastructure.Requests;
+using API.Infrastructure.Requests;
 using Core;
-using IIIF;
 using Models.API.General;
 using Services.Manifests.Exceptions;
 
@@ -8,147 +7,124 @@ namespace API.Features.Common.Helpers;
 
 public static class UpsertErrorHelper
 {
-    public static ModifyEntityResult<TCollection, ModifyCollectionType> NullParentResponse<TCollection>() 
-        where TCollection : JsonLdBase
+    public static ModifyEntityResult<ModifyCollectionType> NullParentResponse()
     {
-        return ModifyEntityResult<TCollection, ModifyCollectionType>.Failure(
+        return ModifyEntityResult<ModifyCollectionType>.Failure(
             "The parent collection could not be found", ModifyCollectionType.ParentCollectionNotFound, WriteResult.BadRequest);
     }
-    
-    public static ModifyEntityResult<TCollection, ModifyCollectionType> CannotGenerateUniqueId<TCollection>() 
-        where TCollection : JsonLdBase
+
+    public static ModifyEntityResult<ModifyCollectionType> CannotGenerateUniqueId()
     {
-        return ModifyEntityResult<TCollection, ModifyCollectionType>.Failure(
+        return ModifyEntityResult<ModifyCollectionType>.Failure(
             "Could not generate a unique identifier.  Please try again",
             ModifyCollectionType.CannotGenerateUniqueId, WriteResult.Error);
     }
-    
-    public static ModifyEntityResult<TCollection, ModifyCollectionType> CannotValidateIIIF<TCollection>() 
-        where TCollection : JsonLdBase
+
+    public static ModifyEntityResult<ModifyCollectionType> CannotValidateIIIF()
     {
-        return ModifyEntityResult<TCollection, ModifyCollectionType>.Failure(
+        return ModifyEntityResult<ModifyCollectionType>.Failure(
             "An error occurred while attempting to validate the collection as IIIF",
             ModifyCollectionType.CannotValidateIIIF, WriteResult.BadRequest);
     }
-    
-    public static ModifyEntityResult<TCollection, ModifyCollectionType> CannotChangeCollectionType<TCollection>
-        (bool storageCollection) where TCollection : JsonLdBase
+
+    public static ModifyEntityResult<ModifyCollectionType> CannotChangeCollectionType(bool storageCollection)
     {
-        return ModifyEntityResult<TCollection, ModifyCollectionType>.Failure(
+        return ModifyEntityResult<ModifyCollectionType>.Failure(
             $"Cannot convert a {CollectionType(storageCollection)} collection to a {CollectionType(!storageCollection)} collection",
             ModifyCollectionType.CannotChangeCollectionType, WriteResult.BadRequest);
     }
 
-    public static ModifyEntityResult<T, ModifyCollectionType> EtagNotRequired<T>()
-        where T : JsonLdBase
+    public static ModifyEntityResult<ModifyCollectionType> EtagNotRequired()
     {
-        return ModifyEntityResult<T, ModifyCollectionType>.Failure(
+        return ModifyEntityResult<ModifyCollectionType>.Failure(
             "ETag should not be included in request when inserting via PUT", ModifyCollectionType.ETagNotAllowed,
             WriteResult.PreconditionFailed);
     }
-    
-    public static ModifyEntityResult<T, ModifyCollectionType> EtagNonMatching<T>()
-        where T : JsonLdBase
+
+    public static ModifyEntityResult<ModifyCollectionType> EtagNonMatching()
     {
-        return ModifyEntityResult<T, ModifyCollectionType>.Failure(
+        return ModifyEntityResult<ModifyCollectionType>.Failure(
             "ETag does not match", ModifyCollectionType.ETagNotMatched, WriteResult.PreconditionFailed);
     }
-    
-    public static ModifyEntityResult<T, ModifyCollectionType> DlcsError<T>(string message)
-        where T : JsonLdBase
-        => ModifyEntityResult<T, ModifyCollectionType>.Failure(
+
+    public static ModifyEntityResult<ModifyCollectionType> DlcsError(string message)
+        => ModifyEntityResult<ModifyCollectionType>.Failure(
             message, ModifyCollectionType.DlcsError, WriteResult.Error);
 
-    public static ModifyEntityResult<T, ModifyCollectionType> SpaceRequired<T>()
-        where T : JsonLdBase
-        => ModifyEntityResult<T, ModifyCollectionType>.Failure(
+    public static ModifyEntityResult<ModifyCollectionType> SpaceRequired()
+        => ModifyEntityResult<ModifyCollectionType>.Failure(
             "A request with assets requires the space header to be set", ModifyCollectionType.RequiresSpaceHeader,
             WriteResult.BadRequest);
-    
-    public static ModifyEntityResult<T, ModifyCollectionType> CouldNotRetrieveAssetId<T>()
-        where T : JsonLdBase
-        => ModifyEntityResult<T, ModifyCollectionType>.Failure(
+
+    public static ModifyEntityResult<ModifyCollectionType> CouldNotRetrieveAssetId()
+        => ModifyEntityResult<ModifyCollectionType>.Failure(
             "Could not retrieve an id from an attached asset", ModifyCollectionType.CouldNotRetrieveAssetId,
             WriteResult.BadRequest);
-    
-    public static ModifyEntityResult<TCollection, ModifyCollectionType> ParentMustBeStorageCollection<TCollection>()
-        where TCollection : JsonLdBase
-        => ModifyEntityResult<TCollection, ModifyCollectionType>.Failure("The parent must be a storage collection",
+
+    public static ModifyEntityResult<ModifyCollectionType> ParentMustBeStorageCollection()
+        => ModifyEntityResult<ModifyCollectionType>.Failure("The parent must be a storage collection",
             ModifyCollectionType.ParentMustBeStorageCollection, WriteResult.Conflict);
-    
-    public static ModifyEntityResult<TCollection, ModifyCollectionType> ParentMustMatchPublicId<TCollection>()
-        where TCollection : JsonLdBase
-        => ModifyEntityResult<TCollection, ModifyCollectionType>.Failure("The parent must match the one specified in the public id",
+
+    public static ModifyEntityResult<ModifyCollectionType> ParentMustMatchPublicId()
+        => ModifyEntityResult<ModifyCollectionType>.Failure("The parent must match the one specified in the public id",
             ModifyCollectionType.ParentMustMatchPublicId, WriteResult.BadRequest);
-    
-    public static ModifyEntityResult<TCollection, ModifyCollectionType> SlugMustMatchPublicId<TCollection>()
-        where TCollection : JsonLdBase
-        => ModifyEntityResult<TCollection, ModifyCollectionType>.Failure("The slug must match the one specified in the public id",
+
+    public static ModifyEntityResult<ModifyCollectionType> SlugMustMatchPublicId()
+        => ModifyEntityResult<ModifyCollectionType>.Failure("The slug must match the one specified in the public id",
             ModifyCollectionType.SlugMustMatchPublicId, WriteResult.BadRequest);
-    
-    public static ModifyEntityResult<TCollection, ModifyCollectionType> InvalidCanvasId<TCollection>(string? canvasId, string reason) 
-        where TCollection : JsonLdBase
-        => ModifyEntityResult<TCollection, ModifyCollectionType>.Failure($"The canvas id {canvasId} is invalid - {reason}",
+
+    public static ModifyEntityResult<ModifyCollectionType> InvalidCanvasId(string? canvasId, string reason)
+        => ModifyEntityResult<ModifyCollectionType>.Failure($"The canvas id {canvasId} is invalid - {reason}",
             ModifyCollectionType.InvalidCanvasId, WriteResult.BadRequest);
-    
-    public static ModifyEntityResult<TCollection, ModifyCollectionType> InvalidCanvasId<TCollection>(params (string canvasId, string reason)[] multiple) 
-        where TCollection : JsonLdBase
+
+    public static ModifyEntityResult<ModifyCollectionType> InvalidCanvasId(params (string canvasId, string reason)[] multiple)
     {
         var failures = string.Join(", ", multiple.Select(p => $"{p.canvasId}: {p.reason}"));
         var message = $"Errors encountered when parsing painted resources: {failures}.";
-        
-        return ModifyEntityResult<TCollection, ModifyCollectionType>.Failure(message,
+
+        return ModifyEntityResult<ModifyCollectionType>.Failure(message,
             ModifyCollectionType.InvalidCanvasId, WriteResult.BadRequest);
     }
 
-    public static ModifyEntityResult<TCollection, ModifyCollectionType> ErrorMergingPaintedResourcesWithItems<TCollection>(string error) 
-        where TCollection : JsonLdBase
-        => ModifyEntityResult<TCollection, ModifyCollectionType>.Failure(error,
+    public static ModifyEntityResult<ModifyCollectionType> ErrorMergingPaintedResourcesWithItems(string error)
+        => ModifyEntityResult<ModifyCollectionType>.Failure(error,
             ModifyCollectionType.ErrorMergingPaintedResourcesWithItems, WriteResult.BadRequest);
 
-    public static ModifyEntityResult<TCollection, ModifyCollectionType> DuplicateCanvasId<TCollection>(string? canvasId)
-        where TCollection : JsonLdBase
-        => ModifyEntityResult<TCollection, ModifyCollectionType>.Failure($"The canvas ID {canvasId} cannot be a duplicate",
+    public static ModifyEntityResult<ModifyCollectionType> DuplicateCanvasId(string? canvasId)
+        => ModifyEntityResult<ModifyCollectionType>.Failure($"The canvas ID {canvasId} cannot be a duplicate",
             ModifyCollectionType.DuplicateCanvasId, WriteResult.BadRequest);
-    
-    public static ModifyEntityResult<TCollection, ModifyCollectionType> IncorrectPublicId<TCollection>()
-        where TCollection : JsonLdBase
-        => ModifyEntityResult<TCollection, ModifyCollectionType>.Failure("publicId incorrect",
+
+    public static ModifyEntityResult<ModifyCollectionType> IncorrectPublicId()
+        => ModifyEntityResult<ModifyCollectionType>.Failure("publicId incorrect",
             ModifyCollectionType.PublicIdIncorrect, WriteResult.BadRequest);
-    
-    public static ModifyEntityResult<TCollection, ModifyCollectionType> PaintableAssetError<TCollection>(string error)
-        where TCollection : JsonLdBase
-        => ModifyEntityResult<TCollection, ModifyCollectionType>.Failure(error,
+
+    public static ModifyEntityResult<ModifyCollectionType> PaintableAssetError(string error)
+        => ModifyEntityResult<ModifyCollectionType>.Failure(error,
             ModifyCollectionType.PaintableAssetError, WriteResult.BadRequest);
-    
-    public static ModifyEntityResult<TCollection, ModifyCollectionType> AssetError<TCollection>(AssetException exception)
-        where TCollection : JsonLdBase
-        => ModifyEntityResult<TCollection, ModifyCollectionType>.Failure(exception.Message,
+
+    public static ModifyEntityResult<ModifyCollectionType> AssetError(AssetException exception)
+        => ModifyEntityResult<ModifyCollectionType>.Failure(exception.Message,
             ModifyCollectionType.AssetError, WriteResult.BadRequest);
-    
-    public static ModifyEntityResult<TCollection, ModifyCollectionType> CustomerIdDoesNotMatchCaller<TCollection>(string field)
-        where TCollection : JsonLdBase
-        => ModifyEntityResult<TCollection, ModifyCollectionType>.Failure($"The {field} has a customer id that does not match the customer id found on the calling URL",
+
+    public static ModifyEntityResult<ModifyCollectionType> CustomerIdDoesNotMatchCaller(string field)
+        => ModifyEntityResult<ModifyCollectionType>.Failure($"The {field} has a customer id that does not match the customer id found on the calling URL",
             ModifyCollectionType.CustomerIdDoesNotMatchCaller, WriteResult.BadRequest);
 
-    public static ModifyEntityResult<TCollection, ModifyCollectionType> AssetAdjunctsDoNotMatch<TCollection>(string assetId, string diff)
-        where TCollection : JsonLdBase
-        => ModifyEntityResult<TCollection, ModifyCollectionType>.Failure(
+    public static ModifyEntityResult<ModifyCollectionType> AssetAdjunctsDoNotMatch(string assetId, string diff)
+        => ModifyEntityResult<ModifyCollectionType>.Failure(
             $"Asset {assetId} is specified multiple times with different adjuncts - diff: {diff}",
             ModifyCollectionType.AssetsAdjunctsDoNotMatch, WriteResult.BadRequest);
 
-    public static ModifyEntityResult<T, ModifyCollectionType> ManifestCurrentlyIngesting<T>()
-        where T : JsonLdBase
-        => ModifyEntityResult<T, ModifyCollectionType>.Failure(
+    public static ModifyEntityResult<ModifyCollectionType> ManifestCurrentlyIngesting()
+        => ModifyEntityResult<ModifyCollectionType>.Failure(
             "The manifest is currently being ingested and cannot be modified",
             ModifyCollectionType.ManifestCurrentlyIngesting, WriteResult.Conflict);
 
-    public static ModifyEntityResult<TCollection, ModifyCollectionType> AssetsDataDoesNotMatch<TCollection>(string assetId, string diff)
-        where TCollection : JsonLdBase
-        => ModifyEntityResult<TCollection, ModifyCollectionType>.Failure(
+    public static ModifyEntityResult<ModifyCollectionType> AssetsDataDoesNotMatch(string assetId, string diff)
+        => ModifyEntityResult<ModifyCollectionType>.Failure(
             $"Asset {assetId} is specified multiple times, but has conflicting data - diff: {diff}",
             ModifyCollectionType.AssetsDoNotMatch, WriteResult.BadRequest);
-    
+
     private static string CollectionType(bool isStorageCollection)
     {
         return isStorageCollection ? "Storage" : "IIIF";

--- a/src/IIIFPresentation/API/Features/Common/Helpers/UpsertErrorHelper.cs
+++ b/src/IIIFPresentation/API/Features/Common/Helpers/UpsertErrorHelper.cs
@@ -7,121 +7,121 @@ namespace API.Features.Common.Helpers;
 
 public static class UpsertErrorHelper
 {
-    public static ModifyEntityResult<ModifyCollectionType> NullParentResponse()
+    public static PresentationResult NullParentResponse()
     {
-        return ModifyEntityResult<ModifyCollectionType>.Failure(
+        return PresentationResult.Failure(
             "The parent collection could not be found", ModifyCollectionType.ParentCollectionNotFound, WriteResult.BadRequest);
     }
 
-    public static ModifyEntityResult<ModifyCollectionType> CannotGenerateUniqueId()
+    public static PresentationResult CannotGenerateUniqueId()
     {
-        return ModifyEntityResult<ModifyCollectionType>.Failure(
+        return PresentationResult.Failure(
             "Could not generate a unique identifier.  Please try again",
             ModifyCollectionType.CannotGenerateUniqueId, WriteResult.Error);
     }
 
-    public static ModifyEntityResult<ModifyCollectionType> CannotValidateIIIF()
+    public static PresentationResult CannotValidateIIIF()
     {
-        return ModifyEntityResult<ModifyCollectionType>.Failure(
+        return PresentationResult.Failure(
             "An error occurred while attempting to validate the collection as IIIF",
             ModifyCollectionType.CannotValidateIIIF, WriteResult.BadRequest);
     }
 
-    public static ModifyEntityResult<ModifyCollectionType> CannotChangeCollectionType(bool storageCollection)
+    public static PresentationResult CannotChangeCollectionType(bool storageCollection)
     {
-        return ModifyEntityResult<ModifyCollectionType>.Failure(
+        return PresentationResult.Failure(
             $"Cannot convert a {CollectionType(storageCollection)} collection to a {CollectionType(!storageCollection)} collection",
             ModifyCollectionType.CannotChangeCollectionType, WriteResult.BadRequest);
     }
 
-    public static ModifyEntityResult<ModifyCollectionType> EtagNotRequired()
+    public static PresentationResult EtagNotRequired()
     {
-        return ModifyEntityResult<ModifyCollectionType>.Failure(
+        return PresentationResult.Failure(
             "ETag should not be included in request when inserting via PUT", ModifyCollectionType.ETagNotAllowed,
             WriteResult.PreconditionFailed);
     }
 
-    public static ModifyEntityResult<ModifyCollectionType> EtagNonMatching()
+    public static PresentationResult EtagNonMatching()
     {
-        return ModifyEntityResult<ModifyCollectionType>.Failure(
+        return PresentationResult.Failure(
             "ETag does not match", ModifyCollectionType.ETagNotMatched, WriteResult.PreconditionFailed);
     }
 
-    public static ModifyEntityResult<ModifyCollectionType> DlcsError(string message)
-        => ModifyEntityResult<ModifyCollectionType>.Failure(
+    public static PresentationResult DlcsError(string message)
+        => PresentationResult.Failure(
             message, ModifyCollectionType.DlcsError, WriteResult.Error);
 
-    public static ModifyEntityResult<ModifyCollectionType> SpaceRequired()
-        => ModifyEntityResult<ModifyCollectionType>.Failure(
+    public static PresentationResult SpaceRequired()
+        => PresentationResult.Failure(
             "A request with assets requires the space header to be set", ModifyCollectionType.RequiresSpaceHeader,
             WriteResult.BadRequest);
 
-    public static ModifyEntityResult<ModifyCollectionType> CouldNotRetrieveAssetId()
-        => ModifyEntityResult<ModifyCollectionType>.Failure(
+    public static PresentationResult CouldNotRetrieveAssetId()
+        => PresentationResult.Failure(
             "Could not retrieve an id from an attached asset", ModifyCollectionType.CouldNotRetrieveAssetId,
             WriteResult.BadRequest);
 
-    public static ModifyEntityResult<ModifyCollectionType> ParentMustBeStorageCollection()
-        => ModifyEntityResult<ModifyCollectionType>.Failure("The parent must be a storage collection",
+    public static PresentationResult ParentMustBeStorageCollection()
+        => PresentationResult.Failure("The parent must be a storage collection",
             ModifyCollectionType.ParentMustBeStorageCollection, WriteResult.Conflict);
 
-    public static ModifyEntityResult<ModifyCollectionType> ParentMustMatchPublicId()
-        => ModifyEntityResult<ModifyCollectionType>.Failure("The parent must match the one specified in the public id",
+    public static PresentationResult ParentMustMatchPublicId()
+        => PresentationResult.Failure("The parent must match the one specified in the public id",
             ModifyCollectionType.ParentMustMatchPublicId, WriteResult.BadRequest);
 
-    public static ModifyEntityResult<ModifyCollectionType> SlugMustMatchPublicId()
-        => ModifyEntityResult<ModifyCollectionType>.Failure("The slug must match the one specified in the public id",
+    public static PresentationResult SlugMustMatchPublicId()
+        => PresentationResult.Failure("The slug must match the one specified in the public id",
             ModifyCollectionType.SlugMustMatchPublicId, WriteResult.BadRequest);
 
-    public static ModifyEntityResult<ModifyCollectionType> InvalidCanvasId(string? canvasId, string reason)
-        => ModifyEntityResult<ModifyCollectionType>.Failure($"The canvas id {canvasId} is invalid - {reason}",
+    public static PresentationResult InvalidCanvasId(string? canvasId, string reason)
+        => PresentationResult.Failure($"The canvas id {canvasId} is invalid - {reason}",
             ModifyCollectionType.InvalidCanvasId, WriteResult.BadRequest);
 
-    public static ModifyEntityResult<ModifyCollectionType> InvalidCanvasId(params (string canvasId, string reason)[] multiple)
+    public static PresentationResult InvalidCanvasId(params (string canvasId, string reason)[] multiple)
     {
         var failures = string.Join(", ", multiple.Select(p => $"{p.canvasId}: {p.reason}"));
         var message = $"Errors encountered when parsing painted resources: {failures}.";
 
-        return ModifyEntityResult<ModifyCollectionType>.Failure(message,
+        return PresentationResult.Failure(message,
             ModifyCollectionType.InvalidCanvasId, WriteResult.BadRequest);
     }
 
-    public static ModifyEntityResult<ModifyCollectionType> ErrorMergingPaintedResourcesWithItems(string error)
-        => ModifyEntityResult<ModifyCollectionType>.Failure(error,
+    public static PresentationResult ErrorMergingPaintedResourcesWithItems(string error)
+        => PresentationResult.Failure(error,
             ModifyCollectionType.ErrorMergingPaintedResourcesWithItems, WriteResult.BadRequest);
 
-    public static ModifyEntityResult<ModifyCollectionType> DuplicateCanvasId(string? canvasId)
-        => ModifyEntityResult<ModifyCollectionType>.Failure($"The canvas ID {canvasId} cannot be a duplicate",
+    public static PresentationResult DuplicateCanvasId(string? canvasId)
+        => PresentationResult.Failure($"The canvas ID {canvasId} cannot be a duplicate",
             ModifyCollectionType.DuplicateCanvasId, WriteResult.BadRequest);
 
-    public static ModifyEntityResult<ModifyCollectionType> IncorrectPublicId()
-        => ModifyEntityResult<ModifyCollectionType>.Failure("publicId incorrect",
+    public static PresentationResult IncorrectPublicId()
+        => PresentationResult.Failure("publicId incorrect",
             ModifyCollectionType.PublicIdIncorrect, WriteResult.BadRequest);
 
-    public static ModifyEntityResult<ModifyCollectionType> PaintableAssetError(string error)
-        => ModifyEntityResult<ModifyCollectionType>.Failure(error,
+    public static PresentationResult PaintableAssetError(string error)
+        => PresentationResult.Failure(error,
             ModifyCollectionType.PaintableAssetError, WriteResult.BadRequest);
 
-    public static ModifyEntityResult<ModifyCollectionType> AssetError(AssetException exception)
-        => ModifyEntityResult<ModifyCollectionType>.Failure(exception.Message,
+    public static PresentationResult AssetError(AssetException exception)
+        => PresentationResult.Failure(exception.Message,
             ModifyCollectionType.AssetError, WriteResult.BadRequest);
 
-    public static ModifyEntityResult<ModifyCollectionType> CustomerIdDoesNotMatchCaller(string field)
-        => ModifyEntityResult<ModifyCollectionType>.Failure($"The {field} has a customer id that does not match the customer id found on the calling URL",
+    public static PresentationResult CustomerIdDoesNotMatchCaller(string field)
+        => PresentationResult.Failure($"The {field} has a customer id that does not match the customer id found on the calling URL",
             ModifyCollectionType.CustomerIdDoesNotMatchCaller, WriteResult.BadRequest);
 
-    public static ModifyEntityResult<ModifyCollectionType> AssetAdjunctsDoNotMatch(string assetId, string diff)
-        => ModifyEntityResult<ModifyCollectionType>.Failure(
+    public static PresentationResult AssetAdjunctsDoNotMatch(string assetId, string diff)
+        => PresentationResult.Failure(
             $"Asset {assetId} is specified multiple times with different adjuncts - diff: {diff}",
             ModifyCollectionType.AssetsAdjunctsDoNotMatch, WriteResult.BadRequest);
 
-    public static ModifyEntityResult<ModifyCollectionType> ManifestCurrentlyIngesting()
-        => ModifyEntityResult<ModifyCollectionType>.Failure(
+    public static PresentationResult ManifestCurrentlyIngesting()
+        => PresentationResult.Failure(
             "The manifest is currently being ingested and cannot be modified",
             ModifyCollectionType.ManifestCurrentlyIngesting, WriteResult.Conflict);
 
-    public static ModifyEntityResult<ModifyCollectionType> AssetsDataDoesNotMatch(string assetId, string diff)
-        => ModifyEntityResult<ModifyCollectionType>.Failure(
+    public static PresentationResult AssetsDataDoesNotMatch(string assetId, string diff)
+        => PresentationResult.Failure(
             $"Asset {assetId} is specified multiple times, but has conflicting data - diff: {diff}",
             ModifyCollectionType.AssetsDoNotMatch, WriteResult.BadRequest);
 

--- a/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingResolver.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingResolver.cs
@@ -14,7 +14,7 @@ using Services.Manifests.Helpers;
 using Services.Manifests.Model;
 using CanvasPainting = Models.Database.CanvasPainting;
 using DbManifest = Models.Database.Collections.Manifest;
-using PresUpdateResult = API.Infrastructure.Requests.ModifyEntityResult<Models.API.Manifest.PresentationManifest, Models.API.General.ModifyCollectionType>;
+using PresUpdateResult = API.Infrastructure.Requests.ModifyEntityResult<Models.API.General.ModifyCollectionType>;
 
 namespace API.Features.Manifest;
 
@@ -48,13 +48,13 @@ public class CanvasPaintingResolver(
         {
             logger.LogDebug(cpId, "InvalidCanvasId '{CanvasId}' encountered in {ManifestId}", cpId.CanvasId,
                 presentationManifest.Id);
-            return ParsedManifestResult.Failure(UpsertErrorHelper.InvalidCanvasId<PresentationManifest>(cpId.CanvasId, cpId.Message));
+            return ParsedManifestResult.Failure(UpsertErrorHelper.InvalidCanvasId(cpId.CanvasId, cpId.Message));
         }
         catch (PaintableAssetException paintableAssetException)
         {
             logger.LogError(paintableAssetException,
                 "Error retrieving details of an asset from items when generating canvas paintings");
-            return ParsedManifestResult.Failure(UpsertErrorHelper.PaintableAssetError<PresentationManifest>(paintableAssetException.Message));
+            return ParsedManifestResult.Failure(UpsertErrorHelper.PaintableAssetError(paintableAssetException.Message));
         }
     }
 
@@ -199,7 +199,7 @@ public class CanvasPaintingResolver(
         logger.LogTrace("Adding {CanvasCounts} to Manifest", canvasPaintings.Count);
         var requiredIds = canvasPaintings.GetRequiredNumberOfCanvasIds();
         var canvasPaintingIds = await GenerateUniqueCanvasPaintingIds(requiredIds, customerId, cancellationToken);
-        if (canvasPaintingIds == null) return UpsertErrorHelper.CannotGenerateUniqueId<PresentationManifest>();
+        if (canvasPaintingIds == null) return UpsertErrorHelper.CannotGenerateUniqueId();
 
         // Build a dictionary of canvas_grouping:canvas_id, this is populated as we iterate over canvas paintings.
         // We will also seed it with any 'new' items that are on the same canvas as these will have been prepopulated
@@ -283,13 +283,13 @@ public class CanvasPaintingResolver(
         {
             logger.LogDebug(cpId, "InvalidCanvasId encountered in {ManifestId}", presentationManifest.Id);
             return new ManifestParseResult(
-                UpsertErrorHelper.InvalidCanvasId<PresentationManifest>(cpId.CanvasId, cpId.Message));
+                UpsertErrorHelper.InvalidCanvasId(cpId.CanvasId, cpId.Message));
         }
         catch (CanvasPaintingValidationException cpve)
         {
             logger.LogDebug(cpve, "Validation errors encountered in {ManifestId}", presentationManifest.Id);
             return new ManifestParseResult(
-                UpsertErrorHelper.InvalidCanvasId<PresentationManifest>(cpve.Errors));
+                UpsertErrorHelper.InvalidCanvasId(cpve.Errors));
         }
         catch (CanvasPaintingMergerException cpMergeError)
         {
@@ -297,26 +297,26 @@ public class CanvasPaintingResolver(
                 "Canvas painting merge exception encountered in {ManifestId} for id {Id} - expected: {Expected}, actual: {Actual}",
                 presentationManifest.Id, cpMergeError.Id, cpMergeError.Expected, cpMergeError.Actual);
             return new ManifestParseResult(
-                UpsertErrorHelper.ErrorMergingPaintedResourcesWithItems<PresentationManifest>(cpMergeError.Message));
+                UpsertErrorHelper.ErrorMergingPaintedResourcesWithItems(cpMergeError.Message));
         }
         catch (InvalidOperationException formatException)
         {
             logger.LogDebug(formatException,
                 "Canvas painting exception encountered in {ManifestId}, could not retrieve an asset id",
                 presentationManifest.Id);
-            return new ManifestParseResult(UpsertErrorHelper.CouldNotRetrieveAssetId<PresentationManifest>());
+            return new ManifestParseResult(UpsertErrorHelper.CouldNotRetrieveAssetId());
         }
         catch (AssetException assetException)
         {
             logger.LogDebug(assetException,
                 "Error when parsing asset - {AssetException}", assetException.Asset);
-            return new ManifestParseResult(UpsertErrorHelper.AssetError<PresentationManifest>(assetException));
+            return new ManifestParseResult(UpsertErrorHelper.AssetError(assetException));
         }
         catch (PaintableAssetException paintableAssetException)
         {
             logger.LogDebug(paintableAssetException,
                 "Error retrieving paintable assets from items");
-            return new ManifestParseResult(UpsertErrorHelper.PaintableAssetError<PresentationManifest>(paintableAssetException.Message));
+            return new ManifestParseResult(UpsertErrorHelper.PaintableAssetError(paintableAssetException.Message));
         }
     }
 

--- a/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingResolver.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/CanvasPaintingResolver.cs
@@ -12,9 +12,9 @@ using Services.Manifests;
 using Services.Manifests.Exceptions;
 using Services.Manifests.Helpers;
 using Services.Manifests.Model;
+using API.Infrastructure.Requests;
 using CanvasPainting = Models.Database.CanvasPainting;
 using DbManifest = Models.Database.Collections.Manifest;
-using PresUpdateResult = API.Infrastructure.Requests.ModifyEntityResult<Models.API.General.ModifyCollectionType>;
 
 namespace API.Features.Manifest;
 
@@ -191,7 +191,7 @@ public class CanvasPaintingResolver(
             : incoming.CanvasOriginalId?.ToString() ?? incoming.SuspectedAssetId ?? "unknown";
     }
     
-    private async Task<PresUpdateResult?> HandleInserts(List<InterimCanvasPainting> canvasPaintings, int customerId,
+    private async Task<PresentationResult?> HandleInserts(List<InterimCanvasPainting> canvasPaintings, int customerId,
         CancellationToken cancellationToken)
     {
         if (canvasPaintings.IsNullOrEmpty()) return null;
@@ -321,12 +321,12 @@ public class CanvasPaintingResolver(
     }
 
     private class ManifestParseResult(
-        PresUpdateResult? error = null,
+        PresentationResult? error = null,
         List<InterimCanvasPainting>? canvasPaintings = null,
         List<InterimCanvasPainting>? assetsIdentifiedInItems = null,
         List<AdjunctInteraction>? adjunctInteractions = null)
     {
-        public PresUpdateResult? Error { get; set; } = error;
+        public PresentationResult? Error { get; set; } = error;
 
         public List<InterimCanvasPainting>? CanvasPaintings { get; set; } = canvasPaintings;
 

--- a/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
@@ -18,7 +18,7 @@ using Repository;
 using Services.Manifests.Helpers;
 using Services.Manifests.Model;
 using Batch = Models.Database.General.Batch;
-using EntityResult = API.Infrastructure.Requests.ModifyEntityResult<Models.API.Manifest.PresentationManifest, Models.API.General.ModifyCollectionType>;
+using EntityResult = API.Infrastructure.Requests.ModifyEntityResult<Models.API.General.ModifyCollectionType>;
 
 namespace API.Features.Manifest;
 
@@ -111,7 +111,7 @@ public class DlcsManifestCoordinator(
         {
             logger.LogError(presentationException, "Error checking for the existence of assets");
 
-            return DlcsInteractionResult.Fail(UpsertErrorHelper.PaintableAssetError<PresentationManifest>(presentationException.Message));
+            return DlcsInteractionResult.Fail(UpsertErrorHelper.PaintableAssetError(presentationException.Message));
         }
 
         return null;
@@ -151,7 +151,7 @@ public class DlcsManifestCoordinator(
                 if (!spaceId.HasValue)
                 {
                     return DlcsInteractionResult.Fail(
-                        UpsertErrorHelper.DlcsError<PresentationManifest>("Error creating DLCS space"));
+                        UpsertErrorHelper.DlcsError("Error creating DLCS space"));
                 }
 
                 // you wanted a space, and there are no assets, so no further work required

--- a/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/DlcsManifestCoordinator.cs
@@ -17,15 +17,15 @@ using Newtonsoft.Json.Linq;
 using Repository;
 using Services.Manifests.Helpers;
 using Services.Manifests.Model;
+using API.Infrastructure.Requests;
 using Batch = Models.Database.General.Batch;
-using EntityResult = API.Infrastructure.Requests.ModifyEntityResult<Models.API.General.ModifyCollectionType>;
 
 namespace API.Features.Manifest;
 
-public class DlcsInteractionResult(EntityResult? error, int? spaceId, bool canBeBuiltUpfront = false, 
+public class DlcsInteractionResult(PresentationResult? error, int? spaceId, bool canBeBuiltUpfront = false, 
     List<AssetId>? ingestedAssets = null)
 {
-    public EntityResult? Error { get; } = error;
+    public PresentationResult? Error { get; } = error;
     public int? SpaceId { get; } = spaceId;
     
     public bool CanBeBuiltUpfront { get; } = canBeBuiltUpfront;
@@ -34,7 +34,7 @@ public class DlcsInteractionResult(EntityResult? error, int? spaceId, bool canBe
 
     public static readonly DlcsInteractionResult NoInteraction = new(null, null, true);
 
-    public static DlcsInteractionResult Fail(EntityResult error) => new(error, null);
+    public static DlcsInteractionResult Fail(PresentationResult error) => new(error, null);
 }
 
 public class DlcsManifestCoordinator(
@@ -198,7 +198,7 @@ public class DlcsManifestCoordinator(
                 error += $" for canvas painting id '{assetIdException.Data[ExceptionDataType.CanvasPaintingId]}'";
             }
             
-            return new DlcsInteractionResult(EntityResult.Failure(error, ModifyCollectionType.AssetError,
+            return new DlcsInteractionResult(PresentationResult.Failure(error, ModifyCollectionType.AssetError,
                 WriteResult.BadRequest), spaceId);
         }
 
@@ -376,7 +376,7 @@ public class DlcsManifestCoordinator(
         return newSpace.Id;
     }
 
-    private async Task<EntityResult?> CreateBatches(int customerId, string manifestId,
+    private async Task<PresentationResult?> CreateBatches(int customerId, string manifestId,
         List<DlcsInteractionRequest> dlcsInteractionRequests, List<Batch> collectedBatches, CancellationToken cancellationToken)
     {
         if (dlcsInteractionRequests.Count == 0) return null;
@@ -409,7 +409,7 @@ public class DlcsManifestCoordinator(
             collectedBatches, cancellationToken);
     }
 
-    private async Task<EntityResult?> IngestDeliverables(int customerId, string manifestId,
+    private async Task<PresentationResult?> IngestDeliverables(int customerId, string manifestId,
         List<JObject> deliverables, DeliverableType deliverableType, List<Batch> collectedBatches, CancellationToken cancellationToken)
     {
         try
@@ -428,7 +428,7 @@ public class DlcsManifestCoordinator(
         {
             logger.LogError(exception, "Error creating batch request for customer {CustomerId}, manifest {ManifestId}",
                 customerId, manifestId);
-            return EntityResult.Failure(exception.Message, ModifyCollectionType.DlcsException,
+            return PresentationResult.Failure(exception.Message, ModifyCollectionType.DlcsException,
                 ErrorStatusCodeToWriteResult(exception.StatusCode));
         }
     }

--- a/src/IIIFPresentation/API/Features/Manifest/Helpers/AssetDuplicateValidator.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/Helpers/AssetDuplicateValidator.cs
@@ -8,7 +8,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Services.Manifests.Helpers;
 using Services.Manifests.Model;
-using PresUpdateResult = API.Infrastructure.Requests.ModifyEntityResult<Models.API.Manifest.PresentationManifest, Models.API.General.ModifyCollectionType>;
+using PresUpdateResult = API.Infrastructure.Requests.ModifyEntityResult<Models.API.General.ModifyCollectionType>;
 
 namespace API.Features.Manifest.Helpers;
 
@@ -43,7 +43,7 @@ public static class AssetDuplicateValidator
                 if (!JToken.DeepEquals(existing, asset))
                 {
                     var cp = paintedResourceCanvasPaintings.FirstOrDefault(c => c.SuspectedAssetId == assetId);
-                    return UpsertErrorHelper.AssetsDataDoesNotMatch<PresentationManifest>(
+                    return UpsertErrorHelper.AssetsDataDoesNotMatch(
                         cp != null ? BuildAssetKey(cp) : assetId,
                         SerializeDiff(existing, asset));
                 }
@@ -66,7 +66,7 @@ public static class AssetDuplicateValidator
             {
                 var existing = seenAdjuncts[key];
                 if (!AdjunctsEqual(existing, adjuncts))
-                    return UpsertErrorHelper.AssetAdjunctsDoNotMatch<PresentationManifest>(key,
+                    return UpsertErrorHelper.AssetAdjunctsDoNotMatch(key,
                         SerializeDiff(new JArray(existing ?? []), new JArray(adjuncts ?? [])));
             }
         }

--- a/src/IIIFPresentation/API/Features/Manifest/Helpers/AssetDuplicateValidator.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/Helpers/AssetDuplicateValidator.cs
@@ -8,20 +8,20 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Services.Manifests.Helpers;
 using Services.Manifests.Model;
-using PresUpdateResult = API.Infrastructure.Requests.ModifyEntityResult<Models.API.General.ModifyCollectionType>;
+using API.Infrastructure.Requests;
 
 namespace API.Features.Manifest.Helpers;
 
 public static class AssetDuplicateValidator
 {
-    public static PresUpdateResult? ValidateDuplicates(
+    public static PresentationResult? ValidateDuplicates(
         List<InterimCanvasPainting> paintedResourceCanvasPaintings,
         List<PaintedResource>? paintedResources)
         => ValidateDuplicateAssets(paintedResourceCanvasPaintings, paintedResources)
            // run the adjunct validator if the asset validator returned no errors
            ?? ValidateDuplicateAdjuncts(paintedResourceCanvasPaintings);
 
-    private static PresUpdateResult? ValidateDuplicateAssets(
+    private static PresentationResult? ValidateDuplicateAssets(
         List<InterimCanvasPainting> paintedResourceCanvasPaintings,
         List<PaintedResource>? paintedResources)
     {
@@ -53,7 +53,7 @@ public static class AssetDuplicateValidator
         return null;
     }
 
-    private static PresUpdateResult? ValidateDuplicateAdjuncts(
+    private static PresentationResult? ValidateDuplicateAdjuncts(
         List<InterimCanvasPainting> paintedResourceCanvasPaintings)
     {
         var seenAdjuncts = new Dictionary<string, List<JObject>?>();

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestController.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestController.cs
@@ -9,7 +9,6 @@ using API.Infrastructure.Helpers;
 using API.Infrastructure.Http;
 using API.Infrastructure.Requests;
 using API.Settings;
-using IIIF;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -103,14 +102,13 @@ public class ManifestController(
         return await HandleDelete(new DeleteManifest(customerId, id, Request.Headers.IfMatch));
     }
 
-    private async Task<IActionResult> ManifestUpsert<T, TEnum>(
-        Func<PresentationManifest, string, IRequest<ModifyEntityResult<T, TEnum>>> requestFactory,
+    private async Task<IActionResult> ManifestUpsert<TEnum>(
+        Func<PresentationManifest, string, IRequest<ModifyEntityResult<TEnum>>> requestFactory,
         PresentationManifestValidator validator,
         string? instance = null,
         string? errorTitle = "Operation failed",
         string? invalidatesEtag = null,
         CancellationToken cancellationToken = default)
-        where T : JsonLdBase
         where TEnum : Enum
     {
         var rawRequestBody = await Request.GetRawRequestBodyAsync(cancellationToken);

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestController.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestController.cs
@@ -9,11 +9,11 @@ using API.Infrastructure.Helpers;
 using API.Infrastructure.Http;
 using API.Infrastructure.Requests;
 using API.Settings;
+using Models.API.General;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
-using Models.API.General;
 using Models.API.Manifest;
 
 namespace API.Features.Manifest;
@@ -102,14 +102,13 @@ public class ManifestController(
         return await HandleDelete(new DeleteManifest(customerId, id, Request.Headers.IfMatch));
     }
 
-    private async Task<IActionResult> ManifestUpsert<TEnum>(
-        Func<PresentationManifest, string, IRequest<ModifyEntityResult<TEnum>>> requestFactory,
+    private async Task<IActionResult> ManifestUpsert(
+        Func<PresentationManifest, string, IRequest<PresentationResult>> requestFactory,
         PresentationManifestValidator validator,
         string? instance = null,
         string? errorTitle = "Operation failed",
         string? invalidatesEtag = null,
         CancellationToken cancellationToken = default)
-        where TEnum : Enum
     {
         var rawRequestBody = await Request.GetRawRequestBodyAsync(cancellationToken);
         var presentationManifest = await rawRequestBody.TryDeserializePresentation<PresentationManifest>(logger);

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
@@ -27,9 +27,9 @@ using Services.Manifests.AWS;
 using Services.Manifests.Helpers;
 using Services.Manifests.Model;
 using Services.TextServices;
+using API.Infrastructure.Requests;
 using CanvasPainting = Models.Database.CanvasPainting;
 using DbManifest = Models.Database.Collections.Manifest;
-using PresUpdateResult = API.Infrastructure.Requests.ModifyEntityResult<Models.API.General.ModifyCollectionType>;
 
 namespace API.Features.Manifest;
 
@@ -78,12 +78,12 @@ public interface IManifestWrite
     /// <summary>
     /// Create or update full manifest, using details provided in request object
     /// </summary>
-    Task<PresUpdateResult> Upsert(UpsertManifestRequest request, CancellationToken cancellationToken);
+    Task<PresentationResult> Upsert(UpsertManifestRequest request, CancellationToken cancellationToken);
 
     /// <summary>
     /// Create new manifest, using details provided in request object
     /// </summary>
-    Task<PresUpdateResult> Create(WriteManifestRequest request, CancellationToken cancellationToken);
+    Task<PresentationResult> Create(WriteManifestRequest request, CancellationToken cancellationToken);
 }
 
 /// <summary>
@@ -108,7 +108,7 @@ public class ManifestWriteService(
     /// <summary>
     /// Create or update full manifest, using details provided in request object
     /// </summary>
-    public async Task<PresUpdateResult> Upsert(UpsertManifestRequest request, CancellationToken cancellationToken)
+    public async Task<PresentationResult> Upsert(UpsertManifestRequest request, CancellationToken cancellationToken)
     {
         using var manifestLock = manifestLockManager.TryAcquire($"M:{request.CustomerId}:{request.ManifestId}");
         if (manifestLock == null)
@@ -143,7 +143,7 @@ public class ManifestWriteService(
         {
             logger.LogError(ex, "Error upserting manifest {ManifestId} for customer {CustomerId}", request.ManifestId,
                 request.CustomerId);
-            return PresUpdateResult.Failure($"Unexpected error upserting manifest {request.ManifestId}",
+            return PresentationResult.Failure($"Unexpected error upserting manifest {request.ManifestId}",
                 ModifyCollectionType.Unknown, WriteResult.Error);
         }
     }
@@ -151,7 +151,7 @@ public class ManifestWriteService(
     /// <summary>
     /// Create new manifest, using details provided in request object
     /// </summary>
-    public async Task<PresUpdateResult> Create(WriteManifestRequest request, CancellationToken cancellationToken)
+    public async Task<PresentationResult> Create(WriteManifestRequest request, CancellationToken cancellationToken)
     {
         try
         {
@@ -165,12 +165,12 @@ public class ManifestWriteService(
         {
             logger.LogError(ex, "Error creating manifest with slug '{Slug}' for customer {CustomerId}",
                 request.PresentationManifest.Slug, request.CustomerId);
-            return PresUpdateResult.Failure("Unexpected error creating manifest", ModifyCollectionType.Unknown,
+            return PresentationResult.Failure("Unexpected error creating manifest", ModifyCollectionType.Unknown,
                 WriteResult.Error);
         }
     }
 
-    private async Task<PresUpdateResult> CreateInternal(WriteManifestRequest request, string? manifestId,
+    private async Task<PresentationResult> CreateInternal(WriteManifestRequest request, string? manifestId,
         CancellationToken cancellationToken)
     {
         using (logger.BeginScope("Creating Manifest for Customer {CustomerId}", request.CustomerId))
@@ -206,7 +206,7 @@ public class ManifestWriteService(
         }
     }
 
-    private async Task<PresUpdateResult> UpdateInternal(UpsertManifestRequest request,
+    private async Task<PresentationResult> UpdateInternal(UpsertManifestRequest request,
         DbManifest existingManifest, CancellationToken cancellationToken)
     {
         if (!EtagComparer.IsMatch(existingManifest.Etag, request.Etag))
@@ -298,7 +298,7 @@ public class ManifestWriteService(
         return ResolvedManifestData.Success(canvasPaintingRecords!, parsedParentSlug!);
     }
 
-    private async Task<(PresUpdateResult? error, ParsedManifestResult? records)> ResolveCanvasPaintings(
+    private async Task<(PresentationResult? error, ParsedManifestResult? records)> ResolveCanvasPaintings(
         WriteManifestRequest request, DbManifest? existingManifest, CancellationToken cancellationToken)
     {
         var isCreate = existingManifest == null;
@@ -311,7 +311,7 @@ public class ManifestWriteService(
         return result.Error != null ? (result.Error, null) : (null, result);
     }
 
-    private async Task<(PresUpdateResult? error, ParsedParentSlug? parsedParentSlug)> ParseParentSlug(
+    private async Task<(PresentationResult? error, ParsedParentSlug? parsedParentSlug)> ParseParentSlug(
         WriteManifestRequest request, string? manifestId, CancellationToken cancellationToken)
     {
         var result = await parentSlugParser.Parse(request.PresentationManifest, request.CustomerId, manifestId,
@@ -319,7 +319,7 @@ public class ManifestWriteService(
         return result.IsError ? (result.Errors, null) : (null, result.ParsedParentSlug);
     }
 
-    private async Task<PresUpdateResult> SaveToS3AndGenerateResult(WriteManifestRequest request, DbManifest dbManifest,
+    private async Task<PresentationResult> SaveToS3AndGenerateResult(WriteManifestRequest request, DbManifest dbManifest,
         DlcsInteractionResult dlcsInteractionResult, WriteResult writeResult, CancellationToken cancellationToken)
     {
         var saveError = await SaveToS3(dbManifest, request, dlcsInteractionResult.CanBeBuiltUpfront, cancellationToken);
@@ -329,7 +329,7 @@ public class ManifestWriteService(
             writeResult, cancellationToken);
     }
 
-    private async Task<PresUpdateResult> GeneratePresentationSuccessResult(PresentationManifest presentationManifest,
+    private async Task<PresentationResult> GeneratePresentationSuccessResult(PresentationManifest presentationManifest,
         int customerId, DbManifest dbManifest, WriteResult writeResult, CancellationToken cancellationToken)
     {
         var assets = await dlcsManifestCoordinator.GetAssets(customerId, dbManifest, cancellationToken);
@@ -339,14 +339,14 @@ public class ManifestWriteService(
             presentationManifest.SetManifestLevelAdjuncts(assets, customerId, dbManifest.Id);
         }
 
-        return PresUpdateResult.Success(
+        return PresentationResult.Success(
             presentationManifest.SetGeneratedFields(dbManifest, pathGenerator, savedManifestPathGenerator, assets,
                 finishedPipelinesLimit: options.Value.FinishedPipelinesLimit),
             writeResult,
             dbManifest?.Etag);
     }
 
-    private async Task<(PresUpdateResult?, DbManifest?)> CreateDatabaseRecord(WriteManifestRequest request,
+    private async Task<(PresentationResult?, DbManifest?)> CreateDatabaseRecord(WriteManifestRequest request,
         ParsedParentSlug parsedParentSlug, int? spaceId, 
         List<CanvasPainting> canvasPaintings, CancellationToken cancellationToken)
     {
@@ -379,7 +379,7 @@ public class ManifestWriteService(
         return (saveErrors, dbManifest);
     }
 
-    private async Task<(PresUpdateResult?, DbManifest?)> UpdateDatabaseRecord(WriteManifestRequest request,
+    private async Task<(PresentationResult?, DbManifest?)> UpdateDatabaseRecord(WriteManifestRequest request,
         ParsedParentSlug parsedParentSlug, DbManifest existingManifest, int? manifestSpace, CancellationToken cancellationToken)
     {
         existingManifest.Label = request.PresentationManifest.Label;
@@ -398,7 +398,7 @@ public class ManifestWriteService(
         return (saveErrors, existingManifest);
     }
 
-    private async Task<PresUpdateResult?> SaveAndPopulateEntity(WriteManifestRequest request, DbManifest dbManifest,
+    private async Task<PresentationResult?> SaveAndPopulateEntity(WriteManifestRequest request, DbManifest dbManifest,
         CancellationToken cancellationToken)
     {
         var saveErrors =
@@ -438,7 +438,7 @@ public class ManifestWriteService(
     /// This is relevant for painted resources + resource level adjuncts
     /// </param>
     /// <param name="cancellationToken">A cancellation token</param>
-    private async Task<PresUpdateResult?> SaveToS3(DbManifest dbManifest, WriteManifestRequest request, bool canBeBuiltUpfront,
+    private async Task<PresentationResult?> SaveToS3(DbManifest dbManifest, WriteManifestRequest request, bool canBeBuiltUpfront,
         CancellationToken cancellationToken)
     {
         var iiifManifest = request.RawRequestBody.ToManifest()!;
@@ -515,13 +515,13 @@ public class ManifestWriteService(
     // Submits the given pipeline job to text-services.
     // The HTTP call runs while the DB transaction is still open — the HttpClient should be configured with a short
     // timeout to bound this window. On failure the staged manifest is cleaned up so the caller can retry cleanly.
-    private async Task<PresUpdateResult?> SubmitPipelineJob(DbManifest dbManifest, PipelineJob job,
+    private async Task<PresentationResult?> SubmitPipelineJob(DbManifest dbManifest, PipelineJob job,
         CancellationToken cancellationToken)
     {
         if (!await pipelineJobService.SubmitPipelineJob(dbManifest, job, cancellationToken))
         {
             await manifestStorageManager.DeleteStagedManifest(dbManifest);
-            return PresUpdateResult.Failure("Error submitting text pipeline job",
+            return PresentationResult.Failure("Error submitting text pipeline job",
                 ModifyCollectionType.CannotConnectToTextService, WriteResult.Error);
         }
 
@@ -549,7 +549,7 @@ public class ManifestWriteService(
         /// <summary>
         /// If canvas painting resolution or slug parsing failed.
         /// </summary>
-        public PresUpdateResult? Error { get; private init; }
+        public PresentationResult? Error { get; private init; }
         /// <summary>
         /// Canvas paintings resolved from the request
         /// </summary>
@@ -559,7 +559,7 @@ public class ManifestWriteService(
         /// </summary>
         public ParsedParentSlug? ParsedParentSlug { get; private init; }
 
-        public static ResolvedManifestData Failure(PresUpdateResult error) => new() { Error = error };
+        public static ResolvedManifestData Failure(PresentationResult error) => new() { Error = error };
 
         public static ResolvedManifestData Success(ParsedManifestResult records, ParsedParentSlug slug) =>
             new() { ParsedManifestResult = records, ParsedParentSlug = slug };
@@ -573,7 +573,7 @@ public class ManifestWriteService(
         /// <summary>
         /// If the DLCS interaction or canvas painting update failed.
         /// </summary>
-        public PresUpdateResult? Error { get; private init; }
+        public PresentationResult? Error { get; private init; }
         /// <summary>
         /// Result of the DLCS interaction, including space ID and ingested asset IDs.
         /// </summary>
@@ -583,7 +583,7 @@ public class ManifestWriteService(
         /// </summary>
         public List<CanvasPainting> CanvasPaintings { get; private init; } = [];
 
-        public static DlcsHandleResult Failure(PresUpdateResult error) => new() { Error = error };
+        public static DlcsHandleResult Failure(PresentationResult error) => new() { Error = error };
 
         public static DlcsHandleResult Success(DlcsInteractionResult interactionResult, List<CanvasPainting> canvasPaintings) =>
             new() { InteractionResult = interactionResult, CanvasPaintings = canvasPaintings };

--- a/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ManifestWriteService.cs
@@ -29,7 +29,7 @@ using Services.Manifests.Model;
 using Services.TextServices;
 using CanvasPainting = Models.Database.CanvasPainting;
 using DbManifest = Models.Database.Collections.Manifest;
-using PresUpdateResult = API.Infrastructure.Requests.ModifyEntityResult<Models.API.Manifest.PresentationManifest, Models.API.General.ModifyCollectionType>;
+using PresUpdateResult = API.Infrastructure.Requests.ModifyEntityResult<Models.API.General.ModifyCollectionType>;
 
 namespace API.Features.Manifest;
 
@@ -115,7 +115,7 @@ public class ManifestWriteService(
         {
             logger.LogDebug("Manifest {ManifestId} for Customer {CustomerId} is already being processed, rejecting write",
                 request.ManifestId, request.CustomerId);
-            return UpsertErrorHelper.ManifestCurrentlyIngesting<PresentationManifest>();
+            return UpsertErrorHelper.ManifestCurrentlyIngesting();
         }
 
         try
@@ -126,7 +126,7 @@ public class ManifestWriteService(
 
             if (existingManifest == null)
             {
-                if (!string.IsNullOrEmpty(request.Etag)) return UpsertErrorHelper.EtagNotRequired<PresentationManifest>();
+                if (!string.IsNullOrEmpty(request.Etag)) return UpsertErrorHelper.EtagNotRequired();
 
                 logger.LogDebug("Manifest {ManifestId} for Customer {CustomerId} doesn't exist, creating",
                     request.ManifestId, request.CustomerId);
@@ -137,7 +137,7 @@ public class ManifestWriteService(
         }
         catch (DlcsException ex)
         {
-            return UpsertErrorHelper.DlcsError<PresentationManifest>(ex.Message);
+            return UpsertErrorHelper.DlcsError(ex.Message);
         }
         catch (Exception ex)
         {
@@ -159,7 +159,7 @@ public class ManifestWriteService(
         }
         catch (DlcsException ex)
         {
-            return UpsertErrorHelper.DlcsError<PresentationManifest>(ex.Message);
+            return UpsertErrorHelper.DlcsError(ex.Message);
         }
         catch (Exception ex)
         {
@@ -177,7 +177,7 @@ public class ManifestWriteService(
         {
             // Generate manifest ID before canvas painting resolution so it's available for stub asset naming
             manifestId ??= await GenerateUniqueManifestId(request, cancellationToken);
-            if (manifestId == null) return UpsertErrorHelper.CannotGenerateUniqueId<PresentationManifest>();
+            if (manifestId == null) return UpsertErrorHelper.CannotGenerateUniqueId();
 
             request.PresentationManifest.Id = manifestId;
             var resolved = await ResolveCanvasPaintingsAndParentSlug(request, manifestId, cancellationToken: cancellationToken);
@@ -211,7 +211,7 @@ public class ManifestWriteService(
     {
         if (!EtagComparer.IsMatch(existingManifest.Etag, request.Etag))
         {
-            return UpsertErrorHelper.EtagNonMatching<PresentationManifest>();
+            return UpsertErrorHelper.EtagNonMatching();
         }
 
         using (logger.BeginScope("Updating Manifest {ManifestId} for Customer {CustomerId}",
@@ -402,7 +402,7 @@ public class ManifestWriteService(
         CancellationToken cancellationToken)
     {
         var saveErrors =
-            await dbContext.TrySave<PresentationManifest>("manifest", request.CustomerId, logger, cancellationToken);
+            await dbContext.TrySave("manifest", request.CustomerId, logger, cancellationToken);
 
         if (saveErrors != null) return saveErrors;
 

--- a/src/IIIFPresentation/API/Features/Manifest/ParsedManifestResult.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ParsedManifestResult.cs
@@ -1,5 +1,4 @@
 ﻿using API.Infrastructure.Requests;
-using Models.API.General;
 using Services.Manifests.Model;
 
 namespace API.Features.Manifest;
@@ -10,7 +9,7 @@ namespace API.Features.Manifest;
 /// </summary>
 public class ParsedManifestResult
 {
-    public static ParsedManifestResult Failure(ModifyEntityResult<ModifyCollectionType> updateResult) =>
+    public static ParsedManifestResult Failure(PresentationResult updateResult) =>
         new()
         {
             Error = updateResult
@@ -27,7 +26,7 @@ public class ParsedManifestResult
     /// <summary>
     /// An error that occurred during processing
     /// </summary>
-    public ModifyEntityResult<ModifyCollectionType>? Error { get; private init; }
+    public PresentationResult? Error { get; private init; }
 
     /// <summary>
     /// Details of all canvas paintings that are considered to be "new"

--- a/src/IIIFPresentation/API/Features/Manifest/ParsedManifestResult.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/ParsedManifestResult.cs
@@ -1,6 +1,5 @@
 ﻿using API.Infrastructure.Requests;
 using Models.API.General;
-using Models.API.Manifest;
 using Services.Manifests.Model;
 
 namespace API.Features.Manifest;
@@ -11,7 +10,7 @@ namespace API.Features.Manifest;
 /// </summary>
 public class ParsedManifestResult
 {
-    public static ParsedManifestResult Failure(ModifyEntityResult<PresentationManifest, ModifyCollectionType> updateResult) =>
+    public static ParsedManifestResult Failure(ModifyEntityResult<ModifyCollectionType> updateResult) =>
         new()
         {
             Error = updateResult
@@ -28,7 +27,7 @@ public class ParsedManifestResult
     /// <summary>
     /// An error that occurred during processing
     /// </summary>
-    public ModifyEntityResult<PresentationManifest, ModifyCollectionType>? Error { get; private init; }
+    public ModifyEntityResult<ModifyCollectionType>? Error { get; private init; }
 
     /// <summary>
     /// Details of all canvas paintings that are considered to be "new"

--- a/src/IIIFPresentation/API/Features/Manifest/Requests/CreateManifest.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/Requests/CreateManifest.cs
@@ -13,7 +13,7 @@ public class CreateManifest(
     PresentationManifest presentationManifest,
     string rawRequestBody,
     bool createSpace) 
-    : IRequest<ModifyEntityResult<PresentationManifest, ModifyCollectionType>>
+    : IRequest<ModifyEntityResult<ModifyCollectionType>>
 {
     public int CustomerId { get; } = customerId;
     public PresentationManifest PresentationManifest { get; } = presentationManifest;
@@ -23,9 +23,9 @@ public class CreateManifest(
 
 public class CreateManifestHandler(
     IManifestWrite manifestService) : IRequestHandler<CreateManifest,
-    ModifyEntityResult<PresentationManifest, ModifyCollectionType>>
+    ModifyEntityResult<ModifyCollectionType>>
 {
-    public Task<ModifyEntityResult<PresentationManifest, ModifyCollectionType>> Handle(CreateManifest request,
+    public Task<ModifyEntityResult<ModifyCollectionType>> Handle(CreateManifest request,
         CancellationToken cancellationToken)
     {
         var upsertRequest = new WriteManifestRequest(request.CustomerId, 

--- a/src/IIIFPresentation/API/Features/Manifest/Requests/CreateManifest.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/Requests/CreateManifest.cs
@@ -1,6 +1,5 @@
 ﻿using API.Infrastructure.Requests;
 using MediatR;
-using Models.API.General;
 using Models.API.Manifest;
 
 namespace API.Features.Manifest.Requests;
@@ -13,7 +12,7 @@ public class CreateManifest(
     PresentationManifest presentationManifest,
     string rawRequestBody,
     bool createSpace) 
-    : IRequest<ModifyEntityResult<ModifyCollectionType>>
+    : IRequest<PresentationResult>
 {
     public int CustomerId { get; } = customerId;
     public PresentationManifest PresentationManifest { get; } = presentationManifest;
@@ -23,9 +22,9 @@ public class CreateManifest(
 
 public class CreateManifestHandler(
     IManifestWrite manifestService) : IRequestHandler<CreateManifest,
-    ModifyEntityResult<ModifyCollectionType>>
+    PresentationResult>
 {
-    public Task<ModifyEntityResult<ModifyCollectionType>> Handle(CreateManifest request,
+    public Task<PresentationResult> Handle(CreateManifest request,
         CancellationToken cancellationToken)
     {
         var upsertRequest = new WriteManifestRequest(request.CustomerId, 

--- a/src/IIIFPresentation/API/Features/Manifest/Requests/UpsertManifest.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/Requests/UpsertManifest.cs
@@ -15,7 +15,7 @@ public class UpsertManifest(
     StringValues etag,
     PresentationManifest presentationManifest,
     string rawRequestBody,
-    bool createSpace) : IRequest<ModifyEntityResult<PresentationManifest, ModifyCollectionType>>
+    bool createSpace) : IRequest<ModifyEntityResult<ModifyCollectionType>>
 {
     public int CustomerId { get; } = customerId;
     public string ManifestId { get; } = manifestId;
@@ -26,9 +26,9 @@ public class UpsertManifest(
 }
 
 public class UpsertManifestHandler(IManifestWrite manifestService)
-    : IRequestHandler<UpsertManifest, ModifyEntityResult<PresentationManifest, ModifyCollectionType>>
+    : IRequestHandler<UpsertManifest, ModifyEntityResult<ModifyCollectionType>>
 {
-    public Task<ModifyEntityResult<PresentationManifest, ModifyCollectionType>> Handle(UpsertManifest request,
+    public Task<ModifyEntityResult<ModifyCollectionType>> Handle(UpsertManifest request,
         CancellationToken cancellationToken)
     {
         var upsertRequest = new UpsertManifestRequest(

--- a/src/IIIFPresentation/API/Features/Manifest/Requests/UpsertManifest.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/Requests/UpsertManifest.cs
@@ -1,7 +1,6 @@
 ﻿using API.Infrastructure.Requests;
 using MediatR;
 using Microsoft.Extensions.Primitives;
-using Models.API.General;
 using Models.API.Manifest;
 
 namespace API.Features.Manifest.Requests;
@@ -15,7 +14,7 @@ public class UpsertManifest(
     StringValues etag,
     PresentationManifest presentationManifest,
     string rawRequestBody,
-    bool createSpace) : IRequest<ModifyEntityResult<ModifyCollectionType>>
+    bool createSpace) : IRequest<PresentationResult>
 {
     public int CustomerId { get; } = customerId;
     public string ManifestId { get; } = manifestId;
@@ -26,9 +25,9 @@ public class UpsertManifest(
 }
 
 public class UpsertManifestHandler(IManifestWrite manifestService)
-    : IRequestHandler<UpsertManifest, ModifyEntityResult<ModifyCollectionType>>
+    : IRequestHandler<UpsertManifest, PresentationResult>
 {
-    public Task<ModifyEntityResult<ModifyCollectionType>> Handle(UpsertManifest request,
+    public Task<PresentationResult> Handle(UpsertManifest request,
         CancellationToken cancellationToken)
     {
         var upsertRequest = new UpsertManifestRequest(

--- a/src/IIIFPresentation/API/Features/Storage/Helpers/PresentationContextX.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Helpers/PresentationContextX.cs
@@ -14,14 +14,14 @@ namespace API.Features.Storage.Helpers;
 
 public static class PresentationContextX
 {
-    public static Task<ModifyEntityResult<ModifyCollectionType>?> TrySaveCollection(
+    public static Task<PresentationResult?> TrySaveCollection(
         this PresentationContext dbContext,
         int customerId,
         ILogger logger,
         CancellationToken cancellationToken)
         => dbContext.TrySave("collection", customerId, logger, cancellationToken);
 
-    public static async Task<ModifyEntityResult<ModifyCollectionType>?> TrySave(
+    public static async Task<PresentationResult?> TrySave(
         this PresentationContext dbContext,
         string resourceType,
         int customerId,
@@ -38,19 +38,19 @@ public static class PresentationContextX
 
             if (ex.IsCustomerIdSlugParentViolation())
             {
-                return ModifyEntityResult<ModifyCollectionType>.Failure(
+                return PresentationResult.Failure(
                     $"The {resourceType} could not be created due to a duplicate slug value",
                     ModifyCollectionType.DuplicateSlugValue, WriteResult.Conflict);
             }
 
             if (ex.IsManifestPrimaryKeyViolation())
             {
-                return ModifyEntityResult<ModifyCollectionType>.Failure(
+                return PresentationResult.Failure(
                     "The manifest is currently being created",
                     ModifyCollectionType.ManifestCurrentlyIngesting, WriteResult.Conflict);
             }
 
-            return ModifyEntityResult<ModifyCollectionType>.Failure(
+            return PresentationResult.Failure(
                 $"The {resourceType} could not be created", ModifyCollectionType.Unknown);
         }
 

--- a/src/IIIFPresentation/API/Features/Storage/Helpers/PresentationContextX.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Helpers/PresentationContextX.cs
@@ -2,7 +2,6 @@
 using API.Infrastructure.Requests;
 using API.Settings;
 using Core;
-using IIIF;
 using Microsoft.EntityFrameworkCore;
 using Models.API.General;
 using Models.Database.Collections;
@@ -15,24 +14,22 @@ namespace API.Features.Storage.Helpers;
 
 public static class PresentationContextX
 {
-    public static Task<ModifyEntityResult<T, ModifyCollectionType>?> TrySaveCollection<T>(
+    public static Task<ModifyEntityResult<ModifyCollectionType>?> TrySaveCollection(
         this PresentationContext dbContext,
         int customerId,
         ILogger logger,
         CancellationToken cancellationToken)
-        where T : JsonLdBase
-        => dbContext.TrySave<T>("collection", customerId, logger, cancellationToken);
-    
-    public static async Task<ModifyEntityResult<T, ModifyCollectionType>?> TrySave<T>(
-        this PresentationContext dbContext, 
+        => dbContext.TrySave("collection", customerId, logger, cancellationToken);
+
+    public static async Task<ModifyEntityResult<ModifyCollectionType>?> TrySave(
+        this PresentationContext dbContext,
         string resourceType,
-        int customerId, 
+        int customerId,
         ILogger logger,
         CancellationToken cancellationToken)
-        where T : JsonLdBase
     {
         try
-        { 
+        {
             await dbContext.SaveChangesAsync(cancellationToken);
         }
         catch (DbUpdateException ex)
@@ -41,19 +38,19 @@ public static class PresentationContextX
 
             if (ex.IsCustomerIdSlugParentViolation())
             {
-                return ModifyEntityResult<T, ModifyCollectionType>.Failure(
+                return ModifyEntityResult<ModifyCollectionType>.Failure(
                     $"The {resourceType} could not be created due to a duplicate slug value",
                     ModifyCollectionType.DuplicateSlugValue, WriteResult.Conflict);
             }
 
             if (ex.IsManifestPrimaryKeyViolation())
             {
-                return ModifyEntityResult<T, ModifyCollectionType>.Failure(
+                return ModifyEntityResult<ModifyCollectionType>.Failure(
                     "The manifest is currently being created",
                     ModifyCollectionType.ManifestCurrentlyIngesting, WriteResult.Conflict);
             }
 
-            return ModifyEntityResult<T, ModifyCollectionType>.Failure(
+            return ModifyEntityResult<ModifyCollectionType>.Failure(
                 $"The {resourceType} could not be created", ModifyCollectionType.Unknown);
         }
 

--- a/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
@@ -27,7 +27,7 @@ namespace API.Features.Storage.Requests;
 /// Create a new Collection (storage or iiif) in DB and upload provided JSON to S3 if iiif-collection
 /// </summary>
 public class CreateCollection(int customerId, PresentationCollection collection, string rawRequestBody)
-    : IRequest<ModifyEntityResult<ModifyCollectionType>>
+    : IRequest<PresentationResult>
 {
     public int CustomerId { get; } = customerId;
 
@@ -45,13 +45,13 @@ public class CreateCollectionHandler(
     SettingsBasedPathGenerator settingsBasedPathGenerator,
     IParentSlugParser parentSlugParser,
     IOptions<ApiSettings> options)
-    : IRequestHandler<CreateCollection, ModifyEntityResult<ModifyCollectionType>>
+    : IRequestHandler<CreateCollection, PresentationResult>
 {
     private readonly ApiSettings settings = options.Value;
 
     private const int CurrentPage = 1;
     
-    public async Task<ModifyEntityResult<ModifyCollectionType>> Handle(CreateCollection request, CancellationToken cancellationToken)
+    public async Task<PresentationResult> Handle(CreateCollection request, CancellationToken cancellationToken)
     {
         var isStorageCollection = request.Collection.Behavior.IsStorageCollection();
         TryConvertIIIFResult<IIIF.Presentation.V3.Collection>? iiifCollection = null;
@@ -126,7 +126,7 @@ public class CreateCollectionHandler(
         var enrichedPresentationCollection = request.Collection.EnrichPresentationCollection(collection,
             settings.PageSize, CurrentPage, 0, [], parsedParentSlug.Parent, pathGenerator, settingsBasedPathGenerator); // there can be no items attached to this, as it's just been created
         
-        return ModifyEntityResult<ModifyCollectionType>.Success(
+        return PresentationResult.Success(
             enrichedPresentationCollection,
             WriteResult.Created,
             collection.Etag);

--- a/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/CreateCollection.cs
@@ -27,7 +27,7 @@ namespace API.Features.Storage.Requests;
 /// Create a new Collection (storage or iiif) in DB and upload provided JSON to S3 if iiif-collection
 /// </summary>
 public class CreateCollection(int customerId, PresentationCollection collection, string rawRequestBody)
-    : IRequest<ModifyEntityResult<PresentationCollection, ModifyCollectionType>>
+    : IRequest<ModifyEntityResult<ModifyCollectionType>>
 {
     public int CustomerId { get; } = customerId;
 
@@ -45,27 +45,27 @@ public class CreateCollectionHandler(
     SettingsBasedPathGenerator settingsBasedPathGenerator,
     IParentSlugParser parentSlugParser,
     IOptions<ApiSettings> options)
-    : IRequestHandler<CreateCollection, ModifyEntityResult<PresentationCollection, ModifyCollectionType>>
+    : IRequestHandler<CreateCollection, ModifyEntityResult<ModifyCollectionType>>
 {
     private readonly ApiSettings settings = options.Value;
 
     private const int CurrentPage = 1;
     
-    public async Task<ModifyEntityResult<PresentationCollection, ModifyCollectionType>> Handle(CreateCollection request, CancellationToken cancellationToken)
+    public async Task<ModifyEntityResult<ModifyCollectionType>> Handle(CreateCollection request, CancellationToken cancellationToken)
     {
         var isStorageCollection = request.Collection.Behavior.IsStorageCollection();
         TryConvertIIIFResult<IIIF.Presentation.V3.Collection>? iiifCollection = null;
         if (!isStorageCollection)
         {
             iiifCollection = request.RawRequestBody.ConvertCollectionToIIIF(logger);
-            if (iiifCollection.Error) return UpsertErrorHelper.CannotValidateIIIF<PresentationCollection>();
+            if (iiifCollection.Error) return UpsertErrorHelper.CannotValidateIIIF();
         }
-        
+
         var parsedParentSlugResult =
-            await parentSlugParser.Parse<PresentationCollection>(request.Collection, request.CustomerId, null, cancellationToken);
+            await parentSlugParser.Parse(request.Collection, request.CustomerId, null, cancellationToken);
         if (parsedParentSlugResult.IsError) return parsedParentSlugResult.Errors;
         var parsedParentSlug = parsedParentSlugResult.ParsedParentSlug;
-            
+
         string id;
 
         try
@@ -75,7 +75,7 @@ public class CreateCollectionHandler(
         catch (ConstraintException ex)
         {
             logger.LogError(ex, "An exception occured while generating a unique id");
-            return UpsertErrorHelper.CannotGenerateUniqueId<PresentationCollection>();
+            return UpsertErrorHelper.CannotGenerateUniqueId();
         }
 
         var dateCreated = DateTime.UtcNow;
@@ -109,7 +109,7 @@ public class CreateCollectionHandler(
         dbContext.Collections.Add(collection);
 
         var saveErrors =
-            await dbContext.TrySaveCollection<PresentationCollection>(request.CustomerId, logger,
+            await dbContext.TrySaveCollection(request.CustomerId, logger,
                 cancellationToken);
 
         if (saveErrors != null)
@@ -126,7 +126,7 @@ public class CreateCollectionHandler(
         var enrichedPresentationCollection = request.Collection.EnrichPresentationCollection(collection,
             settings.PageSize, CurrentPage, 0, [], parsedParentSlug.Parent, pathGenerator, settingsBasedPathGenerator); // there can be no items attached to this, as it's just been created
         
-        return ModifyEntityResult<PresentationCollection, ModifyCollectionType>.Success(
+        return ModifyEntityResult<ModifyCollectionType>.Success(
             enrichedPresentationCollection,
             WriteResult.Created,
             collection.Etag);

--- a/src/IIIFPresentation/API/Features/Storage/Requests/PostHierarchicalCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/PostHierarchicalCollection.cs
@@ -22,7 +22,7 @@ namespace API.Features.Storage.Requests;
 public class PostHierarchicalCollection(
     int customerId,
     string slug, 
-    string rawRequestBody) : IRequest<ModifyEntityResult<Collection, ModifyCollectionType>>
+    string rawRequestBody) : IRequest<ModifyEntityResult<ModifyCollectionType>>
 {
     public int CustomerId { get; } = customerId;
 
@@ -37,34 +37,34 @@ public class PostHierarchicalCollectionHandler(
     IdentityManager identityManager,
     IIIIFS3Service iiifS3,
     IPathGenerator pathGenerator)
-    : IRequestHandler<PostHierarchicalCollection, ModifyEntityResult<Collection, ModifyCollectionType>>
+    : IRequestHandler<PostHierarchicalCollection, ModifyEntityResult<ModifyCollectionType>>
 {
     
-    public async Task<ModifyEntityResult<Collection, ModifyCollectionType>> Handle(PostHierarchicalCollection request,
+    public async Task<ModifyEntityResult<ModifyCollectionType>> Handle(PostHierarchicalCollection request,
         CancellationToken cancellationToken)
     {
         var convertResult = request.RawRequestBody.ConvertCollectionToIIIF(logger);
-        if (convertResult.Error) return UpsertErrorHelper.CannotValidateIIIF<Collection>();
+        if (convertResult.Error) return UpsertErrorHelper.CannotValidateIIIF();
         var collectionFromBody = convertResult.ConvertedIIIF!;
-        
+
         var splitSlug = request.Slug.Split('/');
 
         var parentSlug = string.Join("/", splitSlug.Take(..^1));
         var parentCollection =
             await dbContext.RetrieveHierarchy(request.CustomerId, parentSlug, cancellationToken);
-        
+
         var parentValidationError =
-            ParentValidator.ValidateParentCollection<Collection>(parentCollection?.Collection);
+            ParentValidator.ValidateParentCollection(parentCollection?.Collection);
         if (parentValidationError != null) return parentValidationError;
-        
+
         var id = await GenerateUniqueId(request, cancellationToken);
-        if (id == null) return UpsertErrorHelper.CannotGenerateUniqueId<Collection>();
+        if (id == null) return UpsertErrorHelper.CannotGenerateUniqueId();
 
         var collection = CreateDatabaseCollection(request, collectionFromBody, id, parentCollection, splitSlug);
         dbContext.Collections.Add(collection);
 
         var saveErrors =
-            await dbContext.TrySaveCollection<Collection>(request.CustomerId, logger,
+            await dbContext.TrySaveCollection(request.CustomerId, logger,
                 cancellationToken);
 
         if (saveErrors != null)
@@ -84,7 +84,7 @@ public class PostHierarchicalCollectionHandler(
         }
 
         collectionFromBody.Id = pathGenerator.GenerateHierarchicalId(hierarchy);
-        return ModifyEntityResult<Collection, ModifyCollectionType>.Success(collectionFromBody, WriteResult.Created, collection.Etag);
+        return ModifyEntityResult<ModifyCollectionType>.Success(collectionFromBody, WriteResult.Created, collection.Etag);
     }
 
     private static DatabaseCollection.Collection CreateDatabaseCollection(PostHierarchicalCollection request, Collection collectionFromBody, string id,

--- a/src/IIIFPresentation/API/Features/Storage/Requests/PostHierarchicalCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/PostHierarchicalCollection.cs
@@ -22,7 +22,7 @@ namespace API.Features.Storage.Requests;
 public class PostHierarchicalCollection(
     int customerId,
     string slug, 
-    string rawRequestBody) : IRequest<ModifyEntityResult<ModifyCollectionType>>
+    string rawRequestBody) : IRequest<PresentationResult>
 {
     public int CustomerId { get; } = customerId;
 
@@ -37,10 +37,10 @@ public class PostHierarchicalCollectionHandler(
     IdentityManager identityManager,
     IIIIFS3Service iiifS3,
     IPathGenerator pathGenerator)
-    : IRequestHandler<PostHierarchicalCollection, ModifyEntityResult<ModifyCollectionType>>
+    : IRequestHandler<PostHierarchicalCollection, PresentationResult>
 {
     
-    public async Task<ModifyEntityResult<ModifyCollectionType>> Handle(PostHierarchicalCollection request,
+    public async Task<PresentationResult> Handle(PostHierarchicalCollection request,
         CancellationToken cancellationToken)
     {
         var convertResult = request.RawRequestBody.ConvertCollectionToIIIF(logger);
@@ -84,7 +84,7 @@ public class PostHierarchicalCollectionHandler(
         }
 
         collectionFromBody.Id = pathGenerator.GenerateHierarchicalId(hierarchy);
-        return ModifyEntityResult<ModifyCollectionType>.Success(collectionFromBody, WriteResult.Created, collection.Etag);
+        return PresentationResult.Success(collectionFromBody, WriteResult.Created, collection.Etag);
     }
 
     private static DatabaseCollection.Collection CreateDatabaseCollection(PostHierarchicalCollection request, Collection collectionFromBody, string id,

--- a/src/IIIFPresentation/API/Features/Storage/Requests/UpsertCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/UpsertCollection.cs
@@ -27,7 +27,7 @@ namespace API.Features.Storage.Requests;
 
 public class UpsertCollection(int customerId, string collectionId, PresentationCollection collection, string? eTag, 
     string rawRequestBody)
-    : IRequest<ModifyEntityResult<PresentationCollection, ModifyCollectionType>>
+    : IRequest<ModifyEntityResult<ModifyCollectionType>>
 {
     public int CustomerId { get; } = customerId;
 
@@ -48,13 +48,13 @@ public class UpsertCollectionHandler(
     SettingsBasedPathGenerator settingsBasedPathGenerator,
     IParentSlugParser parentSlugParser,
     IOptions<ApiSettings> options)
-    : IRequestHandler<UpsertCollection, ModifyEntityResult<PresentationCollection, ModifyCollectionType>>
+    : IRequestHandler<UpsertCollection, ModifyEntityResult<ModifyCollectionType>>
 {
     private readonly ApiSettings settings = options.Value;
 
     private const int DefaultCurrentPage = 1;
 
-    public async Task<ModifyEntityResult<PresentationCollection, ModifyCollectionType>> Handle(UpsertCollection request, 
+    public async Task<ModifyEntityResult<ModifyCollectionType>> Handle(UpsertCollection request, 
         CancellationToken cancellationToken)
     {
         var isStorageCollection = request.Collection.Behavior.IsStorageCollection();
@@ -62,7 +62,7 @@ public class UpsertCollectionHandler(
         if (!isStorageCollection)
         {
             iiifCollection = request.RawRequestBody.ConvertCollectionToIIIF(logger);
-            if (iiifCollection.Error) return UpsertErrorHelper.CannotValidateIIIF<PresentationCollection>();
+            if (iiifCollection.Error) return UpsertErrorHelper.CannotValidateIIIF();
         }
         var databaseCollection =
             await dbContext.RetrieveCollectionWithParentAsync(request.CollectionId, true, cancellationToken);
@@ -77,7 +77,7 @@ public class UpsertCollectionHandler(
         if (databaseCollection == null)
         {
             // No existing collection = create
-            if (!string.IsNullOrEmpty(request.ETag)) return UpsertErrorHelper.EtagNotRequired<PresentationCollection>();
+            if (!string.IsNullOrEmpty(request.ETag)) return UpsertErrorHelper.EtagNotRequired();
 
             var createdDate = DateTime.UtcNow;
 
@@ -109,14 +109,14 @@ public class UpsertCollectionHandler(
         else
         {
             if (!EtagComparer.IsMatch(databaseCollection.Etag, request.ETag))
-                return UpsertErrorHelper.EtagNonMatching<PresentationCollection>();
-            
+                return UpsertErrorHelper.EtagNonMatching();
+
             if (isStorageCollection != databaseCollection.IsStorageCollection)
             {
                 logger.LogError(
                     "Customer {CustomerId} attempted to convert collection {CollectionId} to {CollectionType}",
                     request.CustomerId, request.CollectionId, isStorageCollection ? "storage" : "iiif");
-                return UpsertErrorHelper.CannotChangeCollectionType<PresentationCollection>(isStorageCollection);
+                return UpsertErrorHelper.CannotChangeCollectionType(isStorageCollection);
             }
 
             var existingHierarchy = databaseCollection.Hierarchy!.Single(c => c.Canonical);
@@ -140,7 +140,7 @@ public class UpsertCollectionHandler(
             await dbContext.Database.BeginTransactionAsync(cancellationToken);
 
         var saveErrors =
-            await dbContext.TrySaveCollection<PresentationCollection>(request.CustomerId, logger,
+            await dbContext.TrySaveCollection(request.CustomerId, logger,
                 cancellationToken);
 
         if (saveErrors != null)
@@ -159,7 +159,7 @@ public class UpsertCollectionHandler(
             }
             catch (PresentationException)
             {
-                return ModifyEntityResult<PresentationCollection, ModifyCollectionType>.Failure(
+                return ModifyEntityResult<ModifyCollectionType>.Failure(
                     "New slug exceeds 1000 records.  This could mean an item no longer belongs to the root collection.",
                     ModifyCollectionType.PossibleCircularReference, WriteResult.BadRequest);
             }
@@ -187,7 +187,7 @@ public class UpsertCollectionHandler(
             settings.PageSize, DefaultCurrentPage, total, await items.ToListAsync(cancellationToken: cancellationToken),
             parentCollection, pathGenerator, settingsBasedPathGenerator);
 
-        return ModifyEntityResult<PresentationCollection, ModifyCollectionType>.Success(enrichedPresentationCollection, etag: databaseCollection.Etag);
+        return ModifyEntityResult<ModifyCollectionType>.Success(enrichedPresentationCollection, etag: databaseCollection.Etag);
     }
 
     /// <summary>

--- a/src/IIIFPresentation/API/Features/Storage/Requests/UpsertCollection.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Requests/UpsertCollection.cs
@@ -27,7 +27,7 @@ namespace API.Features.Storage.Requests;
 
 public class UpsertCollection(int customerId, string collectionId, PresentationCollection collection, string? eTag, 
     string rawRequestBody)
-    : IRequest<ModifyEntityResult<ModifyCollectionType>>
+    : IRequest<PresentationResult>
 {
     public int CustomerId { get; } = customerId;
 
@@ -48,13 +48,13 @@ public class UpsertCollectionHandler(
     SettingsBasedPathGenerator settingsBasedPathGenerator,
     IParentSlugParser parentSlugParser,
     IOptions<ApiSettings> options)
-    : IRequestHandler<UpsertCollection, ModifyEntityResult<ModifyCollectionType>>
+    : IRequestHandler<UpsertCollection, PresentationResult>
 {
     private readonly ApiSettings settings = options.Value;
 
     private const int DefaultCurrentPage = 1;
 
-    public async Task<ModifyEntityResult<ModifyCollectionType>> Handle(UpsertCollection request, 
+    public async Task<PresentationResult> Handle(UpsertCollection request, 
         CancellationToken cancellationToken)
     {
         var isStorageCollection = request.Collection.Behavior.IsStorageCollection();
@@ -159,7 +159,7 @@ public class UpsertCollectionHandler(
             }
             catch (PresentationException)
             {
-                return ModifyEntityResult<ModifyCollectionType>.Failure(
+                return PresentationResult.Failure(
                     "New slug exceeds 1000 records.  This could mean an item no longer belongs to the root collection.",
                     ModifyCollectionType.PossibleCircularReference, WriteResult.BadRequest);
             }
@@ -187,7 +187,7 @@ public class UpsertCollectionHandler(
             settings.PageSize, DefaultCurrentPage, total, await items.ToListAsync(cancellationToken: cancellationToken),
             parentCollection, pathGenerator, settingsBasedPathGenerator);
 
-        return ModifyEntityResult<ModifyCollectionType>.Success(enrichedPresentationCollection, etag: databaseCollection.Etag);
+        return PresentationResult.Success(enrichedPresentationCollection, etag: databaseCollection.Etag);
     }
 
     /// <summary>

--- a/src/IIIFPresentation/API/Helpers/ParentSlugParser.cs
+++ b/src/IIIFPresentation/API/Helpers/ParentSlugParser.cs
@@ -67,12 +67,12 @@ public class ParentSlugParser(PresentationContext dbContext,
     private static bool IsRoot<T>(T presentation, string? id)
         => presentation is PresentationCollection && id != null && KnownCollections.IsRoot(id);
 
-    private ModifyEntityResult<ModifyCollectionType>? TryValidateRoot(IPresentation presentation, int customer)
+    private PresentationResult? TryValidateRoot(IPresentation presentation, int customer)
         => string.IsNullOrEmpty(presentation.PublicId) || presentation.PublicIdIsRoot(GetBaseUrl(), customer)
             ? null
             : UpsertErrorHelper.IncorrectPublicId();
 
-    private (ModifyEntityResult<ModifyCollectionType>? errors, string? slug) TryGetSlug(IPresentation presentation)
+    private (PresentationResult? errors, string? slug) TryGetSlug(IPresentation presentation)
     {
         // Try and get slug from publicId and/or 'slug' property directly
         var publicIdSlug = presentation.PublicId?.GetLastPathElement();
@@ -181,9 +181,9 @@ public class ParentSlugParser(PresentationContext dbContext,
     {
         public Collection? Parent { get; private init; }
 
-        public ModifyEntityResult<ModifyCollectionType>? Errors { get; private init; }
+        public PresentationResult? Errors { get; private init; }
 
-        public static ParsedParent Fail(ModifyEntityResult<ModifyCollectionType> errors) =>
+        public static ParsedParent Fail(PresentationResult errors) =>
             new() { Errors = errors};
 
         public static ParsedParent Success(Collection? parent) => new() { Parent = parent };
@@ -217,7 +217,7 @@ public class ParsedParentSlug
 
 public class ParsedParentSlugResult
 {
-    public ModifyEntityResult<ModifyCollectionType>? Errors { get; private init; }
+    public PresentationResult? Errors { get; private init; }
 
     public ParsedParentSlug? ParsedParentSlug { get; private init; }
 
@@ -225,7 +225,7 @@ public class ParsedParentSlugResult
     [MemberNotNullWhen(false, nameof(ParsedParentSlug))]
     public bool IsError { get; private init; }
 
-    public static ParsedParentSlugResult Fail(ModifyEntityResult<ModifyCollectionType> errors) =>
+    public static ParsedParentSlugResult Fail(PresentationResult errors) =>
         new() { Errors = errors, IsError = true };
 
     public static ParsedParentSlugResult Success(ParsedParentSlug parsed) => new() { ParsedParentSlug = parsed };

--- a/src/IIIFPresentation/API/Helpers/ParentSlugParser.cs
+++ b/src/IIIFPresentation/API/Helpers/ParentSlugParser.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using API.Features.Common.Helpers;
 using API.Features.Storage.Helpers;
 using API.Infrastructure.Requests;
@@ -20,7 +20,7 @@ namespace API.Helpers;
 /// </summary>
 public interface IParentSlugParser
 {
-    public Task<ParsedParentSlugResult<T>> Parse<T>(
+    public Task<ParsedParentSlugResult> Parse<T>(
         T presentation,
         int customerId,
         string? id,
@@ -29,52 +29,50 @@ public interface IParentSlugParser
 }
 
 public class ParentSlugParser(PresentationContext dbContext,
-    IHttpContextAccessor contextAccessor, 
-    IPathRewriteParser pathRewriteParser, 
+    IHttpContextAccessor contextAccessor,
+    IPathRewriteParser pathRewriteParser,
     ILogger<ParentSlugParser> logger) : IParentSlugParser
 {
-    public async Task<ParsedParentSlugResult<T>> Parse<T>(T presentation,
+    public async Task<ParsedParentSlugResult> Parse<T>(T presentation,
         int customerId, string? id, CancellationToken cancellationToken = default)
         where T : JsonLdBase, IPresentation
     {
         if (IsRoot(presentation, id))
         {
-            var rootError = TryValidateRoot<T>(presentation, customerId);
-            if (rootError != null) return ParsedParentSlugResult<T>.Fail(rootError);
+            var rootError = TryValidateRoot(presentation, customerId);
+            if (rootError != null) return ParsedParentSlugResult.Fail(rootError);
 
             logger.LogDebug("'{Id}' is Root collection, returning default ParserResult", id);
-            return ParsedParentSlugResult<T>.Success(ParsedParentSlug.RootCollection);
+            return ParsedParentSlugResult.Success(ParsedParentSlug.RootCollection);
         }
 
         // Try and match slug, if invalid this is cheaper than parent validation so do first
-        var (slugErrors, slug) = TryGetSlug<T>(presentation);
+        var (slugErrors, slug) = TryGetSlug(presentation);
         if (slugErrors != null)
         {
-            return ParsedParentSlugResult<T>.Fail(slugErrors);
+            return ParsedParentSlugResult.Fail(slugErrors);
         }
 
-        var parent = await TryGetParent<T>(presentation, customerId, cancellationToken);
+        var parent = await TryGetParent(presentation, customerId, cancellationToken);
         if (parent.Errors != null)
         {
-            return ParsedParentSlugResult<T>.Fail(parent.Errors);
+            return ParsedParentSlugResult.Fail(parent.Errors);
         }
 
-        return ParsedParentSlugResult<T>.Success(
+        return ParsedParentSlugResult.Success(
             new ParsedParentSlug(parent.Parent.ThrowIfNull(nameof(parent)), slug.ThrowIfNull(nameof(slug)))
         );
     }
 
-    private static bool IsRoot<T>(T presentation, string? id) 
+    private static bool IsRoot<T>(T presentation, string? id)
         => presentation is PresentationCollection && id != null && KnownCollections.IsRoot(id);
 
-    private ModifyEntityResult<T, ModifyCollectionType>? TryValidateRoot<T>(IPresentation presentation, int customer)
-        where T : JsonLdBase
+    private ModifyEntityResult<ModifyCollectionType>? TryValidateRoot(IPresentation presentation, int customer)
         => string.IsNullOrEmpty(presentation.PublicId) || presentation.PublicIdIsRoot(GetBaseUrl(), customer)
             ? null
-            : UpsertErrorHelper.IncorrectPublicId<T>();
+            : UpsertErrorHelper.IncorrectPublicId();
 
-    private (ModifyEntityResult<T, ModifyCollectionType>? errors, string? slug)
-        TryGetSlug<T>(IPresentation presentation) where T : JsonLdBase
+    private (ModifyEntityResult<ModifyCollectionType>? errors, string? slug) TryGetSlug(IPresentation presentation)
     {
         // Try and get slug from publicId and/or 'slug' property directly
         var publicIdSlug = presentation.PublicId?.GetLastPathElement();
@@ -86,70 +84,66 @@ public class ParentSlugParser(PresentationContext dbContext,
         {
             logger.LogDebug("PublicId slug '{PublicIdSlug}' and explicit slug {Slug} do not match",
                 presentation.PublicId, presentation.Slug);
-            return (UpsertErrorHelper.SlugMustMatchPublicId<T>(), null);
+            return (UpsertErrorHelper.SlugMustMatchPublicId(), null);
         }
 
         return (null, slug);
     }
 
-    private async Task<ParsedParent<T>>
-        TryGetParent<T>(IPresentation presentation, int customerId, CancellationToken cancellationToken)
-        where T : JsonLdBase
+    private async Task<ParsedParent> TryGetParent(IPresentation presentation, int customerId, CancellationToken cancellationToken)
     {
-        var parent =
-            await TryGetParentFromPresentation<T>(presentation, customerId, cancellationToken);
+        var parent = await TryGetParentFromPresentation(presentation, customerId, cancellationToken);
         if (parent.Errors != null) return parent;
 
         // Passed values match, validate parent can be used
-        var parentValidationError = ParentValidator.ValidateParentCollection<T>(parent.Parent);
-        if (parentValidationError != null) return ParsedParent<T>.Fail(parentValidationError);
+        var parentValidationError = ParentValidator.ValidateParentCollection(parent.Parent);
+        if (parentValidationError != null) return ParsedParent.Fail(parentValidationError);
 
         return parent;
     }
 
-    private async Task<ParsedParent<T>>
-        TryGetParentFromPresentation<T>(
-            IPresentation presentation,
-            int customerId,
-            CancellationToken cancellationToken) where T : JsonLdBase
+    private async Task<ParsedParent> TryGetParentFromPresentation(
+        IPresentation presentation,
+        int customerId,
+        CancellationToken cancellationToken)
     {
-        // Try and get a parent from publicId 
-        var publicIdParent = await RetrieveParent<T>(presentation, customerId, true, cancellationToken);
-        
-        // If we don't have parent or there are errors, return what we could parse from publicId 
+        // Try and get a parent from publicId
+        var publicIdParent = await RetrieveParent(presentation, customerId, true, cancellationToken);
+
+        // If we don't have parent or there are errors, return what we could parse from publicId
         if (publicIdParent.Errors != null || presentation.Parent == null) return publicIdParent;
 
-        // We have Parent property - find Collection for that 
-        var parent = await RetrieveParent<T>(presentation, customerId, false, cancellationToken);
-        
-        if (parent.Errors != null) return parent; 
+        // We have Parent property - find Collection for that
+        var parent = await RetrieveParent(presentation, customerId, false, cancellationToken);
 
-        // Validate that if we have publicId AND parent they are for the same thing 
+        if (parent.Errors != null) return parent;
+
+        // Validate that if we have publicId AND parent they are for the same thing
         if (publicIdParent.Parent != null && parent.Parent != null && publicIdParent.Parent.Id != parent.Parent.Id)
         {
             logger.LogDebug("PublicId parent '{PublicIdParent}' and explicit parent {Parent} do not match",
                 presentation.PublicId, presentation.Parent);
-            return ParsedParent<T>.Fail(UpsertErrorHelper.ParentMustMatchPublicId<T>());
+            return ParsedParent.Fail(UpsertErrorHelper.ParentMustMatchPublicId());
         }
 
         return parent;
     }
-    
-    private async Task<ParsedParent<T>> RetrieveParent<T>(
-            IPresentation presentation,
-            int customerId, 
-            bool fromPublicId, 
-            CancellationToken cancellationToken)  where T : JsonLdBase
+
+    private async Task<ParsedParent> RetrieveParent(
+        IPresentation presentation,
+        int customerId,
+        bool fromPublicId,
+        CancellationToken cancellationToken)
     {
         Uri? parentUri;
         if (fromPublicId)
         {
-            if (presentation.PublicId == null) return ParsedParent<T>.Empty();
+            if (presentation.PublicId == null) return ParsedParent.Empty();
             parentUri = PathParser.GetParentUriFromPublicId(presentation.PublicId);
         }
         else
         {
-            if (!Uri.TryCreate(presentation.Parent, UriKind.Absolute, out parentUri)) return ParsedParent<T>.Empty();
+            if (!Uri.TryCreate(presentation.Parent, UriKind.Absolute, out parentUri)) return ParsedParent.Empty();
         }
 
         try
@@ -157,44 +151,44 @@ public class ParentSlugParser(PresentationContext dbContext,
             var parentPath =
                 pathRewriteParser.ParsePathWithRewrites(parentUri.Host, parentUri.AbsolutePath,
                     customerId);
-            
-            if (parentPath.Resource == null) return ParsedParent<T>.Empty();
+
+            if (parentPath.Resource == null) return ParsedParent.Empty();
 
             if (parentPath.Customer != customerId)
             {
-                return ParsedParent<T>.Fail(UpsertErrorHelper.CustomerIdDoesNotMatchCaller<T>("publicId"));
+                return ParsedParent.Fail(UpsertErrorHelper.CustomerIdDoesNotMatchCaller("publicId"));
             }
-            
+
             if (!parentPath.Hierarchical)
             {
-                return ParsedParent<T>.Success(await dbContext.RetrieveCollectionAsync(customerId, parentPath.Resource,
+                return ParsedParent.Success(await dbContext.RetrieveCollectionAsync(customerId, parentPath.Resource,
                     cancellationToken: cancellationToken));
             }
-            
+
             var parentHierarchy =
                 await dbContext.RetrieveHierarchy(customerId, parentPath.Resource, cancellationToken);
             var parent = parentHierarchy?.Collection;
-            return ParsedParent<T>.Success(parent);
+            return ParsedParent.Success(parent);
         }
         catch (FormatException fe)
         {
             logger.LogDebug(fe, "Cannot parse parent from public id");
-            return ParsedParent<T>.Empty();
+            return ParsedParent.Empty();
         }
     }
 
-    private class ParsedParent<T> where T : JsonLdBase
+    private class ParsedParent
     {
         public Collection? Parent { get; private init; }
-        
-        public ModifyEntityResult<T, ModifyCollectionType>? Errors { get; private init; }
-        
-        public static ParsedParent<T> Fail(ModifyEntityResult<T, ModifyCollectionType> errors) =>
+
+        public ModifyEntityResult<ModifyCollectionType>? Errors { get; private init; }
+
+        public static ParsedParent Fail(ModifyEntityResult<ModifyCollectionType> errors) =>
             new() { Errors = errors};
-        
-        public static ParsedParent<T> Success(Collection? parent) => new() { Parent = parent };
-        
-        public static ParsedParent<T> Empty() => new();
+
+        public static ParsedParent Success(Collection? parent) => new() { Parent = parent };
+
+        public static ParsedParent Empty() => new();
     }
 
     private string GetBaseUrl() => contextAccessor.HttpContext!.Request.GetBaseUrl();
@@ -205,13 +199,13 @@ public class ParsedParentSlug
     public Collection? Parent { get; private init; }
 
     public string Slug { get; private init; }
-    
+
     private ParsedParentSlug()
     {
         Slug = string.Empty;
         Parent = null;
     }
-    
+
     public ParsedParentSlug(Collection parent, string slug)
     {
         Parent = parent;
@@ -221,10 +215,9 @@ public class ParsedParentSlug
     public static readonly ParsedParentSlug RootCollection = new();
 }
 
-public class ParsedParentSlugResult<T>
-    where T : JsonLdBase
+public class ParsedParentSlugResult
 {
-    public ModifyEntityResult<T, ModifyCollectionType>? Errors { get; private init; }
+    public ModifyEntityResult<ModifyCollectionType>? Errors { get; private init; }
 
     public ParsedParentSlug? ParsedParentSlug { get; private init; }
 
@@ -232,8 +225,8 @@ public class ParsedParentSlugResult<T>
     [MemberNotNullWhen(false, nameof(ParsedParentSlug))]
     public bool IsError { get; private init; }
 
-    public static ParsedParentSlugResult<T> Fail(ModifyEntityResult<T, ModifyCollectionType> errors) =>
+    public static ParsedParentSlugResult Fail(ModifyEntityResult<ModifyCollectionType> errors) =>
         new() { Errors = errors, IsError = true };
 
-    public static ParsedParentSlugResult<T> Success(ParsedParentSlug parsed) => new() { ParsedParentSlug = parsed };
+    public static ParsedParentSlugResult Success(ParsedParentSlug parsed) => new() { ParsedParentSlug = parsed };
 }

--- a/src/IIIFPresentation/API/Infrastructure/ControllerBaseX.cs
+++ b/src/IIIFPresentation/API/Infrastructure/ControllerBaseX.cs
@@ -57,7 +57,7 @@ public static class ControllerBaseX
     }
 
     /// <summary>
-    /// Create an IActionResult from specified ModifyEntityResult{T}.
+    /// Create an IActionResult from specified ModifyEntityResult{TEnum}.
     /// This will be the model + 200/201 on success. Or an
     /// error and appropriate status code if failed.
     /// </summary>
@@ -68,16 +68,14 @@ public static class ControllerBaseX
     /// The value for <see cref="JSType.Error.Title" />. In some instances this will be prepended to the actual error name.
     /// e.g. errorTitle + ": Conflict"
     /// </param>
-    /// <typeparam name="T">Type of entity being upserted</typeparam>
-    /// <typeparam name="TEnum">An enum used for </typeparam>
+    /// <typeparam name="TEnum">An enum used for error type</typeparam>
     /// <returns>
     /// ActionResult generated from ModifyEntityResult
     /// </returns>
-    public static IActionResult ModifyResultToHttpResult<T, TEnum>(this ControllerBase controller,
-        ModifyEntityResult<T, TEnum> entityResult,
+    public static IActionResult ModifyResultToHttpResult<TEnum>(this ControllerBase controller,
+        ModifyEntityResult<TEnum> entityResult,
         string? instance,
         string? errorTitle)
-        where T : JsonLdBase
         where TEnum : Enum =>
         entityResult.WriteResult switch
         {

--- a/src/IIIFPresentation/API/Infrastructure/ControllerBaseX.cs
+++ b/src/IIIFPresentation/API/Infrastructure/ControllerBaseX.cs
@@ -68,15 +68,13 @@ public static class ControllerBaseX
     /// The value for <see cref="JSType.Error.Title" />. In some instances this will be prepended to the actual error name.
     /// e.g. errorTitle + ": Conflict"
     /// </param>
-    /// <typeparam name="TEnum">An enum used for error type</typeparam>
     /// <returns>
     /// ActionResult generated from ModifyEntityResult
     /// </returns>
-    public static IActionResult ModifyResultToHttpResult<TEnum>(this ControllerBase controller,
-        ModifyEntityResult<TEnum> entityResult,
+    public static IActionResult ModifyResultToHttpResult(this ControllerBase controller,
+        PresentationResult entityResult,
         string? instance,
-        string? errorTitle)
-        where TEnum : Enum =>
+        string? errorTitle) =>
         entityResult.WriteResult switch
         {
             WriteResult.Updated => controller.PresentationContent(entityResult.Entity, etag: entityResult.ETag),

--- a/src/IIIFPresentation/API/Infrastructure/PresentationController.cs
+++ b/src/IIIFPresentation/API/Infrastructure/PresentationController.cs
@@ -48,18 +48,16 @@ public abstract class PresentationController : Controller
     /// </param>
     /// <param name="invalidatesEtag">string etag value used in this request, optional</param>
     /// <param name="cancellationToken">Current cancellation token</param>
-    /// <typeparam name="TEnum">An enum designating the error type</typeparam>
     /// <returns>
     /// ActionResult generated from ModifyEntityResult. This will be the model + 200/201 on success. Or an
     /// error and appropriate status code if failed.
     /// </returns>
-    protected async Task<IActionResult> HandleUpsert<TEnum>(
-    IRequest<ModifyEntityResult<TEnum>> request,
-    string? instance = null,
-    string? errorTitle = "Operation failed",
-    string? invalidatesEtag = null,
-    CancellationToken cancellationToken = default)
-    where TEnum : Enum
+    protected async Task<IActionResult> HandleUpsert(
+        IRequest<PresentationResult> request,
+        string? instance = null,
+        string? errorTitle = "Operation failed",
+        string? invalidatesEtag = null,
+        CancellationToken cancellationToken = default)
     {
         return await HandleRequest(async () =>
         {

--- a/src/IIIFPresentation/API/Infrastructure/PresentationController.cs
+++ b/src/IIIFPresentation/API/Infrastructure/PresentationController.cs
@@ -48,19 +48,17 @@ public abstract class PresentationController : Controller
     /// </param>
     /// <param name="invalidatesEtag">string etag value used in this request, optional</param>
     /// <param name="cancellationToken">Current cancellation token</param>
-    /// <typeparam name="T">Type of entity being upserted</typeparam>
     /// <typeparam name="TEnum">An enum designating the error type</typeparam>
     /// <returns>
     /// ActionResult generated from ModifyEntityResult. This will be the model + 200/201 on success. Or an
     /// error and appropriate status code if failed.
     /// </returns>
-    protected async Task<IActionResult> HandleUpsert<T, TEnum>(
-    IRequest<ModifyEntityResult<T, TEnum>> request,
+    protected async Task<IActionResult> HandleUpsert<TEnum>(
+    IRequest<ModifyEntityResult<TEnum>> request,
     string? instance = null,
     string? errorTitle = "Operation failed",
     string? invalidatesEtag = null,
     CancellationToken cancellationToken = default)
-    where T : JsonLdBase
     where TEnum : Enum
     {
         return await HandleRequest(async () =>

--- a/src/IIIFPresentation/API/Infrastructure/Requests/ModifyEntityResult.cs
+++ b/src/IIIFPresentation/API/Infrastructure/Requests/ModifyEntityResult.cs
@@ -14,28 +14,28 @@ public class ModifyEntityResult<TError> : IModifyRequest
     /// <summary>
     /// Enum representing overall result of operation
     /// </summary>
-    public WriteResult WriteResult { get; private init; }
+    public WriteResult WriteResult { get; protected init; }
 
     /// <summary>
     /// Optional representation of entity
     /// </summary>
-    public JsonLdBase? Entity { get; private init; }
+    public JsonLdBase? Entity { get; protected init; }
 
     /// <summary>
     /// Optional error message if didn't succeed
     /// </summary>
-    public string? Error { get; private init; }
+    public string? Error { get; protected init; }
 
     /// <summary>
     /// Explicit value stating success or failure
     /// </summary>
     [MemberNotNullWhen(false, nameof(ErrorType))]
     [MemberNotNullWhen(true, nameof(Entity))]
-    public bool IsSuccess { get; private init; }
-    
-    public TError? ErrorType { get; private init; }
-    
-    public Guid? ETag { get; private init; }
+    public bool IsSuccess { get; protected init; }
+
+    public TError? ErrorType { get; protected init; }
+
+    public Guid? ETag { get; protected init; }
 
     public static ModifyEntityResult<TError> Failure(string error, TError errorType, WriteResult result = WriteResult.Unknown)
     {

--- a/src/IIIFPresentation/API/Infrastructure/Requests/ModifyEntityResult.cs
+++ b/src/IIIFPresentation/API/Infrastructure/Requests/ModifyEntityResult.cs
@@ -7,10 +7,8 @@ namespace API.Infrastructure.Requests;
 /// <summary>
 ///     Represents the result of a request to modify an entity
 /// </summary>
-/// <typeparam name="T">Type of entity being modified</typeparam>
 /// <typeparam name="TError">Type of error</typeparam>
-public class ModifyEntityResult<T, TError> : IModifyRequest
-    where T : JsonLdBase
+public class ModifyEntityResult<TError> : IModifyRequest
     where TError : Enum
 {
     /// <summary>
@@ -21,7 +19,7 @@ public class ModifyEntityResult<T, TError> : IModifyRequest
     /// <summary>
     /// Optional representation of entity
     /// </summary>
-    public T? Entity { get; private init; }
+    public JsonLdBase? Entity { get; private init; }
 
     /// <summary>
     /// Optional error message if didn't succeed
@@ -39,15 +37,15 @@ public class ModifyEntityResult<T, TError> : IModifyRequest
     
     public Guid? ETag { get; private init; }
 
-    public static ModifyEntityResult<T, TError> Failure(string error, TError errorType, WriteResult result = WriteResult.Unknown)
+    public static ModifyEntityResult<TError> Failure(string error, TError errorType, WriteResult result = WriteResult.Unknown)
     {
-        return new ModifyEntityResult<T, TError>
+        return new ModifyEntityResult<TError>
             { Error = error, WriteResult = result, IsSuccess = false, ErrorType = errorType };
     }
     
-    public static ModifyEntityResult<T, TError> Success(T entity, WriteResult result = WriteResult.Updated, Guid? etag = null)
+    public static ModifyEntityResult<TError> Success(JsonLdBase entity, WriteResult result = WriteResult.Updated, Guid? etag = null)
     {
-        return new ModifyEntityResult<T, TError>
+        return new ModifyEntityResult<TError>
             { Entity = entity, WriteResult = result, IsSuccess = true, ETag = etag };
     }
 

--- a/src/IIIFPresentation/API/Infrastructure/Requests/PresentationResult.cs
+++ b/src/IIIFPresentation/API/Infrastructure/Requests/PresentationResult.cs
@@ -1,0 +1,20 @@
+using Core;
+using IIIF;
+using Models.API.General;
+
+namespace API.Infrastructure.Requests;
+
+/// <summary>
+///     Represents the result of a request to modify a presentation resource.
+///     Concrete alias for <see cref="ModifyEntityResult{TError}"/> with <see cref="ModifyCollectionType"/>.
+/// </summary>
+public class PresentationResult : ModifyEntityResult<ModifyCollectionType>
+{
+    public new static PresentationResult Failure(string error, ModifyCollectionType errorType,
+        WriteResult result = WriteResult.Unknown)
+        => new() { Error = error, WriteResult = result, IsSuccess = false, ErrorType = errorType };
+
+    public new static PresentationResult Success(JsonLdBase entity, WriteResult result = WriteResult.Updated,
+        Guid? etag = null)
+        => new() { Entity = entity, WriteResult = result, IsSuccess = true, ETag = etag };
+}


### PR DESCRIPTION
Housekeeping/DX task. Tidies use of `ModifyEntityResult` class to make usage easier. For reference, prior to this PR the signature for that class is:

```cs
public class ModifyEntityResult<T, TError> : IModifyRequest 
  where T : JsonLdBase 
  where TError : Enum
```

First change was to remove the generic `T` and just use `JsonLdBase` instead (ie `public T? Entity` becomes `public JsonLdBase? Entity`). The need to pass `<T>` bled into various method calls and classes, simplifying to just use the base type meant that these could be cleaned up. Confirmed that there were no call sites that need to differentiate between different types (aside from tests).
* Write path: callers create `ModifyEntityResult.Success(typedEntity, ...)`, the entity goes in as a specific type, no cast needed.
* Read path: `HandleUpsert` -> `ModifyResultToHttpResult` -> uses iiif-net `.AsJson()` helper to serialise to response. This doesn't need to know individual types.
* Error states - only `IsSuccess`, `WriteResult`, `ErrorType`, `ETag` etc are ready.

Some tests did cast to know type to handle but it felt a worthwhile extra cast given the code is cleaner.

Second change to was to introduce a new class `PresentationResult : ModifyEntityResult<ModifyCollectionType>`. _All_ current usages of MER use `ModifyCollectionType` so this is a convenience that avoids repeated usages of long signature, non-functional change but makes code easier to read. There were already a couple of using aliases that did this same thing, these have effectively been replaced with a new concrete type.

## Example of change

Small illustrative example of change:
```cs
// Class def
public class ParsedParentSlugResult<T>
    where T : JsonLdBase
{
    public ModifyEntityResult<T, ModifyCollectionType>? Errors { get; private init; }

    public static ParsedParent<T> Fail(ModifyEntityResult<T, ModifyCollectionType> errors) =>
            new() { Errors = errors};
}

// use
if (rootError != null) return ParsedParentSlugResult<T>.Fail(rootError);
```

now becomes:

```cs
// Updated class def
public class ParsedParentSlugResult
{
    public PresentationResult? Errors { get; private init; }

    public static ParsedParent Fail(PresentationResult errors) =>
            new() { Errors = errors};
}

// use
if (rootError != null) return ParsedParentSlugResult.Fail(rootError);
```

Resolves #310. 