### PR TITLE
Make it so that empty adjunct arrays are removed from the response

### DIFF
--- a/src/IIIFPresentation/API.Tests/Integration/GetManifestTests.cs
+++ b/src/IIIFPresentation/API.Tests/Integration/GetManifestTests.cs
@@ -107,6 +107,55 @@ public class GetManifestTests : IClassFixture<PresentationAppFactory<Program>>
                 A<string>.That.Matches(l => l.EndsWith("_ingestingAssets")),
                 A<CancellationToken>._))
             .ReturnsLazily(() => [ingestingAsset, errorAsset]);
+
+        var emptyAdjunctsAsset = JObject.Parse(
+            """
+            {
+                   "@context": "https://localhost/contexts/Image.jsonld",
+                   "@id": "https://localhost:6000/customers/1/spaces/2/images/emptyAdjunctsPaintedResource",
+                   "@type": "vocab:Image",
+                   "id": "emptyAdjunctsPaintedResource",
+                   "ingesting": false,
+                   "space": 1,
+                   "adjuncts": []
+                 }
+            """
+        );
+        
+        A.CallTo(() => DLCSApiClient.GetCustomerImages(PresentationContextFixture.CustomerId,
+                A<string>.That.Matches(l => l.EndsWith("_emptyAdjuncts")),
+                A<CancellationToken>._))
+            .ReturnsLazily(() => [emptyAdjunctsAsset]);
+    }
+
+    [Fact]
+    public async Task Get_IiifManifest_Flat_OmitsEmptyAdjuncts_OnCanvasAsset()
+    {
+        // Arrange - asset-level adjuncts is an empty array; response should omit it, not echo "adjuncts": []
+        var id = TestIdentifiers.IdWithSuffix(suffix: "_emptyAdjuncts");
+        var dbManifest = await dbContext.Manifests.AddTestManifest(id);
+        var assetId = new AssetId(1, 2, "emptyAdjunctsPaintedResource");
+        await dbContext.CanvasPaintings.AddTestCanvasPainting(dbManifest.Entity, label: new LanguageMap("en", "foo"),
+            assetId: assetId);
+        await dbContext.SaveChangesAsync();
+        await s3.PutObjectAsync(new()
+        {
+            BucketName = LocalStackFixture.StorageBucketName,
+            Key = $"1/manifests/{id}",
+            ContentBody = TestContent.ManifestJson,
+        });
+
+        var requestMessage =
+            HttpRequestMessageBuilder.GetPrivateRequest(HttpMethod.Get, $"1/manifests/{id}");
+
+        // Act
+        var response = await httpClient.AsCustomer().SendAsync(requestMessage);
+        var manifest = await response.ReadAsPresentationJsonAsync<PresentationManifest>();
+
+        // Assert
+        var paintedResource = manifest.PaintedResources.Single();
+        paintedResource.Asset!.ContainsKey("adjuncts").Should()
+            .BeFalse("an empty adjuncts array should be omitted, consistent with manifest-level adjuncts");
     }
     
     [Fact]

--- a/src/IIIFPresentation/API/Converters/ManifestConverter.cs
+++ b/src/IIIFPresentation/API/Converters/ManifestConverter.cs
@@ -261,13 +261,22 @@ public static class ManifestConverter
                 [AssetProperties.Error] = "Unable to retrieve asset details"
             };
 
-        return assets.TryGetValue(fullAssetId, out var asset)
-            ? asset
-            : new()
+        if (!assets.TryGetValue(fullAssetId, out var asset))
+        {
+            return new()
             {
                 [AssetProperties.FullId] = fullAssetId,
                 [AssetProperties.Error] = "Asset not found"
             };
+        }
+
+        // `"adjuncts": []` should be stripped out
+        if (asset[AssetProperties.Adjuncts] is JArray { Count: 0 })
+        {
+            asset.Remove(AssetProperties.Adjuncts);
+        }
+
+        return asset;
     }
     
     private static IngestingAssets? GenerateIngesting(Dictionary<string, JObject>? assets)


### PR DESCRIPTION
## What does this change?

Resolves #612 

This PR makes it so that when an adjuncts array would be declared as empty on a painted resource response (i.e.: no adjuncts attached) then it will be stripped out, matching work on adjucts

example payload:

```json
{
    "type": "Manifest",
    "slug": "test-create-new-asset-adjuncts-empty-array",
    "parent": "{{baseUrl}}/{{customerId}}/collections/root",
    "paintedResources": [
        {
            "asset": {
                "id": "testAssetWithNoAdjuncts",
                "mediaType": "image/jpg",
                "space": 1,
                "origin": "origin",
                "adjuncts": [  ] // declaring empty, but this could be omitted
            }
        }
    ] 
}
```

this should then not have `"adjuncts": []` in the response
