### PR TITLE
Disallow slugs from having slashes or FQDN's in them

### DIFF
--- a/src/IIIFPresentation/API.Tests/Features/Manifest/Validators/PresentationManifestValidatorTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Manifest/Validators/PresentationManifestValidatorTests.cs
@@ -1,4 +1,7 @@
 ﻿using API.Features.Manifest.Validators;
+using API.Settings;
+using AWS.Settings;
+using DLCS;
 using Services.Manifests.Settings;
 using FluentValidation.TestHelper;
 using IIIF.Presentation.V3;
@@ -11,7 +14,12 @@ namespace API.Tests.Features.Manifest.Validators;
 
 public class PresentationManifestValidatorTests
 {
-    private readonly PresentationManifestValidator sut = new(Options.Create(new ServicesSettings()));
+    private readonly PresentationManifestValidator sut = new(Options.Create(new ServicesSettings()),
+        Options.Create(new ApiSettings
+        {
+            AWS = new AWSSettings(),
+            DLCS = new DlcsSettings { ApiUri = new Uri("https://localhost") }
+        }));
 
     [Theory]
     [InlineData(null)]

--- a/src/IIIFPresentation/API.Tests/Features/Storage/Validators/PresentationValidatorTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Storage/Validators/PresentationValidatorTests.cs
@@ -1,13 +1,15 @@
 ﻿using API.Features.Storage.Validators;
 using FluentValidation.TestHelper;
+using Microsoft.Extensions.Options;
 using Models.API.General;
 using Models.API.Manifest;
+using Services.Manifests.Settings;
 
 namespace API.Tests.Features.Storage.Validators;
 
 public class PresentationValidatorTests
 {
-    private readonly PresentationValidator sut = new();
+    private readonly PresentationValidator sut = new(Options.Create(new ServicesSettings()));
 
     [Theory]
     [InlineData(null)]

--- a/src/IIIFPresentation/API.Tests/Features/Storage/Validators/PresentationValidatorTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Storage/Validators/PresentationValidatorTests.cs
@@ -34,6 +34,40 @@ public class PresentationValidatorTests
     }
     
     [Theory]
+    [InlineData("foo/bar")]
+    [InlineData("/foo")]
+    [InlineData("foo/")]
+    public void Slug_CannotContainForwardSlash(string slug)
+    {
+        var manifest = new PresentationManifest { Slug = slug };
+
+        var result = sut.TestValidate(manifest);
+        result.ShouldHaveValidationErrorFor(m => m.Slug);
+    }
+
+    [Theory]
+    [InlineData("https://example.com/foo")]
+    [InlineData("http://example.org")]
+    public void Slug_CannotBeFullyQualifiedUri(string slug)
+    {
+        var manifest = new PresentationManifest { Slug = slug };
+
+        var result = sut.TestValidate(manifest);
+        result.ShouldHaveValidationErrorFor(m => m.Slug);
+    }
+
+    [Theory]
+    [InlineData("normal-slug")]
+    [InlineData("example.com")]
+    public void Slug_ValidValues_NoValidationError(string slug)
+    {
+        var manifest = new PresentationManifest { Slug = slug, PublicId = "https://example.com/1/manifests/foo" };
+
+        var result = sut.TestValidate(manifest);
+        result.ShouldNotHaveValidationErrorFor(m => m.Slug);
+    }
+
+    [Theory]
     [InlineData(null)]
     [InlineData("")]
     public void Parent_Required(string? parent)

--- a/src/IIIFPresentation/API.Tests/Features/Storage/Validators/PresentationValidatorTests.cs
+++ b/src/IIIFPresentation/API.Tests/Features/Storage/Validators/PresentationValidatorTests.cs
@@ -1,15 +1,21 @@
 ﻿using API.Features.Storage.Validators;
+using API.Settings;
+using AWS.Settings;
+using DLCS;
 using FluentValidation.TestHelper;
 using Microsoft.Extensions.Options;
 using Models.API.General;
 using Models.API.Manifest;
-using Services.Manifests.Settings;
 
 namespace API.Tests.Features.Storage.Validators;
 
 public class PresentationValidatorTests
 {
-    private readonly PresentationValidator sut = new(Options.Create(new ServicesSettings()));
+    private readonly PresentationValidator sut = new(Options.Create(new ApiSettings
+    {
+        AWS = new AWSSettings(),
+        DLCS = new DlcsSettings { ApiUri = new Uri("https://localhost") }
+    }));
 
     [Theory]
     [InlineData(null)]

--- a/src/IIIFPresentation/API/Features/Manifest/Validators/PresentationManifestValidator.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/Validators/PresentationManifestValidator.cs
@@ -18,7 +18,7 @@ public class PresentationManifestValidator : AbstractValidator<PresentationManif
         servicesSettings = servicesOptions.Value;
         When(m => !m.PaintedResources.IsNullOrEmpty(), PaintedResourcesValidation);
         When(m => !m.Adjuncts.IsNullOrEmpty(), ManifestAdjunctsValidation);
-        RuleFor(c => c).SetValidator(new PresentationValidator());
+        RuleFor(c => c).SetValidator(new PresentationValidator(servicesOptions));
         
         RuleFor(m => m.Items)
             .Must(i => i.DistinctBy(c => c.Id).Count() == i.Count)

--- a/src/IIIFPresentation/API/Features/Manifest/Validators/PresentationManifestValidator.cs
+++ b/src/IIIFPresentation/API/Features/Manifest/Validators/PresentationManifestValidator.cs
@@ -1,4 +1,5 @@
 using API.Features.Storage.Validators;
+using API.Settings;
 using Core.Helpers;
 using FluentValidation;
 using Microsoft.Extensions.Options;
@@ -13,12 +14,12 @@ public class PresentationManifestValidator : AbstractValidator<PresentationManif
 {
     private readonly ServicesSettings servicesSettings;
 
-    public PresentationManifestValidator(IOptions<ServicesSettings> servicesOptions)
+    public PresentationManifestValidator(IOptions<ServicesSettings> servicesOptions, IOptions<ApiSettings> apiOptions)
     {
         servicesSettings = servicesOptions.Value;
         When(m => !m.PaintedResources.IsNullOrEmpty(), PaintedResourcesValidation);
         When(m => !m.Adjuncts.IsNullOrEmpty(), ManifestAdjunctsValidation);
-        RuleFor(c => c).SetValidator(new PresentationValidator(servicesOptions));
+        RuleFor(c => c).SetValidator(new PresentationValidator(apiOptions));
         
         RuleFor(m => m.Items)
             .Must(i => i.DistinctBy(c => c.Id).Count() == i.Count)

--- a/src/IIIFPresentation/API/Features/Storage/Validators/PresentationValidator.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Validators/PresentationValidator.cs
@@ -1,14 +1,17 @@
-﻿using API.Infrastructure.Validation;
-using FluentValidation;
+﻿using FluentValidation;
+using Microsoft.Extensions.Options;
 using Models.API;
 using Models.API.General;
+using Services.Manifests.Settings;
 
 namespace API.Features.Storage.Validators;
 
 public class PresentationValidator : AbstractValidator<IPresentation>
 {
-    public PresentationValidator()
+    public PresentationValidator(IOptions<ServicesSettings> servicesOptions)
     {
+        var settings = servicesOptions.Value;
+
         RuleFor(f => f.Parent).Must(p => Uri.IsWellFormedUriString(p, UriKind.Absolute))
             .When(f => f.Parent != null)
             .WithMessage("'parent' must be a well formed URI");
@@ -23,8 +26,8 @@ public class PresentationValidator : AbstractValidator<IPresentation>
             .WithMessage("'slug' cannot be one of prohibited terms: '{PropertyValue}'");
 
         RuleFor(f => f.Slug)
-            .Must(slug => !slug!.Contains('/'))
-            .WithMessage("'slug' cannot contain '/'")
+            .Must(slug => !settings.ProhibitedSlugCharacters.Any(slug!.Contains))
+            .WithMessage($"'slug' contains a prohibited character. Cannot contain any of: {settings.ProhibitedSlugCharactersDisplay}")
             .Must(slug => !Uri.IsWellFormedUriString(slug, UriKind.Absolute))
             .WithMessage("'slug' cannot be a fully qualified URI")
             .When(f => !string.IsNullOrEmpty(f.Slug));

--- a/src/IIIFPresentation/API/Features/Storage/Validators/PresentationValidator.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Validators/PresentationValidator.cs
@@ -1,16 +1,16 @@
-﻿using FluentValidation;
+﻿using API.Settings;
+using FluentValidation;
 using Microsoft.Extensions.Options;
 using Models.API;
 using Models.API.General;
-using Services.Manifests.Settings;
 
 namespace API.Features.Storage.Validators;
 
 public class PresentationValidator : AbstractValidator<IPresentation>
 {
-    public PresentationValidator(IOptions<ServicesSettings> servicesOptions)
+    public PresentationValidator(IOptions<ApiSettings> apiOptions)
     {
-        var settings = servicesOptions.Value;
+        var settings = apiOptions.Value;
 
         RuleFor(f => f.Parent).Must(p => Uri.IsWellFormedUriString(p, UriKind.Absolute))
             .When(f => f.Parent != null)

--- a/src/IIIFPresentation/API/Features/Storage/Validators/PresentationValidator.cs
+++ b/src/IIIFPresentation/API/Features/Storage/Validators/PresentationValidator.cs
@@ -22,6 +22,13 @@ public class PresentationValidator : AbstractValidator<IPresentation>
             .Must(slug => !SpecConstants.ProhibitedSlugs.Contains(slug!))
             .WithMessage("'slug' cannot be one of prohibited terms: '{PropertyValue}'");
 
+        RuleFor(f => f.Slug)
+            .Must(slug => !slug!.Contains('/'))
+            .WithMessage("'slug' cannot contain '/'")
+            .Must(slug => !Uri.IsWellFormedUriString(slug, UriKind.Absolute))
+            .WithMessage("'slug' cannot be a fully qualified URI")
+            .When(f => !string.IsNullOrEmpty(f.Slug));
+
         RuleFor(f => f.PublicId)
             .NotEmpty()
             .When(f => f.Parent == null && f.Slug == null)

--- a/src/IIIFPresentation/API/Settings/ApiSettings.cs
+++ b/src/IIIFPresentation/API/Settings/ApiSettings.cs
@@ -36,7 +36,15 @@ public class ApiSettings
     /// The maximum number of historical pipeline jobs returned in a Manifest's "finishedPipelines" property
     /// </summary>
     public int FinishedPipelinesLimit { get; set; } = 20;
-    
+
+    /// <summary>
+    /// Characters that are not permitted in a 'slug'
+    /// </summary>
+    public string[] ProhibitedSlugCharacters { get; set; } = ["/"];
+
+    public string ProhibitedSlugCharactersDisplay =>
+        string.Join(", ", ProhibitedSlugCharacters.Select(p => $"'{p}'"));
+
     public required AWSSettings AWS { get; set; }
 
     public required DlcsSettings DLCS { get; set; }

--- a/src/IIIFPresentation/API/Settings/ApiSettings.cs
+++ b/src/IIIFPresentation/API/Settings/ApiSettings.cs
@@ -38,7 +38,7 @@ public class ApiSettings
     public int FinishedPipelinesLimit { get; set; } = 20;
 
     /// <summary>
-    /// Characters that are not permitted in a 'slug'
+    /// Strings that are not permitted in a 'slug'
     /// </summary>
     public string[] ProhibitedSlugCharacters { get; set; } = ["/"];
 

--- a/src/IIIFPresentation/Services/Manifests/Settings/ServicesSettings.cs
+++ b/src/IIIFPresentation/Services/Manifests/Settings/ServicesSettings.cs
@@ -14,4 +14,9 @@ public class ServicesSettings
 
     public string ProhibitedAdjunctIdCharactersDisplay =>
         string.Join(", ", ProhibitedAdjunctIdCharacters.Select(p => $"'{p}'"));
+
+    public string[] ProhibitedSlugCharacters { get; set; } = ["/"];
+
+    public string ProhibitedSlugCharactersDisplay =>
+        string.Join(", ", ProhibitedSlugCharacters.Select(p => $"'{p}'"));
 }

--- a/src/IIIFPresentation/Services/Manifests/Settings/ServicesSettings.cs
+++ b/src/IIIFPresentation/Services/Manifests/Settings/ServicesSettings.cs
@@ -14,9 +14,4 @@ public class ServicesSettings
 
     public string ProhibitedAdjunctIdCharactersDisplay =>
         string.Join(", ", ProhibitedAdjunctIdCharacters.Select(p => $"'{p}'"));
-
-    public string[] ProhibitedSlugCharacters { get; set; } = ["/"];
-
-    public string ProhibitedSlugCharactersDisplay =>
-        string.Join(", ", ProhibitedSlugCharacters.Select(p => $"'{p}'"));
 }


### PR DESCRIPTION
## What does this change?

Resolves #571

Makes it so slugs aren't allowed to have FQDN's or forward slashes.  This is also extendable, due to adding a setting controlling characters that are disallowed from use in slugs.

## Configuration Changes

> [!NOTE]
> This PR introduces configuration changes.
>
> |Service | AppSetting | Required? | Description | Default |
> |---|---|---|---|---|
> | API | `ApiSettings:ProhibitedSlugCharacters` | N | Prohibited characters in the slug | `["/"]` |
